### PR TITLE
Improve security of Console and Log files

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -433,8 +433,6 @@ Security:
         # AuthMe will automatically disable and the server won't be protected!
         stopServer: true
     console:
-        # Remove passwords from console?
-        removePassword: true
         # Copy AuthMe log output in a separate file as well?
         logConsole: true
     captcha:

--- a/samples/NewConfig.yml
+++ b/samples/NewConfig.yml
@@ -473,8 +473,6 @@ Security:
     console:
         # Remove spam console
         noConsoleSpam: false
-        # Replace passwords in the console when player type a command like /login
-        removePassword: true
     captcha:
         # Player need to put a captcha when he fails too lot the password
         useCaptcha: false

--- a/src/main/java/fr/xephi/authme/initialization/OnStartupTasks.java
+++ b/src/main/java/fr/xephi/authme/initialization/OnStartupTasks.java
@@ -63,9 +63,6 @@ public class OnStartupTasks {
      * @param logger   the plugin logger
      */
     public static void setupConsoleFilter(Settings settings, Logger logger) {
-        if (!settings.getProperty(SecuritySettings.REMOVE_PASSWORD_FROM_CONSOLE)) {
-            return;
-        }
         // Try to set the log4j filter
         try {
             Class.forName("org.apache.logging.log4j.core.filter.AbstractFilter");

--- a/src/main/java/fr/xephi/authme/initialization/OnStartupTasks.java
+++ b/src/main/java/fr/xephi/authme/initialization/OnStartupTasks.java
@@ -12,7 +12,6 @@ import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.DatabaseSettings;
 import fr.xephi.authme.settings.properties.EmailSettings;
 import fr.xephi.authme.settings.properties.PluginSettings;
-import fr.xephi.authme.settings.properties.SecuritySettings;
 import org.apache.logging.log4j.LogManager;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;

--- a/src/main/java/fr/xephi/authme/settings/properties/SecuritySettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/SecuritySettings.java
@@ -20,10 +20,6 @@ public final class SecuritySettings implements SettingsHolder {
     public static final Property<Boolean> STOP_SERVER_ON_PROBLEM =
         newProperty("Security.SQLProblem.stopServer", true);
 
-    @Comment("Remove passwords from console?")
-    public static final Property<Boolean> REMOVE_PASSWORD_FROM_CONSOLE =
-        newProperty("Security.console.removePassword", true);
-
     @Comment("Copy AuthMe log output in a separate file as well?")
     public static final Property<Boolean> USE_LOGGING =
         newProperty("Security.console.logConsole", true);

--- a/src/test/resources/fr/xephi/authme/config.test.yml
+++ b/src/test/resources/fr/xephi/authme/config.test.yml
@@ -275,8 +275,6 @@ Security:
     console:
         # Remove spam console
         noConsoleSpam: false
-        # Replace passwords in the console when player type a command like /login
-        removePassword: true
         # Copy AuthMe log output in a separate file as well?
         logConsole: true
     captcha:

--- a/src/test/resources/fr/xephi/authme/settings/config-old.yml
+++ b/src/test/resources/fr/xephi/authme/settings/config-old.yml
@@ -315,8 +315,6 @@ Security:
     console:
         # Remove spam console
         noConsoleSpam: true
-        # Replace passwords in the console when player type a command like /login
-        removePassword: true
     captcha:
         # Player need to put a captcha when he fails too lot the password
         useCaptcha: false

--- a/src/test/resources/fr/xephi/authme/settings/config-old.yml
+++ b/src/test/resources/fr/xephi/authme/settings/config-old.yml
@@ -315,6 +315,8 @@ Security:
     console:
         # Remove spam console
         noConsoleSpam: true
+        # Replace passwords in the console when player type a command like /login
+        removePassword: true
     captcha:
         # Player need to put a captcha when he fails too lot the password
         useCaptcha: false


### PR DESCRIPTION
This is a security plugin and given it's purpose, having a simple option to show in plain text every password while instead there's no PLAINTEXT store option in the database (not anymore, as last time we discussed about this option there was still many refactoring to do), is stupid and unsafe.

Many people use this option more for bad than for good, probably no one will ever complain about this providing a good use case.

Latest step in security would be a way to encrypt or hide commands to command loggers, but this may be impossible with Bukkit API.