### PR TITLE
#872 Use Player#hasPermission instead of custom PermissionHandler method

### DIFF
--- a/src/main/java/fr/xephi/authme/permission/PermissionsManager.java
+++ b/src/main/java/fr/xephi/authme/permission/PermissionsManager.java
@@ -198,13 +198,13 @@ public class PermissionsManager implements Reloadable {
             return true;
         }
 
-        // Return if the player is an Op if sender is console or no permission system in use
+        // Return default if sender is not a player or no permission system is in use
         if (!(sender instanceof Player) || !isEnabled()) {
             return permissionNode.getDefaultPermission().evaluate(sender);
         }
 
         Player player = (Player) sender;
-        return handler.hasPermission(player, permissionNode);
+        return player.hasPermission(permissionNode.getNode());
     }
 
     /**

--- a/src/main/java/fr/xephi/authme/permission/handlers/BPermissionsHandler.java
+++ b/src/main/java/fr/xephi/authme/permission/handlers/BPermissionsHandler.java
@@ -23,11 +23,6 @@ public class BPermissionsHandler implements PermissionHandler {
     }
 
     @Override
-    public boolean hasPermission(Player player, PermissionNode node) {
-        return ApiLayer.hasPermission(player.getWorld().getName(), CalculableType.USER, player.getName(), node.getNode());
-    }
-
-    @Override
     public boolean hasPermissionOffline(String name, PermissionNode node) {
         return ApiLayer.hasPermission(null, CalculableType.USER, name, node.getNode());
     }

--- a/src/main/java/fr/xephi/authme/permission/handlers/GroupManagerHandler.java
+++ b/src/main/java/fr/xephi/authme/permission/handlers/GroupManagerHandler.java
@@ -30,12 +30,6 @@ public class GroupManagerHandler implements PermissionHandler {
     }
 
     @Override
-    public boolean hasPermission(Player player, PermissionNode node) {
-        final AnjoPermissionsHandler handler = groupManager.getWorldsHolder().getWorldPermissions(player);
-        return handler != null && handler.has(player, node.getNode());
-    }
-
-    @Override
     public boolean hasPermissionOffline(String name, PermissionNode node) {
         final AnjoPermissionsHandler handler = groupManager.getWorldsHolder().getWorldPermissionsByPlayerName(name);
         if(handler == null) {

--- a/src/main/java/fr/xephi/authme/permission/handlers/PermissionHandler.java
+++ b/src/main/java/fr/xephi/authme/permission/handlers/PermissionHandler.java
@@ -29,16 +29,6 @@ public interface PermissionHandler {
     boolean hasGroupSupport();
 
     /**
-     * Check if a player has permission.
-     *
-     * @param player    The player.
-     * @param node The permission node.
-     *
-     * @return True if the player has permission.
-     */
-    boolean hasPermission(Player player, PermissionNode node);
-
-    /**
      * Check if a player has permission by their name.
      * Used to check an offline player's permission.
      *

--- a/src/main/java/fr/xephi/authme/permission/handlers/PermissionsBukkitHandler.java
+++ b/src/main/java/fr/xephi/authme/permission/handlers/PermissionsBukkitHandler.java
@@ -21,11 +21,6 @@ public class PermissionsBukkitHandler implements PermissionHandler {
     }
 
     @Override
-    public boolean hasPermission(Player player, PermissionNode node) {
-        return player.hasPermission(node.getNode());
-    }
-
-    @Override
     public boolean hasPermissionOffline(String name, PermissionNode node) {
         return false;
     }

--- a/src/main/java/fr/xephi/authme/permission/handlers/PermissionsExHandler.java
+++ b/src/main/java/fr/xephi/authme/permission/handlers/PermissionsExHandler.java
@@ -38,12 +38,6 @@ public class PermissionsExHandler implements PermissionHandler {
     }
 
     @Override
-    public boolean hasPermission(Player player, PermissionNode node) {
-        PermissionUser user = permissionManager.getUser(player);
-        return user.has(node.getNode());
-    }
-
-    @Override
     public boolean hasPermissionOffline(String name, PermissionNode node) {
         PermissionUser user = permissionManager.getUser(name);
         return user.has(node.getNode());

--- a/src/main/java/fr/xephi/authme/permission/handlers/VaultHandler.java
+++ b/src/main/java/fr/xephi/authme/permission/handlers/VaultHandler.java
@@ -45,11 +45,6 @@ public class VaultHandler implements PermissionHandler {
     }
 
     @Override
-    public boolean hasPermission(Player player, PermissionNode node) {
-        return vaultProvider.has(player, node.getNode());
-    }
-
-    @Override
     public boolean hasPermissionOffline(String name, PermissionNode node) {
         return vaultProvider.has("", name, node.getNode());
     }

--- a/src/main/java/fr/xephi/authme/permission/handlers/ZPermissionsHandler.java
+++ b/src/main/java/fr/xephi/authme/permission/handlers/ZPermissionsHandler.java
@@ -34,15 +34,6 @@ public class ZPermissionsHandler implements PermissionHandler {
     }
 
     @Override
-    public boolean hasPermission(Player player, PermissionNode node) {
-        Map<String, Boolean> perms = zPermissionsService.getPlayerPermissions(player.getWorld().getName(), null, player.getName());
-        if (perms.containsKey(node.getNode()))
-            return perms.get(node.getNode());
-        else
-            return node.getDefaultPermission().evaluate(player);
-    }
-
-    @Override
     public boolean hasPermissionOffline(String name, PermissionNode node) {
         Map<String, Boolean> perms = zPermissionsService.getPlayerPermissions(null, null, name);
         if (perms.containsKey(node.getNode()))


### PR DESCRIPTION
- Use Player#hasPermission to check if a player has a permission
- Remove hasPermission method from PermissionHandler implementations


See my comment in issue #872:
> As tested by @Platinteufel this issue is solved when Player#hasPermission is used instead of the PermissionHandler#hasPermission. I'm not sure if this is true for each permission plugin, though I would assume this is how Bukkit intended things to work. 

@Platinteufel tested with PEX, I will check with BukkitPermissions. Anyone else that can check with a permission system?