### PR TITLE
#642 - Quick Command Protection

### DIFF
--- a/src/main/java/fr/xephi/authme/data/QuickCommandsProtectionManager.java
+++ b/src/main/java/fr/xephi/authme/data/QuickCommandsProtectionManager.java
@@ -26,14 +26,28 @@ public class QuickCommandsProtectionManager implements SettingsDependent, HasCle
         reload(settings);
     }
 
+    /**
+     * Save the player in the set
+     * @param name the player's name
+     */
     public void setLogin(String name) {
         latestLogin.add(name);
     }
 
+    /**
+     * Returns whether the given player has the permission and should be saved in the set
+     * @param player the player to check
+     * @return true if the player has the permission, false otherwise
+     */
     public boolean shouldSaveLogin(Player player) {
         return permissionsManager.hasPermission(player, PlayerPermission.QUICK_COMMANDS_PROTECTION);
     }
 
+    /**
+     * Returns whether the given player is able to perform the command
+     * @param name the name of the player to check
+     * @return true if the player is not in the set (so it's allowed to perform the command), false otherwise
+     */
     public boolean isAllowed(String name) {
         return !latestLogin.contains(name);
     }

--- a/src/main/java/fr/xephi/authme/data/QuickCommandsProtectionManager.java
+++ b/src/main/java/fr/xephi/authme/data/QuickCommandsProtectionManager.java
@@ -1,0 +1,51 @@
+package fr.xephi.authme.data;
+
+import fr.xephi.authme.initialization.HasCleanup;
+import fr.xephi.authme.initialization.SettingsDependent;
+import fr.xephi.authme.permission.PermissionsManager;
+import fr.xephi.authme.permission.PlayerPermission;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.ProtectionSettings;
+import fr.xephi.authme.util.expiring.ExpiringSet;
+import org.bukkit.entity.Player;
+
+import javax.inject.Inject;
+import java.util.concurrent.TimeUnit;
+
+public class QuickCommandsProtectionManager implements SettingsDependent, HasCleanup {
+
+    private PermissionsManager permissionsManager;
+
+    private final ExpiringSet<String> latestLogin;
+
+    @Inject
+    public QuickCommandsProtectionManager(Settings settings, PermissionsManager permissionsManager) {
+        this.permissionsManager = permissionsManager;
+        long countTimeout = settings.getProperty(ProtectionSettings.QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS);
+        latestLogin = new ExpiringSet<>(countTimeout, TimeUnit.MILLISECONDS);
+        reload(settings);
+    }
+
+    public void setLogin(String name) {
+        latestLogin.add(name);
+    }
+
+    public boolean shouldSaveLogin(Player player) {
+        return permissionsManager.hasPermission(player, PlayerPermission.QUICK_COMMANDS_PROTECTION);
+    }
+
+    public boolean isAllowed(String name) {
+        return !latestLogin.contains(name);
+    }
+
+    @Override
+    public void reload(Settings settings) {
+        long countTimeout = settings.getProperty(ProtectionSettings.QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS);
+        latestLogin.setExpiration(countTimeout, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void performCleanup() {
+        latestLogin.removeExpiredEntries();
+    }
+}

--- a/src/main/java/fr/xephi/authme/data/QuickCommandsProtectionManager.java
+++ b/src/main/java/fr/xephi/authme/data/QuickCommandsProtectionManager.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 
 public class QuickCommandsProtectionManager implements SettingsDependent, HasCleanup {
 
-    private PermissionsManager permissionsManager;
+    private final PermissionsManager permissionsManager;
 
     private final ExpiringSet<String> latestLogin;
 

--- a/src/main/java/fr/xephi/authme/listener/PlayerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/PlayerListener.java
@@ -105,7 +105,7 @@ public class PlayerListener implements Listener {
         final Player player = event.getPlayer();
         if (!quickCommandsProtectionManager.isAllowed(player.getName())) {
             event.setCancelled(true);
-            player.kickPlayer(m.retrieveSingle(MessageKey.QUICK_COMMAND_PROTECTION_KICK));
+            player.kickPlayer(m.retrieveSingle(player, MessageKey.QUICK_COMMAND_PROTECTION_KICK));
             return;
         }
         if (listenerService.shouldCancelEvent(player)) {

--- a/src/main/java/fr/xephi/authme/listener/PlayerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/PlayerListener.java
@@ -1,5 +1,6 @@
 package fr.xephi.authme.listener;
 
+import fr.xephi.authme.data.QuickCommandsProtectionManager;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.message.MessageKey;
@@ -86,6 +87,8 @@ public class PlayerListener implements Listener {
     @Inject
     private PermissionsManager permissionsManager;
     @Inject
+    private QuickCommandsProtectionManager quickCommandsProtectionManager;
+    @Inject
     private BungeeSender bungeeSender;
 
     private boolean isAsyncPlayerPreLoginEventCalled = false;
@@ -100,6 +103,11 @@ public class PlayerListener implements Listener {
             return;
         }
         final Player player = event.getPlayer();
+        if (!quickCommandsProtectionManager.isAllowed(player.getName())) {
+            event.setCancelled(true);
+            player.kickPlayer(m.retrieveSingle(MessageKey.QUICK_COMMAND_PROTECTION_KICK));
+            return;
+        }
         if (listenerService.shouldCancelEvent(player)) {
             event.setCancelled(true);
             m.send(player, MessageKey.DENIED_COMMAND);
@@ -207,6 +215,11 @@ public class PlayerListener implements Listener {
         if (!PlayerListener19Spigot.isPlayerSpawnLocationEventCalled()) {
             teleportationService.teleportOnJoin(player);
         }
+
+        if (quickCommandsProtectionManager.shouldSaveLogin(player)) {
+            quickCommandsProtectionManager.setLogin(player.getName());
+        }
+
         management.performJoin(player);
 
         teleportationService.teleportNewPlayerToFirstSpawn(player);

--- a/src/main/java/fr/xephi/authme/listener/PlayerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/PlayerListener.java
@@ -216,9 +216,7 @@ public class PlayerListener implements Listener {
             teleportationService.teleportOnJoin(player);
         }
 
-        if (quickCommandsProtectionManager.shouldSaveLogin(player)) {
-            quickCommandsProtectionManager.setLogin(player.getName());
-        }
+        quickCommandsProtectionManager.processJoin(player);
 
         management.performJoin(player);
 

--- a/src/main/java/fr/xephi/authme/message/MessageKey.java
+++ b/src/main/java/fr/xephi/authme/message/MessageKey.java
@@ -276,7 +276,7 @@ public enum MessageKey {
     VERIFICATION_CODE_EMAIL_NEEDED("verification.email_needed"),
 
     /** You used a command too fast! Please, join the server again and wait more before using any command. */
-    QUICK_COMMAND_PROTECTION_KICK("quick_command.kick"),
+    QUICK_COMMAND_PROTECTION_KICK("on_join_validation.quick_command"),
 
     /** second */
     SECOND("time.second"),

--- a/src/main/java/fr/xephi/authme/message/MessageKey.java
+++ b/src/main/java/fr/xephi/authme/message/MessageKey.java
@@ -275,6 +275,9 @@ public enum MessageKey {
     /** To verify your identity you need to link an email address with your account! */
     VERIFICATION_CODE_EMAIL_NEEDED("verification.email_needed"),
 
+    /** You used a command too fast! Please, join the server again and wait more before using any command. */
+    QUICK_COMMAND_PROTECTION_KICK("quick_command.kick"),
+
     /** second */
     SECOND("time.second"),
 

--- a/src/main/java/fr/xephi/authme/permission/PlayerPermission.java
+++ b/src/main/java/fr/xephi/authme/permission/PlayerPermission.java
@@ -68,7 +68,12 @@ public enum PlayerPermission implements PermissionNode {
     /**
      * Permission to use the email verification codes feature.
      */
-    VERIFICATION_CODE("authme.player.security.verificationcode");
+    VERIFICATION_CODE("authme.player.security.verificationcode"),
+
+    /**
+     * Permission to use the email verification codes feature.
+     */
+    QUICK_COMMANDS_PROTECTION("authme.player.protection.quickcommandsprotection");
 
     /**
      * The permission node.

--- a/src/main/java/fr/xephi/authme/permission/PlayerPermission.java
+++ b/src/main/java/fr/xephi/authme/permission/PlayerPermission.java
@@ -71,7 +71,7 @@ public enum PlayerPermission implements PermissionNode {
     VERIFICATION_CODE("authme.player.security.verificationcode"),
 
     /**
-     * Permission to use the email verification codes feature.
+     * Permission that enables on join quick commands checks for the player.
      */
     QUICK_COMMANDS_PROTECTION("authme.player.protection.quickcommandsprotection");
 

--- a/src/main/java/fr/xephi/authme/settings/properties/ProtectionSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/ProtectionSettings.java
@@ -55,9 +55,9 @@ public final class ProtectionSettings implements SettingsHolder {
     public static final Property<Integer> ANTIBOT_DELAY =
         newProperty("Protection.antiBotDelay", 60);
 
-    @Comment("Kicks the player that issued a command before the defined time after the login process")
+    @Comment("Kicks the player that issued a command before the defined time after the join process")
     public static final Property<Integer> QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS =
-        newProperty("Protection.quickCommands.denyCommandsBeforeSeconds", 1000);
+        newProperty("Protection.quickCommands.denyCommandsBeforeMilliseconds", 1000);
 
     private ProtectionSettings() {
     }

--- a/src/main/java/fr/xephi/authme/settings/properties/ProtectionSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/ProtectionSettings.java
@@ -55,6 +55,10 @@ public final class ProtectionSettings implements SettingsHolder {
     public static final Property<Integer> ANTIBOT_DELAY =
         newProperty("Protection.antiBotDelay", 60);
 
+    @Comment("Kicks the player that issued a command before the defined time after the login process")
+    public static final Property<Integer> QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS =
+        newProperty("Protection.quickCommands.denyCommandsBeforeSeconds", 1000);
+
     private ProtectionSettings() {
     }
 

--- a/src/main/resources/messages/messages_bg.yml
+++ b/src/main/resources/messages/messages_bg.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Твоята държава е забранена в този сървър!'
     not_owner_error: 'Ти не си собственика на този акаунт. Моля избери друго потребителско име!'
     invalid_name_case: 'Трябва да влезеш с %valid, а не с %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_br.yml
+++ b/src/main/resources/messages/messages_br.yml
@@ -82,6 +82,7 @@ on_join_validation:
     country_banned: '&4O seu país está banido neste servidor!'
     not_owner_error: 'Você não é o proprietário da conta. Por favor, escolha outro nome!'
     invalid_name_case: 'Você deve se juntar usando nome de usuário %valid, não %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_cz.yml
+++ b/src/main/resources/messages/messages_cz.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: 'Vaše země je na tomto serveru zakázána'
     not_owner_error: 'Nejsi majitelem tohoto účtu, prosím zvol si jiné jméno!'
     invalid_name_case: 'Měl by jsi použít jméno %valid, ne jméno %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_de.yml
+++ b/src/main/resources/messages/messages_de.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Dein Land ist gesperrt!'
     not_owner_error: 'Du bist nicht der Besitzer dieses Accounts. Bitte wähle einen anderen Namen!'
     invalid_name_case: 'Dein registrierter Benutzername ist &2%valid&f - nicht &4%invalid&f.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_en.yml
+++ b/src/main/resources/messages/messages_en.yml
@@ -78,6 +78,7 @@ on_join_validation:
   same_nick_online: '&4The same username is already playing on the server!'
   invalid_name_case: 'You should join using username %valid, not %invalid.'
   same_ip_online: 'A player with the same IP is already in game!'
+  quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_eo.yml
+++ b/src/main/resources/messages/messages_eo.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Via lando estas malpermesitaj de tiu servilo!'
     not_owner_error: 'Vi ne estas la posedanto de tiu konto. Bonvolu elekti alian nomon!'
     invalid_name_case: 'Vi devus aliĝi uzante uzantnomon %valid, ne %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_es.yml
+++ b/src/main/resources/messages/messages_es.yml
@@ -80,6 +80,7 @@ on_join_validation:
     country_banned: '¡Tu país ha sido baneado de este servidor!'
     not_owner_error: 'No eres el propietario de esta cuenta. ¡Por favor, elije otro nombre!'
     invalid_name_case: 'Solo puedes unirte mediante el nombre de usuario %valid, no %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_et.yml
+++ b/src/main/resources/messages/messages_et.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Su riik on siin serveris keelatud!'
     not_owner_error: 'Sa ei ole selle konto omanik. Vali teine nimi.'
     invalid_name_case: 'Logi sisse kasutajanimega %valid, mitte kasutajanimega %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_eu.yml
+++ b/src/main/resources/messages/messages_eu.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '[AuthMe] Zure herrialdea blokeatuta dago zerbitzari honetan'
     # TODO not_owner_error: 'You are not the owner of this account. Please choose another name!'
     # TODO invalid_name_case: 'You should join using username %valid, not %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_fi.yml
+++ b/src/main/resources/messages/messages_fi.yml
@@ -79,6 +79,7 @@ on_join_validation:
     # TODO country_banned: '&4Your country is banned from this server!'
     # TODO not_owner_error: 'You are not the owner of this account. Please choose another name!'
     # TODO invalid_name_case: 'You should join using username %valid, not %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_fr.yml
+++ b/src/main/resources/messages/messages_fr.yml
@@ -82,6 +82,7 @@ on_join_validation:
     country_banned: 'Votre pays est banni de ce serveur.'
     not_owner_error: 'Vous n''êtes pas le propriétaire de ce compte. Veuillez utiliser un autre pseudo !'
     invalid_name_case: 'Veuillez vous connecter avec "%valid" et non pas avec "%invalid".'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_gl.yml
+++ b/src/main/resources/messages/messages_gl.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: 'O teu país está bloqueado neste servidor'
     # TODO not_owner_error: 'You are not the owner of this account. Please choose another name!'
     # TODO invalid_name_case: 'You should join using username %valid, not %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_hu.yml
+++ b/src/main/resources/messages/messages_hu.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Az országod a tiltólistán van ezen a szerveren!'
     not_owner_error: 'Ez nem a te felhasználód. Kérlek, válassz másik nevet!'
     invalid_name_case: '%valid a felhasználó neved nem? Akkor ne %invalid névvel próbálj feljönni.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_id.yml
+++ b/src/main/resources/messages/messages_id.yml
@@ -79,6 +79,7 @@ on_join_validation:
     # TODO country_banned: '&4Your country is banned from this server!'
     # TODO not_owner_error: 'You are not the owner of this account. Please choose another name!'
     # TODO invalid_name_case: 'You should join using username %valid, not %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_it.yml
+++ b/src/main/resources/messages/messages_it.yml
@@ -5,6 +5,8 @@
 # %displayname% - Sostituisce il nickname (e i colori) dell'utente che riceve il messaggio.
 
 # Registrazione
+
+# Registration
 registration:
     disabled: '&cLa registrazione tramite i comandi di gioco è disabilitata.'
     name_taken: '&cHai già eseguito la registrazione, non puoi eseguirla nuovamente.'
@@ -14,7 +16,7 @@ registration:
     success: '&2Registrato correttamente!'
     kicked_admin_registered: 'Un amministratore ti ha appena registrato, per favore rientra nel server'
 
-# Errori della password durante la registrazione
+# Password errors on registration
 password:
     match_error: '&cLe password non corrispondono!'
     name_in_password: '&cNon puoi usare il tuo nome utente come password, per favore scegline un''altra...'
@@ -22,7 +24,7 @@ password:
     forbidden_characters: '&4La tua password contiene caratteri non consentiti. I caratteri consentiti sono: %valid_chars'
     wrong_length: '&cLa password che hai inserito è troppo corta o troppo lunga, per favore scegline un''altra...'
 
-# Autenticazione
+# Login
 login:
     command_usage: '&cUtilizzo: /login <password>'
     wrong_password: '&cPassword non corretta!'
@@ -30,7 +32,7 @@ login:
     login_request: '&cPer favore, esegui l''autenticazione con il comando: /login <password>'
     timeout_error: '&4Tempo scaduto per eseguire l''autenticazione, sei stato espulso dal server, per favore riprova!'
 
-# Errori
+# Errors
 error:
     denied_command: '&cPer poter usare questo comando devi essere autenticato!'
     denied_chat: '&cPer poter scrivere messaggi in chat devi essere autenticato!'
@@ -49,12 +51,12 @@ antibot:
     auto_enabled: '&4Il servizio di AntiBot è stato automaticamente abilitato a seguito delle numerose connessioni!'
     auto_disabled: '&2Il servizio di AntiBot è stato automaticamente disabilitato dopo %m minuti!'
 
-# Rimozione dal Database
+# Unregister
 unregister:
     success: '&2Sei stato correttamente rimosso dal database!'
     command_usage: '&cUtilizzo: /unregister <password>'
 
-# Altri messaggi
+# Other messages
 misc:
     account_not_activated: '&cIl tuo account non è stato ancora verificato, controlla fra le tue email per scoprire come attivarlo!'
     password_changed: '&2Password cambiata correttamente!'
@@ -65,12 +67,12 @@ misc:
     accounts_owned_self: 'Possiedi %count account:'
     accounts_owned_other: 'Il giocatore %name possiede %count account:'
 
-# Messaggi della sessione
+# Session messages
 session:
     valid_session: '&2Autenticato automaticamente attraverso la precedente sessione!'
     invalid_session: '&cIl tuo indirizzo IP è cambiato e la tua sessione è stata terminata!'
 
-# Messaggi di errore durante l'accesso
+# Error messages when joining
 on_join_validation:
     same_ip_online: 'Un giocatore con il tuo stesso IP è già connesso sul server!'
     same_nick_online: '&4Un giocatore con il tuo stesso nome utente è già connesso sul server!'
@@ -80,6 +82,7 @@ on_join_validation:
     country_banned: '&4Il tuo paese è bandito da questo server!'
     not_owner_error: 'Non sei il proprietario di questo account. Per favore scegli un altro nome!'
     invalid_name_case: 'Dovresti entrare con questo nome utente "%valid", al posto di "%invalid".'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:
@@ -100,7 +103,7 @@ email:
     change_password_expired: 'Non puoi più cambiare la tua password con questo comando.'
     email_cooldown_error: '&cUna email di recupero ti è già stata inviata recentemente. Devi attendere %time prima di poterne richiedere una nuova.'
 
-# Recupero password via Email
+# Password recovery by email
 recovery:
     forgot_password_hint: '&3Hai dimenticato la tua password? Puoi recuperarla eseguendo il comando: /email recovery <email>'
     command_usage: '&cUtilizzo: /email recovery <email>'
@@ -120,7 +123,7 @@ captcha:
     captcha_for_registration: 'Per poterti registrare devi prima risolvere un captcha, per favore scrivi: /captcha %captcha_code'
     register_captcha_valid: '&2Il captcha inserito è valido! Ora puoi eseguire la registrazione con: /register <password> <confermaPassword>'
 
-# Codice di verifica
+# Verification code
 verification:
     code_required: '&3Questo comando va a modificare dati sensibili e richiede una verifica tramite email! Controlla la tua posta in arrivo e segui le istruzioni nell''email.'
     command_usage: '&cUtilizzo: /verification <codice>'
@@ -130,7 +133,7 @@ verification:
     code_expired: '&3Il tuo codice è scaduto! Esegui nuovamente un comando che modifica dati sensibili per ricevere uno nuovo codice!'
     email_needed: '&3Per verificare la tua identità devi collegare un indirizzo email al tuo account!'
 
-# Unità di tempo
+# Time units
 time:
     second: 'secondo'
     seconds: 'secondi'

--- a/src/main/resources/messages/messages_ko.yml
+++ b/src/main/resources/messages/messages_ko.yml
@@ -81,6 +81,7 @@ on_join_validation:
     country_banned: '&4당신의 국가에서는 이 서버를 이용하실 수 없습니다!'
     not_owner_error: '이 계정의 소유자가 아닙니다. 다른 닉네임을 선택하세요!'
     invalid_name_case: '%invalid가 아닌, %valid 사용하여 접속해야 합니다.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_lt.yml
+++ b/src/main/resources/messages/messages_lt.yml
@@ -79,6 +79,7 @@ on_join_validation:
     # TODO country_banned: '&4Your country is banned from this server!'
     # TODO not_owner_error: 'You are not the owner of this account. Please choose another name!'
     # TODO invalid_name_case: 'You should join using username %valid, not %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_nl.yml
+++ b/src/main/resources/messages/messages_nl.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Jouw land is gebanned op deze server!'
     not_owner_error: 'Jij bent niet de eigenaar van dit account. Kies alsjeblieft een andere naam!'
     invalid_name_case: 'Verbind je alsjeblieft als %valid, niet als %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_pl.yml
+++ b/src/main/resources/messages/messages_pl.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Ten kraj jest zbanowany na tym serwerze'
     not_owner_error: '&cNie jesteś właścicielem tego konta, wybierz inny nick!'
     invalid_name_case: '&cPowinieneś dołączyć do serwera z nicku %valid, a nie %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_pt.yml
+++ b/src/main/resources/messages/messages_pt.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: 'O seu país está banido deste servidor'
     not_owner_error: 'Não é o proprietário da conta. Por favor, escolha outro nome!'
     invalid_name_case: 'Deve se juntar usando nome de usuário %valid, não %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_ro.yml
+++ b/src/main/resources/messages/messages_ro.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Tara ta este interzisa pe acest server!'
     not_owner_error: 'Tu nu esti detinatorul acestui cont. Te rugam alege alt nume!'
     invalid_name_case: 'Ar trebui sa intri cu numele %valid, nu %invalid'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_ru.yml
+++ b/src/main/resources/messages/messages_ru.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Вход с IP-адресов вашей страны запрещён на этом сервере.'
     not_owner_error: 'Вы не являетесь владельцем данной уч. записи. Выберите себе другое имя!'
     invalid_name_case: 'Неверное имя! Зайдите под именем %valid, а не %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_sk.yml
+++ b/src/main/resources/messages/messages_sk.yml
@@ -85,6 +85,7 @@ on_join_validation:
     country_banned: '&4Tvoja krajina je zabanovaná na tomto serveri!'
     not_owner_error: 'Niesi majiteľ tohto účtu. Prosím zvoľ si iné meno!'
     invalid_name_case: 'Mal by si sa pripojiť s nickom %valid, nie %invalid -pozor na veľké a malé písmená.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_tr.yml
+++ b/src/main/resources/messages/messages_tr.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Senin bolgen sunucudan yasaklandi!'
     not_owner_error: 'Bu hesabin sahibi degilsin. Lutfen farkli bir isim sec!'
     invalid_name_case: 'Oyuna %valid isminde katilmalisin. %invalid ismini kullanarak katilamazsin.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_uk.yml
+++ b/src/main/resources/messages/messages_uk.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Your country is banned from this server!'
     not_owner_error: 'Цей акаунт вам не належить! Будь ласка, оберіть інакший нікнейм!'
     invalid_name_case: 'Регістр у вашому нікнеймі відрізняється від регістру при реєстрації.%nl%Поточний регістр: &c%invalid&f.  Валідний регістр: &a%valid&f.%nl%Будь ласка, перезайдіть з валідним регістром!'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_vn.yml
+++ b/src/main/resources/messages/messages_vn.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4Quốc gia của bạn bị cấm tham gia máy chủ này!'
     not_owner_error: 'Bạn không phải là chủ sở hữu tài khoản này, hãy chọn tên khác!'
     invalid_name_case: 'Bạn nên vào máy chủ với tên đăng nhập là %valid, không phải là %invalid.'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_zhcn.yml
+++ b/src/main/resources/messages/messages_zhcn.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '这个服务器禁止该国家登陆'
     not_owner_error: '&8[&6玩家系统&8] &4警告！ &c你并不是此帐户持有人，请立即登出。 '
     invalid_name_case: '&8[&6玩家系统&8] &c你应该使用「%valid」而并非「%invalid」登入游戏。 '
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_zhhk.yml
+++ b/src/main/resources/messages/messages_zhhk.yml
@@ -82,6 +82,7 @@ on_join_validation:
     country_banned: '&8[&6用戶系統&8] &4本伺服器已停止對你的國家提供遊戲服務。'
     not_owner_error: '&8[&6用戶系統&8] &4警告！&c你並不是此帳戶持有人，請立即登出。'
     invalid_name_case: '&8[&6用戶系統&8] &4警告！&c你應該使用「%valid」而並非「%invalid」登入遊戲。'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_zhmc.yml
+++ b/src/main/resources/messages/messages_zhmc.yml
@@ -79,6 +79,7 @@ on_join_validation:
     country_banned: '&4您的國家/地區已被禁止使用此伺服器!'
     not_owner_error: '您不是此帳戶的所有者。 請選擇其他名稱!'
     invalid_name_case: '您應該使用用戶名 %valid 而不是 %invalid 來加入。'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/messages/messages_zhtw.yml
+++ b/src/main/resources/messages/messages_zhtw.yml
@@ -81,6 +81,7 @@ on_join_validation:
     country_banned: '&b【AuthMe】&6您所在的地區無法進入此伺服器'
     not_owner_error: '&b【AuthMe】&4警告！&c您並不是此帳戶持有人，請立即登出。'
     invalid_name_case: '&b【AuthMe】&4警告！&c您應該使用「%valid」而並非「%invalid」登入遊戲。'
+    # TODO quick_command: 'You used a command too fast! Please, join the server again and wait more before using any command.'
 
 # Email
 email:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -230,6 +230,7 @@ permissions:
       authme.player.email.see: true
       authme.player.login: true
       authme.player.logout: true
+      authme.player.protection.quickcommandsprotection: true
       authme.player.register: true
       authme.player.security.verificationcode: true
       authme.player.seeownaccounts: true
@@ -267,6 +268,9 @@ permissions:
     default: true
   authme.player.logout:
     description: Command permission to logout.
+    default: true
+  authme.player.protection.quickcommandsprotection:
+    description: Permission that enables on join quick commands checks for the player.
     default: true
   authme.player.register:
     description: Command permission to register.

--- a/src/test/java/fr/xephi/authme/data/QuickCommandsProtectionManagerTest.java
+++ b/src/test/java/fr/xephi/authme/data/QuickCommandsProtectionManagerTest.java
@@ -1,8 +1,10 @@
 package fr.xephi.authme.data;
 
 import fr.xephi.authme.permission.PermissionsManager;
+import fr.xephi.authme.permission.PlayerPermission;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.ProtectionSettings;
+import org.bukkit.entity.Player;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -11,6 +13,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test for {@link QuickCommandsProtectionManager}.
@@ -27,16 +30,19 @@ public class QuickCommandsProtectionManagerTest {
     @Test
     public void shouldAllowCommand() {
         // given
-        String name1 = "TestName1";
-        String name2 = "TestName2";
+        String playername = "PlayerName";
+        Player player = mockPlayerWithName(playername);
         given(settings.getProperty(ProtectionSettings.QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS)).willReturn(0);
+        given(permissionsManager.hasPermission(player, PlayerPermission.QUICK_COMMANDS_PROTECTION)).willReturn(true);
+
+        String name = "TestName";
 
         QuickCommandsProtectionManager qcpm = createQuickCommandsProtectioneManager();
-        qcpm.setLogin(name2);
+        qcpm.processJoin(player);
 
         // when
-        boolean test1 = qcpm.isAllowed(name1);
-        boolean test2 = qcpm.isAllowed(name2);
+        boolean test1 = qcpm.isAllowed(name);
+        boolean test2 = qcpm.isAllowed(playername);
 
         // then
         assertThat(test1, equalTo(true));
@@ -47,10 +53,12 @@ public class QuickCommandsProtectionManagerTest {
     public void shouldDenyCommand() {
         // given
         String name = "TestName1";
+        Player player = mockPlayerWithName(name);
         given(settings.getProperty(ProtectionSettings.QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS)).willReturn(5000);
 
         QuickCommandsProtectionManager qcpm = createQuickCommandsProtectioneManager();
-        qcpm.setLogin(name);
+        given(permissionsManager.hasPermission(player, PlayerPermission.QUICK_COMMANDS_PROTECTION)).willReturn(true);
+        qcpm.processJoin(player);
 
         // when
         boolean test = qcpm.isAllowed(name);
@@ -62,4 +70,11 @@ public class QuickCommandsProtectionManagerTest {
     private QuickCommandsProtectionManager createQuickCommandsProtectioneManager() {
         return new QuickCommandsProtectionManager(settings, permissionsManager);
     }
+
+    private static Player mockPlayerWithName(String name) {
+        Player player = mock(Player.class);
+        given(player.getName()).willReturn(name);
+        return player;
+    }
+
 }

--- a/src/test/java/fr/xephi/authme/data/QuickCommandsProtectionManagerTest.java
+++ b/src/test/java/fr/xephi/authme/data/QuickCommandsProtectionManagerTest.java
@@ -1,0 +1,65 @@
+package fr.xephi.authme.data;
+
+import fr.xephi.authme.permission.PermissionsManager;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.ProtectionSettings;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Test for {@link QuickCommandsProtectionManager}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class QuickCommandsProtectionManagerTest {
+
+    @Mock
+    private Settings settings;
+
+    @Mock
+    private PermissionsManager permissionsManager;
+
+    @Test
+    public void shouldAllowCommand() {
+        // given
+        String name1 = "TestName1";
+        String name2 = "TestName2";
+        given(settings.getProperty(ProtectionSettings.QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS)).willReturn(0);
+
+        QuickCommandsProtectionManager qcpm = createQuickCommandsProtectioneManager();
+        qcpm.setLogin(name2);
+
+        // when
+        boolean test1 = qcpm.isAllowed(name1);
+        boolean test2 = qcpm.isAllowed(name2);
+
+        // then
+        assertThat(test1, equalTo(true));
+        assertThat(test2, equalTo(true));
+    }
+
+    @Test
+    public void shouldDenyCommand() {
+        // given
+        String name = "TestName1";
+        given(settings.getProperty(ProtectionSettings.QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS)).willReturn(5000);
+
+        QuickCommandsProtectionManager qcpm = createQuickCommandsProtectioneManager();
+        qcpm.setLogin(name);
+
+        // when
+        boolean test = qcpm.isAllowed(name);
+
+        // then
+        assertThat(test, equalTo(false));
+    }
+
+    private QuickCommandsProtectionManager createQuickCommandsProtectioneManager() {
+        return new QuickCommandsProtectionManager(settings, permissionsManager);
+    }
+}

--- a/src/test/java/fr/xephi/authme/listener/PlayerListenerTest.java
+++ b/src/test/java/fr/xephi/authme/listener/PlayerListenerTest.java
@@ -254,7 +254,7 @@ public class PlayerListenerTest {
     }
 
     @Test
-    public void shouldCancelCommandFastCommandEvent() {
+    public void shouldCancelFastCommandEvent() {
         // given
         given(settings.getProperty(HooksSettings.USE_ESSENTIALS_MOTD)).willReturn(false);
         given(settings.getProperty(RestrictionSettings.ALLOW_COMMANDS)).willReturn(Arrays.asList("/spawn", "/help"));

--- a/src/test/java/fr/xephi/authme/listener/PlayerListenerTest.java
+++ b/src/test/java/fr/xephi/authme/listener/PlayerListenerTest.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.listener;
 
 import fr.xephi.authme.TestHelper;
+import fr.xephi.authme.data.QuickCommandsProtectionManager;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.message.MessageKey;
@@ -110,6 +111,8 @@ public class PlayerListenerTest {
     private ValidationService validationService;
     @Mock
     private JoinMessageService joinMessageService;
+    @Mock
+    private QuickCommandsProtectionManager quickCommandsProtectionManager;
 
     /**
      * #831: If a player is kicked because of "logged in from another location", the kick
@@ -219,6 +222,7 @@ public class PlayerListenerTest {
         // PlayerCommandPreprocessEvent#getPlayer is final, so create a spy instead of a mock
         PlayerCommandPreprocessEvent event = spy(new PlayerCommandPreprocessEvent(player, "/hub"));
         given(listenerService.shouldCancelEvent(player)).willReturn(false);
+        given(quickCommandsProtectionManager.isAllowed(player.getName())).willReturn(true);
 
         // when
         listener.onPlayerCommandPreprocess(event);
@@ -238,6 +242,7 @@ public class PlayerListenerTest {
         Player player = playerWithMockedServer();
         PlayerCommandPreprocessEvent event = spy(new PlayerCommandPreprocessEvent(player, "/hub"));
         given(listenerService.shouldCancelEvent(player)).willReturn(true);
+        given(quickCommandsProtectionManager.isAllowed(player.getName())).willReturn(true);
 
         // when
         listener.onPlayerCommandPreprocess(event);
@@ -246,6 +251,23 @@ public class PlayerListenerTest {
         verify(listenerService).shouldCancelEvent(player);
         verify(event).setCancelled(true);
         verify(messages).send(player, MessageKey.DENIED_COMMAND);
+    }
+
+    @Test
+    public void shouldCancelCommandFastCommandEvent() {
+        // given
+        given(settings.getProperty(HooksSettings.USE_ESSENTIALS_MOTD)).willReturn(false);
+        given(settings.getProperty(RestrictionSettings.ALLOW_COMMANDS)).willReturn(Arrays.asList("/spawn", "/help"));
+        Player player = playerWithMockedServer();
+        PlayerCommandPreprocessEvent event = spy(new PlayerCommandPreprocessEvent(player, "/hub"));
+        given(quickCommandsProtectionManager.isAllowed(player.getName())).willReturn(false);
+
+        // when
+        listener.onPlayerCommandPreprocess(event);
+
+        // then
+        verify(event).setCancelled(true);
+        verify(player).kickPlayer(messages.retrieveSingle(player, MessageKey.QUICK_COMMAND_PROTECTION_KICK));
     }
 
     @Test


### PR DESCRIPTION
The point of this Protection is simply detect "suspicious" players in order to kick 'em before the anti bot will be triggered.

I've implemented a manager class that:

- Has an `ExpiringSet` used to store the name for the defined time `QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS`
  - The name is stored only if the player has the permission `PlayerPermission.QUICK_COMMANDS_PROTECTION`
- Checks if the player is in the `Set`
  - Used to know if the player should be kicked

And yeah, that's it...

## Question:

Should the setting `QUICK_COMMANDS_DENIED_BEFORE_MILLISECONDS` be under the `ProtectionSettings` section (the one used by the anti bot stuffs)  or somewhere else?


## TODO:
- [x] Add kick message
- [x] Check and add players to the set on login
- [x] Check and kick players in set on command execution