### PR TITLE
#1119 email show permission and privacy improvements

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED FILE! Do not edit this directly -->
-<!-- File auto-generated on Sat Apr 29 18:27:38 CEST 2017. See docs/commands/commands.tpl.md -->
+<!-- File auto-generated on Fri Aug 11 04:37:25 CEST 2017. See docs/commands/commands.tpl.md -->
 
 ## AuthMe Commands
 You can use the following commands to use the features of AuthMe. Mandatory arguments are marked with `< >`
@@ -47,13 +47,27 @@ brackets; optional arguments are enclosed in square brackets (`[ ]`).
 - **/authme reload**: Reload the AuthMeReloaded plugin.
   <br />Requires `authme.admin.reload`
 - **/authme version**: Show detailed information about the installed AuthMeReloaded version, the developers, contributors, and license.
-- **/authme converter** &lt;job>: Converter command for AuthMeReloaded.
+- **/authme converter** [job]: Converter command for AuthMeReloaded.
   <br />Requires `authme.admin.converter`
 - **/authme messages**: Adds missing messages to the current messages file.
   <br />Requires `authme.admin.updatemessages`
 - **/authme debug** [child] [arg] [arg]: Allows various operations for debugging.
   <br />Requires `authme.debug.command`
 - **/authme help** [query]: View detailed help for /authme commands.
+- **/email**: The AuthMeReloaded email command base.
+- **/email show**: Show your current email address.
+  <br />Requires `authme.player.email.see`
+- **/email add** &lt;email> &lt;verifyEmail>: Add a new email address to your account.
+  <br />Requires `authme.player.email.add`
+- **/email change** &lt;oldEmail> &lt;newEmail>: Change an email address of your account.
+  <br />Requires `authme.player.email.change`
+- **/email recover** &lt;email>: Recover your account using an Email address by sending a mail containing a new password.
+  <br />Requires `authme.player.email.recover`
+- **/email code** &lt;code>: Recover your account by submitting a code delivered to your email.
+  <br />Requires `authme.player.email.recover`
+- **/email setpassword** &lt;password>: Set a new password after successfully recovering your account.
+  <br />Requires `authme.player.email.recover`
+- **/email help** [query]: View detailed help for /email commands.
 - **/login** &lt;password>: Command to log in using AuthMeReloaded.
   <br />Requires `authme.player.login`
 - **/login help** [query]: View detailed help for /login commands.
@@ -69,19 +83,6 @@ brackets; optional arguments are enclosed in square brackets (`[ ]`).
 - **/changepassword** &lt;oldPassword> &lt;newPassword>: Command to change your password using AuthMeReloaded.
   <br />Requires `authme.player.changepassword`
 - **/changepassword help** [query]: View detailed help for /changepassword commands.
-- **/email**: The AuthMeReloaded email command base.
-- **/email show**: Show your current email address.
-- **/email add** &lt;email> &lt;verifyEmail>: Add a new email address to your account.
-  <br />Requires `authme.player.email.add`
-- **/email change** &lt;oldEmail> &lt;newEmail>: Change an email address of your account.
-  <br />Requires `authme.player.email.change`
-- **/email recover** &lt;email>: Recover your account using an Email address by sending a mail containing a new password.
-  <br />Requires `authme.player.email.recover`
-- **/email code** &lt;code>: Recover your account by submitting a code delivered to your email.
-  <br />Requires `authme.player.email.recover`
-- **/email setpassword** &lt;password>: Set a new password after successfully recovering your account.
-  <br />Requires `authme.player.email.recover`
-- **/email help** [query]: View detailed help for /email commands.
 - **/captcha** &lt;captcha>: Captcha command for AuthMeReloaded.
   <br />Requires `authme.player.captcha`
 - **/captcha help** [query]: View detailed help for /captcha commands.
@@ -89,4 +90,4 @@ brackets; optional arguments are enclosed in square brackets (`[ ]`).
 
 ---
 
