### PR TITLE
Fix Java 9 support for Pbkdf2Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ addons:
       - git
 
 language: java
-jdk: oraclejdk8
+jdk:
+  - oraclejdk8
+  - oraclejdk9
 
 before_script:
     - "sudo git clone https://www.github.com/P-H-C/phc-winner-argon2.git argon2-src"

--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-            <version>2.11.0</version>
+            <version>2.10.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>hamcrest-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-            <version>2.10.0</version>
+            <version>2.11.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>hamcrest-core</artifactId>

--- a/src/main/java/fr/xephi/authme/security/crypts/Pbkdf2Django.java
+++ b/src/main/java/fr/xephi/authme/security/crypts/Pbkdf2Django.java
@@ -5,7 +5,7 @@ import de.rtner.security.auth.spi.PBKDF2Parameters;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.security.crypts.description.AsciiRestricted;
 
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 @AsciiRestricted
 public class Pbkdf2Django extends HexSaltedMethod {
@@ -18,7 +18,7 @@ public class Pbkdf2Django extends HexSaltedMethod {
         PBKDF2Parameters params = new PBKDF2Parameters("HmacSHA256", "ASCII", salt.getBytes(), DEFAULT_ITERATIONS);
         PBKDF2Engine engine = new PBKDF2Engine(params);
 
-        return result + DatatypeConverter.printBase64Binary(engine.deriveKey(password, 32));
+        return result + Base64.getEncoder().encodeToString(engine.deriveKey(password, 32));
     }
 
     @Override
@@ -35,7 +35,7 @@ public class Pbkdf2Django extends HexSaltedMethod {
             return false;
         }
         String salt = line[2];
-        byte[] derivedKey = DatatypeConverter.parseBase64Binary(line[3]);
+        byte[] derivedKey = Base64.getDecoder().decode(line[3]);
         PBKDF2Parameters params = new PBKDF2Parameters("HmacSHA256", "ASCII", salt.getBytes(), iterations, derivedKey);
         PBKDF2Engine engine = new PBKDF2Engine(params);
         return engine.verifyKey(password);

--- a/src/test/java/fr/xephi/authme/AuthMeInitializationTest.java
+++ b/src/test/java/fr/xephi/authme/AuthMeInitializationTest.java
@@ -4,7 +4,6 @@ import ch.jalu.configme.resource.PropertyResource;
 import ch.jalu.injector.Injector;
 import ch.jalu.injector.InjectorBuilder;
 import com.google.common.io.Files;
-import fr.xephi.authme.api.NewAPI;
 import fr.xephi.authme.api.v3.AuthMeApi;
 import fr.xephi.authme.command.CommandHandler;
 import fr.xephi.authme.datasource.DataSource;
@@ -76,7 +75,7 @@ public class AuthMeInitializationTest {
         Files.copy(TestHelper.getJarFile(TestHelper.PROJECT_ROOT + "config.test.yml"), settingsFile);
 
         // Mock / wire various Bukkit components
-        given(server.getLogger()).willReturn(mock(Logger.class));
+        given(server.getLogger()).willReturn(Logger.getGlobal());
         ReflectionTestUtils.setField(Bukkit.class, null, "server", server);
         given(server.getPluginManager()).willReturn(pluginManager);
 

--- a/src/test/java/fr/xephi/authme/AuthMeInitializationTest.java
+++ b/src/test/java/fr/xephi/authme/AuthMeInitializationTest.java
@@ -75,7 +75,7 @@ public class AuthMeInitializationTest {
         Files.copy(TestHelper.getJarFile(TestHelper.PROJECT_ROOT + "config.test.yml"), settingsFile);
 
         // Mock / wire various Bukkit components
-        given(server.getLogger()).willReturn(Logger.getGlobal());
+        given(server.getLogger()).willReturn(Logger.getAnonymousLogger());
         ReflectionTestUtils.setField(Bukkit.class, null, "server", server);
         given(server.getPluginManager()).willReturn(pluginManager);
 

--- a/src/test/java/fr/xephi/authme/command/executable/email/SetPasswordCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/email/SetPasswordCommandTest.java
@@ -1,5 +1,6 @@
 package fr.xephi.authme.command.executable.email;
 
+import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.security.PasswordSecurity;
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
+import java.util.logging.Logger;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -47,6 +49,8 @@ public class SetPasswordCommandTest {
 
     @Test
     public void shouldChangePassword() {
+        ConsoleLogger.setLogger(Logger.getAnonymousLogger());
+
         // given
         Player player = mock(Player.class);
         String name = "Jerry";

--- a/src/test/java/fr/xephi/authme/command/executable/email/SetPasswordCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/email/SetPasswordCommandTest.java
@@ -1,6 +1,6 @@
 package fr.xephi.authme.command.executable.email;
 
-import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.TestHelper;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.security.PasswordSecurity;
@@ -9,6 +9,7 @@ import fr.xephi.authme.service.CommonService;
 import fr.xephi.authme.service.PasswordRecoveryService;
 import fr.xephi.authme.service.ValidationService;
 import org.bukkit.entity.Player;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -16,7 +17,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
-import java.util.logging.Logger;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -47,10 +47,13 @@ public class SetPasswordCommandTest {
     @Mock
     private ValidationService validationService;
 
+    @BeforeClass
+    public static void setUpLogger() {
+        TestHelper.setupLogger();
+    }
+
     @Test
     public void shouldChangePassword() {
-        ConsoleLogger.setLogger(Logger.getAnonymousLogger());
-
         // given
         Player player = mock(Player.class);
         String name = "Jerry";

--- a/src/test/java/fr/xephi/authme/service/RecoveryCodeServiceTest.java
+++ b/src/test/java/fr/xephi/authme/service/RecoveryCodeServiceTest.java
@@ -125,7 +125,7 @@ public class RecoveryCodeServiceTest {
         return ReflectionTestUtils.getFieldValue(RecoveryCodeService.class, recoveryCodeService, "recoveryCodes");
     }
 
-    private ExpiringMap<String, String> getTriesCounter() {
+    private ExpiringMap<String, Integer> getTriesCounter() {
         return ReflectionTestUtils.getFieldValue(RecoveryCodeService.class, recoveryCodeService, "playerTries");
     }
 }


### PR DESCRIPTION
Java 9 removed the DatatypeConvert class and so I replaced it with the Base64 class which was introduced in Java 8. 

While working on that I discovered some issues with the Tests which were reproducible on [Travis](https://travis-ci.org/AuthMe/AuthMeReloaded/jobs/294205481). Suprisingly they occured only Java 9 which could be a bug in the Mockito implementation. 

1. AuthMeInitializationTest.initAuthMe NPE when accessing the mocked Logger [in PluginLogger of Bukkit](https://github.com/Bukkit/Bukkit/blob/master/src/main/java/org/bukkit/plugin/PluginLogger.java#L26) 

Fix:
Change to anonymous logger
https://github.com/AuthMe/AuthMeReloaded/blob/d9b53f08b129ab8b1e8292d5999d3b4705d93b6e/src/test/java/fr/xephi/authme/AuthMeInitializationTest.java#L78

2.  SetPasswordCommandTest.shouldChangePassword NPE when trying to log something using ConsoleLogger

Fix:
Manually set the logger using TestHelper. 

3. RecoveryCodeServiceTest.shouldRemoveCode ClassCastException Integer cannot be cast to String 

Fix:
Change the generics to `<String, Integer>` instead of <String, String>. This seams pretty reasonable, because TimedCounter has <K, Integer>.