### PR TITLE
#937 Add option for AuthMe to run in sync

### DIFF
--- a/src/main/java/fr/xephi/authme/AuthMe.java
+++ b/src/main/java/fr/xephi/authme/AuthMe.java
@@ -179,11 +179,11 @@ public class AuthMe extends JavaPlugin {
         ConsoleLogger.setLogger(getLogger());
         ConsoleLogger.setLogFile(new File(getDataFolder(), LOG_FILENAME));
 
-        bukkitService = new BukkitService(this);
+        // Load settings and set up the console and console filter
+        settings = Initializer.createSettings(this);
+        bukkitService = new BukkitService(this, settings);
         Initializer initializer = new Initializer(this, bukkitService);
 
-        // Load settings and set up the console and console filter
-        settings = initializer.createSettings();
         ConsoleLogger.setLoggingOptions(settings);
         initializer.setupConsoleFilter(settings, getLogger());
 

--- a/src/main/java/fr/xephi/authme/command/executable/authme/ChangePasswordAdminCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/ChangePasswordAdminCommand.java
@@ -55,7 +55,7 @@ public class ChangePasswordAdminCommand implements ExecutableCommand {
 
         // Set the password
         final String playerNameLowerCase = playerName.toLowerCase();
-        bukkitService.runTaskAsynchronously(new Runnable() {
+        bukkitService.runTaskOptionallyAsync(new Runnable() {
 
             @Override
             public void run() {

--- a/src/main/java/fr/xephi/authme/command/executable/authme/RegisterAdminCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/RegisterAdminCommand.java
@@ -55,7 +55,7 @@ public class RegisterAdminCommand implements ExecutableCommand {
             return;
         }
 
-        bukkitService.runTaskAsynchronously(new Runnable() {
+        bukkitService.runTaskOptionallyAsync(new Runnable() {
 
             @Override
             public void run() {
@@ -80,7 +80,7 @@ public class RegisterAdminCommand implements ExecutableCommand {
                 ConsoleLogger.info(sender.getName() + " registered " + playerName);
                 final Player player = bukkitService.getPlayerExact(playerName);
                 if (player != null) {
-                    bukkitService.scheduleSyncDelayedTask(new Runnable() {
+                    bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(new Runnable() {
                         @Override
                         public void run() {
                             limboCache.restoreData(player);

--- a/src/main/java/fr/xephi/authme/command/executable/authme/SetEmailCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/SetEmailCommand.java
@@ -41,7 +41,7 @@ public class SetEmailCommand implements ExecutableCommand {
             return;
         }
 
-        bukkitService.runTaskAsynchronously(new Runnable() {
+        bukkitService.runTaskOptionallyAsync(new Runnable() {
             @Override
             public void run() {
                 // Validate the user
@@ -68,7 +68,6 @@ public class SetEmailCommand implements ExecutableCommand {
 
                 // Show a status message
                 commandService.send(sender, MessageKey.EMAIL_CHANGED_SUCCESS);
-
             }
         });
     }

--- a/src/main/java/fr/xephi/authme/events/AuthMeAsyncPreLoginEvent.java
+++ b/src/main/java/fr/xephi/authme/events/AuthMeAsyncPreLoginEvent.java
@@ -19,9 +19,10 @@ public class AuthMeAsyncPreLoginEvent extends CustomEvent {
      * Constructor.
      *
      * @param player The player
+     * @param isAsync True if the event is async, false otherwise
      */
-    public AuthMeAsyncPreLoginEvent(Player player) {
-        super(true);
+    public AuthMeAsyncPreLoginEvent(Player player, boolean isAsync) {
+        super(isAsync);
         this.player = player;
     }
 

--- a/src/main/java/fr/xephi/authme/events/ProtectInventoryEvent.java
+++ b/src/main/java/fr/xephi/authme/events/ProtectInventoryEvent.java
@@ -22,9 +22,10 @@ public class ProtectInventoryEvent extends CustomEvent implements Cancellable {
      * Constructor.
      *
      * @param player The player
+     * @param isAsync True if the event is async, false otherwise
      */
-    public ProtectInventoryEvent(Player player) {
-        super(true);
+    public ProtectInventoryEvent(Player player, boolean isAsync) {
+        super(isAsync);
         this.player = player;
         this.storedInventory = player.getInventory().getContents();
         this.storedArmor = player.getInventory().getArmorContents();

--- a/src/main/java/fr/xephi/authme/initialization/Initializer.java
+++ b/src/main/java/fr/xephi/authme/initialization/Initializer.java
@@ -58,9 +58,10 @@ public class Initializer {
     /**
      * Loads the plugin's settings.
      *
-     * @return The settings instance, or null if it could not be constructed
+     * @param authMe the plugin instance
+     * @return the settings instance, or null if it could not be constructed
      */
-    public Settings createSettings() throws Exception {
+    public static Settings createSettings(AuthMe authMe) throws Exception {
         File configFile = new File(authMe.getDataFolder(), "config.yml");
         PropertyResource resource = new YamlFileResource(configFile);
         SettingsMigrationService migrationService = new SettingsMigrationService(authMe.getDataFolder());

--- a/src/main/java/fr/xephi/authme/process/Management.java
+++ b/src/main/java/fr/xephi/authme/process/Management.java
@@ -15,7 +15,9 @@ import org.bukkit.entity.Player;
 
 import javax.inject.Inject;
 
-
+/**
+ * Performs auth actions, e.g. when a player joins, registers or wants to change his password.
+ */
 public class Management {
 
     @Inject
@@ -41,100 +43,51 @@ public class Management {
     @Inject
     private AsyncChangePassword asyncChangePassword;
 
-    Management() { }
-
-
-    public void performLogin(final Player player, final String password, final boolean forceLogin) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asynchronousLogin.login(player, password, forceLogin);
-            }
-        });
+    Management() {
     }
 
-    public void performLogout(final Player player) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asynchronousLogout.logout(player);
-            }
-        });
+
+    public void performLogin(Player player, String password, boolean forceLogin) {
+        runTask(() -> asynchronousLogin.login(player, password, forceLogin));
     }
 
-    public void performRegister(final Player player, final String password, final String email, final boolean autoLogin) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asyncRegister.register(player, password, email, autoLogin);
-            }
-        });
+    public void performLogout(Player player) {
+        runTask(() -> asynchronousLogout.logout(player));
     }
 
-    public void performUnregister(final Player player, final String password) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asynchronousUnregister.unregister(player, password);
-            }
-        });
+    public void performRegister(Player player, String password, String email, boolean autoLogin) {
+        runTask(() -> asyncRegister.register(player, password, email, autoLogin));
     }
 
-    public void performUnregisterByAdmin(final CommandSender initiator, final String name, final Player player) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asynchronousUnregister.adminUnregister(initiator, name, player);
-            }
-        });
+    public void performUnregister(Player player, String password) {
+        runTask(() -> asynchronousUnregister.unregister(player, password));
     }
 
-    public void performJoin(final Player player) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asynchronousJoin.processJoin(player);
-            }
-        });
+    public void performUnregisterByAdmin(CommandSender initiator, String name, Player player) {
+        runTask(() -> asynchronousUnregister.adminUnregister(initiator, name, player));
     }
 
-    public void performQuit(final Player player) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asynchronousQuit.processQuit(player);
-            }
-        });
+    public void performJoin(Player player) {
+        runTask(() -> asynchronousJoin.processJoin(player));
     }
 
-    public void performAddEmail(final Player player, final String newEmail) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asyncAddEmail.addEmail(player, newEmail);
-            }
-        });
+    public void performQuit(Player player) {
+        runTask(() -> asynchronousQuit.processQuit(player));
     }
 
-    public void performChangeEmail(final Player player, final String oldEmail, final String newEmail) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asyncChangeEmail.changeEmail(player, oldEmail, newEmail);
-            }
-        });
+    public void performAddEmail(Player player, String newEmail) {
+        runTask(() -> asyncAddEmail.addEmail(player, newEmail));
     }
 
-    public void performPasswordChange(final Player player, final String oldPassword, final String newPassword) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                asyncChangePassword.changePassword(player, oldPassword, newPassword);
-            }
-        });
+    public void performChangeEmail(Player player, String oldEmail, String newEmail) {
+        runTask(() -> asyncChangeEmail.changeEmail(player, oldEmail, newEmail));
+    }
+
+    public void performPasswordChange(Player player, String oldPassword, String newPassword) {
+        runTask(() -> asyncChangePassword.changePassword(player, oldPassword, newPassword));
     }
 
     private void runTask(Runnable runnable) {
-        bukkitService.runTaskAsynchronously(runnable);
+        bukkitService.runTaskOptionallyAsync(runnable);
     }
 }