-This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sat Apr 29 18:27:38 CEST 2017
+This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Fri Aug 11 04:37:25 CEST 2017

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED FILE! Do not edit this directly -->
-<!-- File auto-generated on Sat Aug 12 00:01:58 CEST 2017. See docs/config/config.tpl.md -->
+<!-- File auto-generated on Sat Aug 12 13:49:42 CEST 2017. See docs/config/config.tpl.md -->
 
 ## AuthMe Configuration
 The first time you run AuthMe it will create a config.yml file in the plugins/AuthMe folder, 
@@ -458,11 +458,11 @@ Security:
         # This prevents an attacker from abusing AuthMe's email feature.
         cooldown: 60
     privacy:
-        # The maill showed using /email show will be partially hidden
+        # The maill shown using /email show will be partially hidden
         # E.g. (if enabled)
-        #  original email: myemail@domain.com
-        #  hidden email: mye***@***in.com
-        email: false
+        #  original email: my.email@example.com
+        #  hidden email: my.***@***mple.com
+        enableEmailMasking: false
 # Before a user logs in, various properties are temporarily removed from the player,
 # such as OP status, ability to fly, and walk/fly speed.
 # Once the user is logged in, we add back the properties we previously saved.
@@ -540,4 +540,4 @@ To change settings on a running server, save your changes to config.yml and use
 
 ---
 
-This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sat Aug 12 00:01:58 CEST 2017
+This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sat Aug 12 13:49:42 CEST 2017

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED FILE! Do not edit this directly -->
-<!-- File auto-generated on Sat Jul 15 19:32:28 CEST 2017. See docs/config/config.tpl.md -->
+<!-- File auto-generated on Sat Aug 12 00:01:58 CEST 2017. See docs/config/config.tpl.md -->
 
 ## AuthMe Configuration
 The first time you run AuthMe it will create a config.yml file in the plugins/AuthMe folder, 
@@ -457,6 +457,12 @@ Security:
         # Seconds a user has to wait for before a password recovery mail may be sent again
         # This prevents an attacker from abusing AuthMe's email feature.
         cooldown: 60
+    privacy:
+        # The maill showed using /email show will be partially hidden
+        # E.g. (if enabled)
+        #  original email: myemail@domain.com
+        #  hidden email: mye***@***in.com
+        email: false
 # Before a user logs in, various properties are temporarily removed from the player,
 # such as OP status, ability to fly, and walk/fly speed.
 # Once the user is logged in, we add back the properties we previously saved.
@@ -534,4 +540,4 @@ To change settings on a running server, save your changes to config.yml and use
 
 ---
 
-This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sat Jul 15 19:32:28 CEST 2017
+This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sat Aug 12 00:01:58 CEST 2017

--- a/docs/permission_nodes.md
+++ b/docs/permission_nodes.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED FILE! Do not edit this directly -->
-<!-- File auto-generated on Sat Aug 12 00:01:13 CEST 2017. See docs/permissions/permission_nodes.tpl.md -->
+<!-- File auto-generated on Sat Aug 12 13:42:15 CEST 2017. See docs/permissions/permission_nodes.tpl.md -->
 
 ## AuthMe Permission Nodes
 The following are the permission nodes that are currently supported by the latest dev builds.
@@ -62,4 +62,4 @@ The following are the permission nodes that are currently supported by the lates
 
 ---
 
-This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sat Aug 12 00:01:13 CEST 2017
+This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sat Aug 12 13:42:15 CEST 2017

--- a/docs/permission_nodes.md
+++ b/docs/permission_nodes.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED FILE! Do not edit this directly -->
-<!-- File auto-generated on Sat Apr 29 18:27:41 CEST 2017. See docs/permissions/permission_nodes.tpl.md -->
+<!-- File auto-generated on Sat Aug 12 00:01:13 CEST 2017. See docs/permissions/permission_nodes.tpl.md -->
 
 ## AuthMe Permission Nodes
 The following are the permission nodes that are currently supported by the latest dev builds.
@@ -51,6 +51,7 @@ The following are the permission nodes that are currently supported by the lates
 - **authme.player.email.add** – Command permission to add an email address.
 - **authme.player.email.change** – Command permission to change the email address.
 - **authme.player.email.recover** – Command permission to recover an account using its email address.
