### PR TITLE
Remove VIP status to OP by default

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -283,4 +283,4 @@ permissions:
   authme.vip:
     description: When the server is full and someone with this permission joins the
       server, someone will be kicked.
-    default: op
+    default: false


### PR DESCRIPTION
Closes #1040.

I think this is the best solution, better than implementing a case to not kick anyone when an OP player joins.
There's Essentials and other plugins for allowing more people than maximum slots.