--- a/src/main/java/fr/xephi/authme/process/SyncProcessManager.java
+++ b/src/main/java/fr/xephi/authme/process/SyncProcessManager.java
@@ -36,51 +36,26 @@ public class SyncProcessManager {
 
 
     public void processSyncEmailRegister(final Player player) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                processSyncEmailRegister.processEmailRegister(player);
-            }
-        });
+        runTask(() -> processSyncEmailRegister.processEmailRegister(player));
     }
 
     public void processSyncPasswordRegister(final Player player) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                processSyncPasswordRegister.processPasswordRegister(player);
-            }
-        });
+        runTask(() -> processSyncPasswordRegister.processPasswordRegister(player));
     }
 
     public void processSyncPlayerLogout(final Player player) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                processSynchronousPlayerLogout.processSyncLogout(player);
-            }
-        });
+        runTask(() -> processSynchronousPlayerLogout.processSyncLogout(player));
     }
 
     public void processSyncPlayerLogin(final Player player) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                processSyncPlayerLogin.processPlayerLogin(player);
-            }
-        });
+        runTask(() -> processSyncPlayerLogin.processPlayerLogin(player));
     }
 
     public void processSyncPlayerQuit(final Player player) {
-        runTask(new Runnable() {
-            @Override
-            public void run() {
-                processSyncronousPlayerQuit.processSyncQuit(player);
-            }
-        });
+        runTask(() -> processSyncronousPlayerQuit.processSyncQuit(player));
     }
 
     private void runTask(Runnable runnable) {
-        bukkitService.scheduleSyncDelayedTask(runnable);
+        bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(runnable);
     }
 }