+- **authme.player.email.see** – Command permission to see the own email address.
 - **authme.player.login** – Command permission to login.
 - **authme.player.logout** – Command permission to logout.
 - **authme.player.register** – Command permission to register.
@@ -61,4 +62,4 @@ The following are the permission nodes that are currently supported by the lates
 
 ---
 
-This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sat Apr 29 18:27:41 CEST 2017
+This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sat Aug 12 00:01:13 CEST 2017

--- a/src/main/java/fr/xephi/authme/command/CommandInitializer.java
+++ b/src/main/java/fr/xephi/authme/command/CommandInitializer.java
@@ -456,6 +456,7 @@ public class CommandInitializer {
             .labels("show", "myemail")
             .description("Show Email")
             .detailedDescription("Show your current email address.")
+            .permission(PlayerPermission.SEE_EMAIL)
             .executableCommand(ShowEmailCommand.class)
             .register();
 

--- a/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
@@ -19,9 +19,6 @@ import java.util.List;
 public class ShowEmailCommand extends PlayerCommand {
 
     @Inject
-    private Settings settings;
-
-    @Inject
     private CommonService commonService;
 
     @Inject
@@ -31,7 +28,7 @@ public class ShowEmailCommand extends PlayerCommand {
     public void runCommand(Player player, List<String> arguments) {
         PlayerAuth auth = playerCache.getAuth(player.getName());
         if (auth != null && !Utils.isEmailEmpty(auth.getEmail())) {
-            if(settings.getProperty(SecuritySettings.EMAIL_PRIVACY)){
+            if(commonService.getProperty(SecuritySettings.USE_EMAIL_MASKING)){
                 commonService.send(player, MessageKey.EMAIL_SHOW, emailMask(auth.getEmail()));
             } else {
                 commonService.send(player, MessageKey.EMAIL_SHOW, auth.getEmail());

--- a/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
@@ -5,6 +5,8 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.service.CommonService;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.SecuritySettings;
 import fr.xephi.authme.util.Utils;
 import org.bukkit.entity.Player;
 
@@ -17,6 +19,9 @@ import java.util.List;
 public class ShowEmailCommand extends PlayerCommand {
 
     @Inject
+    private Settings settings;
+
+    @Inject
     private CommonService commonService;
 
     @Inject
@@ -26,7 +31,11 @@ public class ShowEmailCommand extends PlayerCommand {
     public void runCommand(Player player, List<String> arguments) {
         PlayerAuth auth = playerCache.getAuth(player.getName());
         if (auth != null && !Utils.isEmailEmpty(auth.getEmail())) {
-            commonService.send(player, MessageKey.EMAIL_SHOW, emailMask(auth.getEmail()));
+            if(settings.getProperty(SecuritySettings.EMAIL_PRIVACY)){
+                commonService.send(player, MessageKey.EMAIL_SHOW, emailMask(auth.getEmail()));
+            } else {
+                commonService.send(player, MessageKey.EMAIL_SHOW, auth.getEmail());
+            }
         } else {
             commonService.send(player, MessageKey.SHOW_NO_EMAIL);
         }
@@ -34,9 +43,9 @@ public class ShowEmailCommand extends PlayerCommand {
 
     private String emailMask(String email){
         String[] frag = email.split("@");   //Split id and domain
-        int sid = frag[0].length() / 3 + 1;     //Define the id view
-        int sdomain = frag[1].length() / 3 + 1;   //Define the domain view
-        String id = frag[0].substring(0, sid) + "*****";  //Build the id
+        int sid = frag[0].length() / 3 + 1;     //Define the id view (required length >= 1)
+        int sdomain = frag[1].length() / 3;   //Define the domain view (required length >= 0)
+        String id = frag[0].substring(0, sid) + "***";  //Build the id
         String domain = "***" + frag[1].substring(sdomain);  //Build the domain
         return id + "@" + domain;
     }

--- a/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
@@ -34,10 +34,11 @@ public class ShowEmailCommand extends PlayerCommand {
 
     private String emailMask(String email){
         String[] frag = email.split("@");   //Split id and domain
-        int sid = frag[0].length() / 3 + 1;     //Define the id view
-        int sdomain = frag[1].length() / 3 + 1;   //Define the domain view
+        int sid = frag[0].length() / 3 + 1;     //Define the id view (must be a value >= 1)
+        String[] dom = frag[1].split(".");  //Domain substrings
+        int sdomain = dom[0].length() / 3;   //Define the domain view (must be a value >= 0)
         String id = frag[0].substring(0, sid) + "*****";  //Build the id
-        String domain = "***" + frag[1].substring(sdomain);  //Build the domain
+        String domain = "***" + dom[0].substring(sdomain) + "." + dom[1];  //Build the domain
         return id + "@" + domain;
     }
 }

--- a/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
@@ -26,9 +26,18 @@ public class ShowEmailCommand extends PlayerCommand {
     public void runCommand(Player player, List<String> arguments) {
         PlayerAuth auth = playerCache.getAuth(player.getName());
         if (auth != null && !Utils.isEmailEmpty(auth.getEmail())) {
-            commonService.send(player, MessageKey.EMAIL_SHOW, auth.getEmail());
+            commonService.send(player, MessageKey.EMAIL_SHOW, emailMask(auth.getEmail()));
         } else {
             commonService.send(player, MessageKey.SHOW_NO_EMAIL);
         }
+    }
+
+    private String emailMask(String email){
+        String[] frag = email.split("@");   //Split id and domain
+        int sid = frag[0].length() / 3 + 1;     //Define the id view
+        int sdomain = frag[1].length() / 3 + 1;   //Define the domain view
+        String id = frag[0].substring(0, sid) + "*****";  //Build the id
+        String domain = "***" + frag[1].substring(sdomain, frag[1].length());  //Build the domain
+        return id + "@" + domain;
     }
 }

--- a/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
@@ -34,11 +34,10 @@ public class ShowEmailCommand extends PlayerCommand {
 
     private String emailMask(String email){
         String[] frag = email.split("@");   //Split id and domain
-        int sid = frag[0].length() / 3 + 1;     //Define the id view (must be a value >= 1)
-        String[] dom = frag[1].split(".");  //Domain substrings
-        int sdomain = dom[0].length() / 3;   //Define the domain view (must be a value >= 0)
+        int sid = frag[0].length() / 3 + 1;     //Define the id view
+        int sdomain = frag[1].length() / 3 + 1;   //Define the domain view
         String id = frag[0].substring(0, sid) + "*****";  //Build the id
-        String domain = "***" + dom[0].substring(sdomain) + "." + dom[1];  //Build the domain
+        String domain = "***" + frag[1].substring(sdomain);  //Build the domain
         return id + "@" + domain;
     }
 }

--- a/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
@@ -37,7 +37,7 @@ public class ShowEmailCommand extends PlayerCommand {
         int sid = frag[0].length() / 3 + 1;     //Define the id view
         int sdomain = frag[1].length() / 3 + 1;   //Define the domain view
         String id = frag[0].substring(0, sid) + "*****";  //Build the id
-        String domain = "***" + frag[1].substring(sdomain, frag[1].length());  //Build the domain
+        String domain = "***" + frag[1].substring(sdomain);  //Build the domain
         return id + "@" + domain;
     }
 }

--- a/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
@@ -5,7 +5,6 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.service.CommonService;
-import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.SecuritySettings;
 import fr.xephi.authme.util.Utils;
 import org.bukkit.entity.Player;

--- a/src/main/java/fr/xephi/authme/permission/PlayerPermission.java
+++ b/src/main/java/fr/xephi/authme/permission/PlayerPermission.java
@@ -31,6 +31,11 @@ public enum PlayerPermission implements PermissionNode {
     CHANGE_PASSWORD("authme.player.changepassword"),
 
     /**
+     * Command permission to see the own email address.
+     */
+    SEE_EMAIL("authme.player.email.see"),
+
+    /**
      * Command permission to add an email address.
      */
     ADD_EMAIL("authme.player.email.add"),

--- a/src/main/java/fr/xephi/authme/settings/properties/SecuritySettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/SecuritySettings.java
@@ -132,6 +132,15 @@ public final class SecuritySettings implements SettingsHolder {
     public static final Property<Integer> EMAIL_RECOVERY_COOLDOWN_SECONDS =
         newProperty("Security.emailRecovery.cooldown", 60);
 
+    @Comment({
+        "The maill showed using /email show will be partially hidden",
+        "E.g. (if enabled)",
+        " original email: myemail@domain.com",
+        " hidden email: mye***@***in.com"
+    })
+    public static final Property<Boolean> EMAIL_PRIVACY =
+        newProperty("Security.privacy.email", false);
+
     private SecuritySettings() {
     }
 

--- a/src/main/java/fr/xephi/authme/settings/properties/SecuritySettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/SecuritySettings.java
@@ -133,13 +133,13 @@ public final class SecuritySettings implements SettingsHolder {
         newProperty("Security.emailRecovery.cooldown", 60);
 
     @Comment({
-        "The maill showed using /email show will be partially hidden",
+        "The maill shown using /email show will be partially hidden",
         "E.g. (if enabled)",
-        " original email: myemail@domain.com",
-        " hidden email: mye***@***in.com"
+        " original email: my.email@example.com",
+        " hidden email: my.***@***mple.com"
     })
-    public static final Property<Boolean> EMAIL_PRIVACY =
-        newProperty("Security.privacy.email", false);
+    public static final Property<Boolean> USE_EMAIL_MASKING =
+        newProperty("Security.privacy.enableEmailMasking", false);
 
     private SecuritySettings() {
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,6 +18,9 @@ commands:
   authme:
     description: AuthMe op commands
     usage: /authme register|unregister|forcelogin|password|lastlogin|accounts|email|setemail|getip|spawn|setspawn|firstspawn|setfirstspawn|purge|purgeplayer|backup|resetpos|purgebannedplayers|switchantibot|reload|version|converter|messages|debug
+  email:
+    description: Add email or recover password
+    usage: /email show|add|change|recover|code|setpassword
   login:
     description: Login command
     usage: /login <password>
@@ -43,9 +46,6 @@ commands:
     aliases:
     - changepass
     - cp
-  email:
-    description: Add email or recover password
-    usage: /email show|add|change|recover|code|setpassword
   captcha:
     description: Captcha Command
     usage: /captcha <captcha>
@@ -213,6 +213,7 @@ permissions:
       authme.player.email.add: true
       authme.player.email.change: true
       authme.player.email.recover: true
+      authme.player.email.see: true
       authme.player.login: true
       authme.player.logout: true
       authme.player.register: true
@@ -233,6 +234,7 @@ permissions:
       authme.player.email.add: true
       authme.player.email.change: true
       authme.player.email.recover: true
+      authme.player.email.see: true
   authme.player.email.add:
     description: Command permission to add an email address.
     default: true
@@ -241,6 +243,9 @@ permissions:
     default: true
   authme.player.email.recover:
     description: Command permission to recover an account using its email address.
+    default: true
+  authme.player.email.see:
+    description: Command permission to see the own email address.
     default: true
   authme.player.login:
     description: Command permission to login.
@@ -258,5 +263,6 @@ permissions:
     description: Command permission to unregister.
     default: true
   authme.vip:
-    description: When the server is full and someone with this permission joins the server, someone will be kicked.
+    description: When the server is full and someone with this permission joins the
+      server, someone will be kicked.
     default: op

--- a/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
@@ -4,6 +4,8 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.service.CommonService;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.SecuritySettings;
 import org.bukkit.entity.Player;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +32,9 @@ public class ShowEmailCommandTest {
     private ShowEmailCommand command;
 
     @Mock
+    private Settings settings;
+
+    @Mock
     private CommonService commandService;
 
     @Mock
@@ -41,12 +46,28 @@ public class ShowEmailCommandTest {
         Player sender = mock(Player.class);
         given(sender.getName()).willReturn(USERNAME);
         given(playerCache.getAuth(USERNAME)).willReturn(newAuthWithEmail(CURRENT_EMAIL));
+        given(settings.getProperty(SecuritySettings.EMAIL_PRIVACY)).willReturn(false);
 
         // when
         command.executeCommand(sender, Collections.emptyList());
 
         // then
-        verify(commandService).send(sender, MessageKey.EMAIL_SHOW, "my.*****@***ple.com");
+        verify(commandService).send(sender, MessageKey.EMAIL_SHOW, CURRENT_EMAIL);
+    }
+
+    @Test
+    public void shouldShowHiddenEmailMessage() {
+        // given
+        Player sender = mock(Player.class);
+        given(sender.getName()).willReturn(USERNAME);
+        given(playerCache.getAuth(USERNAME)).willReturn(newAuthWithEmail(CURRENT_EMAIL));
+        given(settings.getProperty(SecuritySettings.EMAIL_PRIVACY)).willReturn(true);
+
+        // when
+        command.executeCommand(sender, Collections.emptyList());
+
+        // then
+        verify(commandService).send(sender, MessageKey.EMAIL_SHOW, "my.***@***mple.com");
     }
 
     @Test

--- a/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
@@ -32,10 +32,7 @@ public class ShowEmailCommandTest {
     private ShowEmailCommand command;
 
     @Mock
-    private Settings settings;
-
-    @Mock
-    private CommonService commandService;
+    private CommonService commonService;
 
     @Mock
     private PlayerCache playerCache;
@@ -46,13 +43,13 @@ public class ShowEmailCommandTest {
         Player sender = mock(Player.class);
         given(sender.getName()).willReturn(USERNAME);
         given(playerCache.getAuth(USERNAME)).willReturn(newAuthWithEmail(CURRENT_EMAIL));
-        given(settings.getProperty(SecuritySettings.EMAIL_PRIVACY)).willReturn(false);
+        given(commonService.getProperty(SecuritySettings.USE_EMAIL_MASKING)).willReturn(false);
 
         // when
         command.executeCommand(sender, Collections.emptyList());
 
         // then
-        verify(commandService).send(sender, MessageKey.EMAIL_SHOW, CURRENT_EMAIL);
+        verify(commonService).send(sender, MessageKey.EMAIL_SHOW, CURRENT_EMAIL);
     }
 
     @Test
@@ -61,13 +58,13 @@ public class ShowEmailCommandTest {
         Player sender = mock(Player.class);
         given(sender.getName()).willReturn(USERNAME);
         given(playerCache.getAuth(USERNAME)).willReturn(newAuthWithEmail(CURRENT_EMAIL));
-        given(settings.getProperty(SecuritySettings.EMAIL_PRIVACY)).willReturn(true);
+        given(commonService.getProperty(SecuritySettings.USE_EMAIL_MASKING)).willReturn(true);
 
         // when
         command.executeCommand(sender, Collections.emptyList());
 
         // then
-        verify(commandService).send(sender, MessageKey.EMAIL_SHOW, "my.***@***mple.com");
+        verify(commonService).send(sender, MessageKey.EMAIL_SHOW, "my.***@***mple.com");
     }
 
     @Test
@@ -81,7 +78,7 @@ public class ShowEmailCommandTest {
         command.executeCommand(sender, Collections.emptyList());
 
         // then
-        verify(commandService).send(sender, MessageKey.SHOW_NO_EMAIL);
+        verify(commonService).send(sender, MessageKey.SHOW_NO_EMAIL);
     }
 
     private static PlayerAuth newAuthWithEmail(String email) {

--- a/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
@@ -46,7 +46,7 @@ public class ShowEmailCommandTest {
         command.executeCommand(sender, Collections.emptyList());
 
         // then
-        verify(commandService).send(sender, MessageKey.EMAIL_SHOW, CURRENT_EMAIL);
+        verify(commandService).send(sender, MessageKey.EMAIL_SHOW, "my.*****@***ple.com");
     }
 
     @Test

--- a/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
@@ -4,7 +4,6 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.service.CommonService;
-import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.SecuritySettings;
 import org.bukkit.entity.Player;
 import org.junit.Test;


### PR DESCRIPTION
Now the command `/email show` requires the permission: `"authme.player.email.see"` and will return a partially hidden email.

E.g.
normal: `my.email@example.com`
hidden: `my.*****@***ple.com`
format: `1/3(id lenght) + *** + @ + *** + 2/3(domain lenght)`