### PR TITLE
Migrate to GEO IP 2 (Related #1471)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can also create your own translation file and, if you want, you can share it
 <ul>
   <li><strong>E-Mail Recovery System !!!</strong></li>
   <li>Username spoofing protection.</li>
-  <li>Countries Whitelist/Blacklist! <a href="http://dev.maxmind.com/geoip/legacy/codes/iso3166/">(country codes)</a></li>
+  <li>Countries Whitelist/Blacklist! <a href="https://dev.maxmind.com/geoip/legacy/codes/iso3166/">(country codes)</a></li>
   <li><strong>Built-in AntiBot System!</strong></li>
   <li><strong>ForceLogin Feature: Admins can login with all account via console command!</strong></li>
   <li><strong>Avoid the "Logged in from another location" message!</strong></li>

--- a/README.md
+++ b/README.md
@@ -126,4 +126,4 @@ Credits for the old version of the plugin: d4rkwarriors, fabe1337, Whoami2 and p
 Thanks also to: AS1LV3RN1NJA, Hoeze and eprimex
 
 ##### GeoIP License:
-This product uses data from the GeoLite API created by MaxMind, available at http://www.maxmind.com
+This product uses data from the GeoLite API created by MaxMind, available at https://www.maxmind.com

--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
         <dependency>
             <groupId>com.maxmind.db</groupId>
             <artifactId>maxmind-db-gson</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -403,13 +403,15 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Maxmind GeoIp API -->
+        <!-- MaxMind GEO IP with our modifications to use GSON in replacement of the big Jackson dependency -->
+        <!-- GSON is already included and therefore it reduces the file size in comparison to the original version -->
         <dependency>
             <groupId>com.maxmind.db</groupId>
             <artifactId>maxmind-db-gson</artifactId>
             <version>2.0.2-SNAPSHOT</version>
         </dependency>
 
+        <!-- Library for tar archives -->
         <dependency>
             <groupId>javatar</groupId>
             <artifactId>javatar</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -267,8 +267,12 @@
                             <shadedPattern>fr.xephi.authme.libs.slf4j.slf4j</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>com.maxmind.geoip</pattern>
-                            <shadedPattern>fr.xephi.authme.libs.maxmind.geoip</shadedPattern>
+                            <pattern>com.maxmind.db</pattern>
+                            <shadedPattern>fr.xephi.authme.libs.maxmind</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.ice.tar</pattern>
+                            <shadedPattern>fr.xephi.authme.libs.tar</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>net.ricecode.similarity</pattern>
@@ -401,11 +405,15 @@
 
         <!-- Maxmind GeoIp API -->
         <dependency>
-            <groupId>com.maxmind.geoip</groupId>
-            <artifactId>geoip-api</artifactId>
-            <version>1.3.1</version>
-            <scope>compile</scope>
-            <optional>true</optional>
+            <groupId>com.maxmind.db</groupId>
+            <artifactId>maxmind-db-gson</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javatar</groupId>
+            <artifactId>javatar</artifactId>
+            <version>2.5</version>
         </dependency>
 
         <!-- Java Email Library -->
@@ -526,7 +534,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib-API</artifactId>
-            <version>4.4.0-SNAPSHOT</version>
+            <version>4.3.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/fr/xephi/authme/AuthMe.java
+++ b/src/main/java/fr/xephi/authme/AuthMe.java
@@ -2,7 +2,9 @@ package fr.xephi.authme;
 
 import ch.jalu.injector.Injector;
 import ch.jalu.injector.InjectorBuilder;
+
 import com.google.common.annotations.VisibleForTesting;
+
 import fr.xephi.authme.api.NewAPI;
 import fr.xephi.authme.command.CommandHandler;
 import fr.xephi.authme.datasource.DataSource;
@@ -33,6 +35,9 @@ import fr.xephi.authme.settings.properties.SecuritySettings;
 import fr.xephi.authme.task.CleanupTask;
 import fr.xephi.authme.task.purge.PurgeService;
 import fr.xephi.authme.util.ExceptionUtils;
+
+import java.io.File;
+
 import org.apache.commons.lang.SystemUtils;
 import org.bukkit.Server;
 import org.bukkit.command.Command;
@@ -42,8 +47,6 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
 import org.bukkit.scheduler.BukkitScheduler;
-
-import java.io.File;
 
 import static fr.xephi.authme.service.BukkitService.TICKS_PER_MINUTE;
 import static fr.xephi.authme.util.Utils.isClassLoaded;

--- a/src/main/java/fr/xephi/authme/service/GeoIpService.java
+++ b/src/main/java/fr/xephi/authme/service/GeoIpService.java
@@ -187,6 +187,9 @@ public class GeoIpService {
                     if (filename.endsWith(DATABASE_EXT)) {
                         // found the database file
                         Files.copy(tarIn, outputFile, StandardCopyOption.REPLACE_EXISTING);
+
+                        // update the last modification date to be same as in the archive
+                        Files.setLastModifiedTime(outputFile, FileTime.from(entry.getModTime().toInstant()));
                         return true;
                     }
                 }

--- a/src/main/java/fr/xephi/authme/service/GeoIpService.java
+++ b/src/main/java/fr/xephi/authme/service/GeoIpService.java
@@ -52,7 +52,7 @@ public class GeoIpService {
     private static final String ARCHIVE_URL = "https://geolite.maxmind.com/download/geoip/database/" + ARCHIVE_FILE;
     private static final String CHECKSUM_URL = ARCHIVE_URL + ".md5";
 
-    private static final int UPDATE_INTERVAL = 30;
+    private static final int UPDATE_INTERVAL_DAYS = 30;
 
     private final Path dataFile;
     private final BukkitService bukkitService;
@@ -96,7 +96,7 @@ public class GeoIpService {
         if (Files.exists(dataFile)) {
             try {
                 FileTime lastModifiedTime = Files.getLastModifiedTime(dataFile);
-                if (Duration.between(lastModifiedTime.toInstant(), Instant.now()).toDays() <= UPDATE_INTERVAL) {
+                if (Duration.between(lastModifiedTime.toInstant(), Instant.now()).toDays() <= UPDATE_INTERVAL_DAYS) {
                     databaseReader = new Reader(dataFile.toFile(), FileMode.MEMORY, new CHMCache());
                     ConsoleLogger.info(LICENSE);
 

--- a/src/main/java/fr/xephi/authme/service/GeoIpService.java
+++ b/src/main/java/fr/xephi/authme/service/GeoIpService.java
@@ -16,6 +16,7 @@ import com.maxmind.db.model.CountryResponse;
 
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.initialization.DataFolder;
+import fr.xephi.authme.util.FileUtils;
 import fr.xephi.authme.util.InternetProtocolUtils;
 
 import java.io.BufferedInputStream;
@@ -126,9 +127,10 @@ public class GeoIpService {
         bukkitService.runTaskAsynchronously(() -> {
             ConsoleLogger.info("Downloading GEO IP database, because the old database is outdated or doesn't exist");
 
+            Path tempFile = null;
             try {
                 // download database to temporarily location
-                Path tempFile = Files.createTempFile(ARCHIVE_FILE, null);
+                tempFile = Files.createTempFile(ARCHIVE_FILE, null);
                 try (OutputStream out = Files.newOutputStream(tempFile)) {
                     Resources.copy(new URL(ARCHIVE_URL), out);
                 }
@@ -151,6 +153,11 @@ public class GeoIpService {
                 downloading = false;
             } catch (IOException ioEx) {
                 ConsoleLogger.logException("Could not download GeoLiteAPI database", ioEx);
+            } finally {
+                // clean up
+                if (tempFile != null) {
+                    FileUtils.delete(tempFile.toFile());
+                }
             }
         });
     }

--- a/src/main/java/fr/xephi/authme/service/GeoIpService.java
+++ b/src/main/java/fr/xephi/authme/service/GeoIpService.java
@@ -243,7 +243,8 @@ public class GeoIpService {
             //Reader.getCountry() can be null for unknown addresses
             return Optional.ofNullable(databaseReader.getCountry(address)).map(CountryResponse::getCountry);
         } catch (UnknownHostException e) {
-            //ignore invalid ip addresses
+            // Ignore invalid ip addresses
+            // Legacy GEO IP Database returned a unknown country object with Country-Code: '--' and Country-Name: 'N/A'
         } catch (IOException ioEx) {
             ConsoleLogger.logException("Cannot lookup country for " + ip + " at GEO IP database", ioEx);
         }

--- a/src/main/java/fr/xephi/authme/service/GeoIpService.java
+++ b/src/main/java/fr/xephi/authme/service/GeoIpService.java
@@ -151,6 +151,7 @@ public class GeoIpService {
     /**
      * Verify if the expected checksum is equal to the checksum of the given file.
      *
+     * @param function the checksum function like MD5, SHA256 used to generate the checksum from the file
      * @param file the file we want to calculate the checksum from
      * @param expectedChecksum the expected checksum
      * @return true if equal, false otherwise

--- a/src/main/java/fr/xephi/authme/service/GeoIpService.java
+++ b/src/main/java/fr/xephi/authme/service/GeoIpService.java
@@ -7,6 +7,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.Resources;
 import com.ice.tar.TarEntry;
 import com.ice.tar.TarInputStream;
+import com.maxmind.db.GeoIp2Provider;
 import com.maxmind.db.Reader;
 import com.maxmind.db.Reader.FileMode;
 import com.maxmind.db.cache.CHMCache;
@@ -56,7 +57,7 @@ public class GeoIpService {
     private final Path dataFile;
     private final BukkitService bukkitService;
 
-    private Reader databaseReader;
+    private GeoIp2Provider databaseReader;
     private volatile boolean downloading;
 
     @Inject
@@ -69,7 +70,7 @@ public class GeoIpService {
     }
 
     @VisibleForTesting
-    GeoIpService(@DataFolder File dataFolder, BukkitService bukkitService, Reader reader) {
+    GeoIpService(@DataFolder File dataFolder, BukkitService bukkitService, GeoIp2Provider reader) {
         this.bukkitService = bukkitService;
         this.dataFile = dataFolder.toPath().resolve(DATABASE_FILE);
 

--- a/src/main/java/fr/xephi/authme/service/GeoIpService.java
+++ b/src/main/java/fr/xephi/authme/service/GeoIpService.java
@@ -142,6 +142,7 @@ public class GeoIpService {
                 // tar extract database and copy to target destination
                 if (!extractDatabase(tempFile, dataFile)) {
                     ConsoleLogger.warning("Cannot find database inside downloaded GEO IP file at " + tempFile);
+                    return;
                 }
 
                 ConsoleLogger.info("Successfully downloaded new GEO IP database to " + dataFile);

--- a/src/main/java/fr/xephi/authme/settings/properties/ProtectionSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/ProtectionSettings.java
@@ -22,7 +22,7 @@ public final class ProtectionSettings implements SettingsHolder {
 
     @Comment({
         "Countries allowed to join the server and register. For country codes, see",
-        "http://dev.maxmind.com/geoip/legacy/codes/iso3166/",
+        "https://dev.maxmind.com/geoip/legacy/codes/iso3166/",
         "PLEASE USE QUOTES!"})
     public static final Property<List<String>> COUNTRIES_WHITELIST =
         newListProperty("Protection.countries", "US", "GB");

--- a/src/test/java/fr/xephi/authme/service/GeoIpServiceTest.java
+++ b/src/test/java/fr/xephi/authme/service/GeoIpServiceTest.java
@@ -1,8 +1,13 @@
 package fr.xephi.authme.service;
 
-import com.maxmind.db.Reader;
+import com.maxmind.db.GeoIp2Provider;
 import com.maxmind.db.model.Country;
 import com.maxmind.db.model.CountryResponse;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,14 +16,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.InetAddress;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -32,9 +34,8 @@ public class GeoIpServiceTest {
     private GeoIpService geoIpService;
     private File dataFolder;
 
-    //todo: find solution for mocking final class
     @Mock
-    private Reader lookupService;
+    private GeoIp2Provider lookupService;
 
     @Mock
     private BukkitService bukkitService;


### PR DESCRIPTION
As mentioned in ticket #1471 , MaxMind will stop updating the GEO IP database in April.

Copied from the commit message:

* Update MaxMind database dependency and add javatar to extract the database from the tar archive
(now only a small difference in jar file size)
* Verify downloaded archive using MD5 (There are no other checksums available)
* Migrated to Java NIO instead of old java file I/O (Feedback?)
* Internal Optional usage for nullable values (Feedback?)
* Changed the DatabaseReader at MaxMind to use an interface. This allows us to mock the final class.
* File modification date represents the last time the database was updated at MaxMind.

Minor:
* Change all links of MaxMind to https
* Schedule a Bukkit async task instead of creating a thread manually
* Validate IP input string
* Extract validation into single method
* Close all resources safely using try-resources

Once approved, the commits should be squashed into one and that commit should include the issue number.