--- a/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
@@ -21,6 +21,7 @@ import fr.xephi.authme.security.PasswordSecurity;
 import fr.xephi.authme.settings.properties.DatabaseSettings;
 import fr.xephi.authme.settings.properties.EmailSettings;
 import fr.xephi.authme.settings.properties.HooksSettings;
+import fr.xephi.authme.settings.properties.PluginSettings;
 import fr.xephi.authme.settings.properties.RestrictionSettings;
 import fr.xephi.authme.task.PlayerDataTaskManager;
 import fr.xephi.authme.util.BukkitService;
@@ -110,7 +111,8 @@ public class AsynchronousLogin implements AsynchronousProcess {
             }
         }
 
-        AuthMeAsyncPreLoginEvent event = new AuthMeAsyncPreLoginEvent(player);
+        boolean isAsync = service.getProperty(PluginSettings.USE_ASYNC_TASKS);
+        AuthMeAsyncPreLoginEvent event = new AuthMeAsyncPreLoginEvent(player, isAsync);
         bukkitService.callEvent(event);
         if (!event.canLogin()) {
             return null;

--- a/src/main/java/fr/xephi/authme/process/register/AsyncRegister.java
+++ b/src/main/java/fr/xephi/authme/process/register/AsyncRegister.java
@@ -15,6 +15,7 @@ import fr.xephi.authme.security.PasswordSecurity;
 import fr.xephi.authme.security.crypts.HashedPassword;
 import fr.xephi.authme.security.crypts.TwoFactor;
 import fr.xephi.authme.settings.properties.EmailSettings;
+import fr.xephi.authme.settings.properties.PluginSettings;
 import fr.xephi.authme.settings.properties.RegistrationSettings;
 import fr.xephi.authme.settings.properties.RestrictionSettings;
 import fr.xephi.authme.settings.properties.SecuritySettings;
@@ -36,36 +37,33 @@ import static fr.xephi.authme.permission.PlayerStatePermission.ALLOW_MULTIPLE_AC
  */
 public class AsyncRegister implements AsynchronousProcess {
 
+    /**
+     * Number of ticks to wait before running the login action when it is run synchronously.
+     * A small delay is necessary or the database won't return the newly saved PlayerAuth object
+     * and the login process thinks the user is not registered.
+     */
+    private static final int SYNC_LOGIN_DELAY = 5;
+
     @Inject
     private DataSource database;
-
     @Inject
     private PlayerCache playerCache;
-
     @Inject
     private PasswordSecurity passwordSecurity;
-
     @Inject
     private ProcessService service;
-
     @Inject
     private SyncProcessManager syncProcessManager;
-
     @Inject
     private PermissionsManager permissionsManager;
-
     @Inject
     private ValidationService validationService;
-
     @Inject
     private SendMailSSL sendMailSsl;
-
     @Inject
     private AsynchronousLogin asynchronousLogin;
-
     @Inject
     private BukkitService bukkitService;
-
 
     AsyncRegister() {
     }
@@ -172,7 +170,12 @@ public class AsyncRegister implements AsynchronousProcess {
         }
 
         if (!service.getProperty(RegistrationSettings.FORCE_LOGIN_AFTER_REGISTER) && autoLogin) {
-            bukkitService.runTaskOptionallyAsync(() -> asynchronousLogin.login(player, "dontneed", true));
+            if (service.getProperty(PluginSettings.USE_ASYNC_TASKS)) {
+                bukkitService.runTaskAsynchronously(() -> asynchronousLogin.login(player, "dontneed", true));
+            } else {
+                bukkitService.scheduleSyncDelayedTask(
+                    () -> asynchronousLogin.login(player, "dontneed", true), SYNC_LOGIN_DELAY);
+            }
         }
         syncProcessManager.processSyncPasswordRegister(player);
 

--- a/src/main/java/fr/xephi/authme/process/register/AsyncRegister.java
+++ b/src/main/java/fr/xephi/authme/process/register/AsyncRegister.java
@@ -67,7 +67,8 @@ public class AsyncRegister implements AsynchronousProcess {
     private BukkitService bukkitService;
 
 
-    AsyncRegister() { }
+    AsyncRegister() {
+    }
 
     private boolean preRegisterCheck(Player player, String password) {
         final String name = player.getName().toLowerCase();
@@ -171,12 +172,7 @@ public class AsyncRegister implements AsynchronousProcess {
         }
 
         if (!service.getProperty(RegistrationSettings.FORCE_LOGIN_AFTER_REGISTER) && autoLogin) {
-            bukkitService.runTaskAsynchronously(new Runnable(){
-                @Override
-                public void run() {
-                    asynchronousLogin.login(player, "dontneed", true);
-                }
-            });
+            bukkitService.runTaskOptionallyAsync(() -> asynchronousLogin.login(player, "dontneed", true));
         }
         syncProcessManager.processSyncPasswordRegister(player);
 

--- a/src/main/java/fr/xephi/authme/settings/properties/PluginSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/PluginSettings.java
@@ -68,6 +68,13 @@ public class PluginSettings implements SettingsHolder {
     public static final Property<LogLevel> LOG_LEVEL =
         newProperty(LogLevel.class, "settings.logLevel", LogLevel.FINE);
 
+    @Comment({
+        "By default we schedule async tasks when talking to the database",
+        "If you want typical communication with the database to happen synchronously, set this to false"
+    })
+    public static final Property<Boolean> USE_ASYNC_TASKS =
+        newProperty("settings.useAsyncTasks", true);
+
     private PluginSettings() {
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -271,6 +271,9 @@ settings:
     # FINE for some additional detailed ones (like password failed),
     # and DEBUG for debug messages
     logLevel: 'FINE'
+    # By default we schedule async tasks when talking to the database
+    # If you want typical communication with the database to happen synchronously, set this to false
+    useAsyncTasks: true
 ExternalBoardOptions:
     # MySQL column for the salt, needed for some forum/cms support
     mySQLColumnSalt: ''

--- a/src/test/java/fr/xephi/authme/TestHelper.java
+++ b/src/test/java/fr/xephi/authme/TestHelper.java
@@ -88,6 +88,20 @@ public final class TestHelper {
     }
 
     /**
+     * Execute a {@link Runnable} passed to a mock's {@link BukkitService#runTaskOptionallyAsync} method.
+     * Note that calling this method expects that there be a runnable sent to the method and will fail
+     * otherwise.
+     *
+     * @param service The mock service
+     */
+    public static void runOptionallyAsyncTask(BukkitService service) {
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(service).runTaskOptionallyAsync(captor.capture());
+        Runnable runnable = captor.getValue();
+        runnable.run();
+    }
+
+    /**
      * Execute a {@link Runnable} passed to a mock's {@link BukkitService#scheduleSyncDelayedTask(Runnable)}
      * method. Note that calling this method expects that there be a runnable sent to the method and will fail
      * otherwise.
@@ -111,6 +125,20 @@ public final class TestHelper {
     public static void runSyncDelayedTaskWithDelay(BukkitService service) {
         ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
         verify(service).scheduleSyncDelayedTask(captor.capture(), anyLong());
+        Runnable runnable = captor.getValue();
+        runnable.run();
+    }
+
+    /**
+     * Execute a {@link Runnable} passed to a mock's {@link BukkitService#scheduleSyncTaskFromOptionallyAsyncTask}
+     * method. Note that calling this method expects that there be a runnable sent to the method and will fail
+     * otherwise.
+     *
+     * @param service The mock service
+     */
+    public static void runSyncTaskFromOptionallyAsyncTask(BukkitService service) {
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(service).scheduleSyncTaskFromOptionallyAsyncTask(captor.capture());
         Runnable runnable = captor.getValue();
         runnable.run();
     }

--- a/src/test/java/fr/xephi/authme/command/executable/authme/ChangePasswordAdminCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/authme/ChangePasswordAdminCommandTest.java
@@ -21,7 +21,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Arrays;
 
-import static fr.xephi.authme.TestHelper.runInnerRunnable;
+import static fr.xephi.authme.TestHelper.runOptionallyAsyncTask;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -89,7 +89,7 @@ public class ChangePasswordAdminCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(player, password));
-        runInnerRunnable(bukkitService);
+        runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(service).send(sender, MessageKey.UNKNOWN_USER);
@@ -114,7 +114,7 @@ public class ChangePasswordAdminCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(player, password));
-        runInnerRunnable(bukkitService);
+        runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(validationService).validatePassword(password, player);
@@ -142,7 +142,7 @@ public class ChangePasswordAdminCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(player, password));
-        runInnerRunnable(bukkitService);
+        runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(validationService).validatePassword(password, player);
@@ -169,7 +169,7 @@ public class ChangePasswordAdminCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(player, password));
-        runInnerRunnable(bukkitService);
+        runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(validationService).validatePassword(password, player);

--- a/src/test/java/fr/xephi/authme/command/executable/authme/RegisterAdminCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/authme/RegisterAdminCommandTest.java
@@ -23,6 +23,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Arrays;
 
+import static fr.xephi.authme.TestHelper.runSyncTaskFromOptionallyAsyncTask;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -92,7 +93,7 @@ public class RegisterAdminCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(user, password));
-        TestHelper.runInnerRunnable(bukkitService);
+        TestHelper.runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(validationService).validatePassword(password, user);
@@ -114,7 +115,7 @@ public class RegisterAdminCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(user, password));
-        TestHelper.runInnerRunnable(bukkitService);
+        TestHelper.runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(validationService).validatePassword(password, user);
@@ -139,7 +140,7 @@ public class RegisterAdminCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(user, password));
-        TestHelper.runInnerRunnable(bukkitService);
+        TestHelper.runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(validationService).validatePassword(password, user);
@@ -168,8 +169,8 @@ public class RegisterAdminCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(user, password));
-        TestHelper.runInnerRunnable(bukkitService);
-        runSyncDelayedTask(bukkitService);
+        TestHelper.runOptionallyAsyncTask(bukkitService);
+        runSyncTaskFromOptionallyAsyncTask(bukkitService);
 
         // then
         verify(validationService).validatePassword(password, user);
@@ -185,12 +186,5 @@ public class RegisterAdminCommandTest {
         assertThat(auth.getRealName(), equalTo(name));
         assertThat(auth.getNickname(), equalTo(name.toLowerCase()));
         assertThat(auth.getPassword(), equalTo(hashedPassword));
-    }
-
-    private static void runSyncDelayedTask(BukkitService bukkitService) {
-        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-        verify(bukkitService).scheduleSyncDelayedTask(captor.capture());
-        Runnable runnable = captor.getValue();
-        runnable.run();
     }
 }

--- a/src/test/java/fr/xephi/authme/command/executable/authme/SetEmailCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/authme/SetEmailCommandTest.java
@@ -15,7 +15,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Arrays;
 
-import static fr.xephi.authme.TestHelper.runInnerRunnable;
+import static fr.xephi.authme.TestHelper.runOptionallyAsyncTask;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -73,7 +73,7 @@ public class SetEmailCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(user, email));
-        runInnerRunnable(bukkitService);
+        runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(commandService).validateEmail(email);
@@ -95,7 +95,7 @@ public class SetEmailCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(user, email));
-        runInnerRunnable(bukkitService);
+        runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(commandService).validateEmail(email);
@@ -120,7 +120,7 @@ public class SetEmailCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(user, email));
-        runInnerRunnable(bukkitService);
+        runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(commandService).validateEmail(email);
@@ -146,7 +146,7 @@ public class SetEmailCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(user, email));
-        runInnerRunnable(bukkitService);
+        runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(commandService).validateEmail(email);
@@ -173,7 +173,7 @@ public class SetEmailCommandTest {
 
         // when
         command.executeCommand(sender, Arrays.asList(user, email));
-        runInnerRunnable(bukkitService);
+        runOptionallyAsyncTask(bukkitService);
 
         // then
         verify(commandService).validateEmail(email);

--- a/src/test/java/fr/xephi/authme/util/BukkitServiceTest.java
+++ b/src/test/java/fr/xephi/authme/util/BukkitServiceTest.java
@@ -2,6 +2,8 @@ package fr.xephi.authme.util;
 
 import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ReflectionTestUtils;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.PluginSettings;
 import org.bukkit.entity.Player;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,6 +15,7 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -23,6 +26,8 @@ public class BukkitServiceTest {
 
     @Mock
     private AuthMe authMe;
+    @Mock
+    private Settings settings;
 
     /**
      * Checks that {@link BukkitService#getOnlinePlayersIsCollection} is initialized to {@code true} on startup;
@@ -31,7 +36,8 @@ public class BukkitServiceTest {
     @Test
     public void shouldHavePlayerListAsCollectionMethod() {
         // given
-        BukkitService bukkitService = new BukkitService(authMe);
+        given(settings.getProperty(PluginSettings.USE_ASYNC_TASKS)).willReturn(true);
+        BukkitService bukkitService = new BukkitService(authMe, settings);
 
         // when
         boolean doesMethodReturnCollection = ReflectionTestUtils
@@ -44,7 +50,8 @@ public class BukkitServiceTest {
     @Test
     public void shouldRetrieveListOfOnlinePlayersFromReflectedMethod() {
         // given
-        BukkitService bukkitService = new BukkitService(authMe);
+        given(settings.getProperty(PluginSettings.USE_ASYNC_TASKS)).willReturn(true);
+        BukkitService bukkitService = new BukkitService(authMe, settings);
         ReflectionTestUtils.setField(BukkitService.class, bukkitService, "getOnlinePlayersIsCollection", false);
         ReflectionTestUtils.setField(BukkitService.class, bukkitService, "getOnlinePlayers",
             ReflectionTestUtils.getMethod(BukkitServiceTest.class, "onlinePlayersImpl"));


### PR DESCRIPTION
Please review these changes for #937

- Added new setting to define whether tasks should be async (default) or sync
- Added new methods in BukkitService to schedule tasks async / sync based on that setting
  * If it's sync we just run the code directly, it's not scheduled as a sync delayed task. **Is that OK?**

I don't understand when we us BukkitScheduler's `runTask()` vs. `scheduledSyncDelayedTask()`. We use both to run sync code inside an async thread, e.g. in AsynchronousJoin. Does anyone know the difference?

Finally, the change to the Initializer is ugly but it can be refactored once https://github.com/ljacqu/DependencyInjector/issues/32 has been implemented.

