### PR TITLE
#1417 Add permission node to allow chat before login

### DIFF
--- a/docs/permission_nodes.md
+++ b/docs/permission_nodes.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED FILE! Do not edit this directly -->
-<!-- File auto-generated on Sun Apr 22 11:00:13 CEST 2018. See docs/permissions/permission_nodes.tpl.md -->
+<!-- File auto-generated on Mon May 21 08:43:08 CEST 2018. See docs/permissions/permission_nodes.tpl.md -->
 
 ## AuthMe Permission Nodes
 The following are the permission nodes that are currently supported by the latest dev builds.
@@ -30,6 +30,7 @@ The following are the permission nodes that are currently supported by the lates
 - **authme.admin.switchantibot** – Administrator command to toggle the AntiBot protection status.
 - **authme.admin.unregister** – Administrator command to unregister an existing user.
 - **authme.admin.updatemessages** – Permission to use the update messages command.
+- **authme.allowchatbeforelogin** – Permission to send chat messages before being logged in.
 - **authme.allowmultipleaccounts** – Permission to be able to register multiple accounts.
 - **authme.bypassantibot** – Permission node to bypass AntiBot protection.
 - **authme.bypasscountrycheck** – Permission to bypass the GeoIp country code check.
@@ -69,4 +70,4 @@ The following are the permission nodes that are currently supported by the lates
 
 ---
 
-This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Sun Apr 22 11:00:13 CEST 2018
+This page was automatically generated on the [AuthMe/AuthMeReloaded repository](https://github.com/AuthMe/AuthMeReloaded/tree/master/docs/) on Mon May 21 08:43:08 CEST 2018

--- a/src/main/java/fr/xephi/authme/permission/PlayerStatePermission.java
+++ b/src/main/java/fr/xephi/authme/permission/PlayerStatePermission.java
@@ -34,7 +34,12 @@ public enum PlayerStatePermission implements PermissionNode {
     /**
      * Permission to bypass the GeoIp country code check.
      */
-    BYPASS_COUNTRY_CHECK("authme.bypasscountrycheck", DefaultPermission.NOT_ALLOWED);
+    BYPASS_COUNTRY_CHECK("authme.bypasscountrycheck", DefaultPermission.NOT_ALLOWED),
+
+    /**
+     * Permission to send chat messages before being logged in.
+     */
+    ALLOW_CHAT_BEFORE_LOGIN("authme.allowchatbeforelogin", DefaultPermission.NOT_ALLOWED);
 
     /**
      * The permission node.
@@ -42,7 +47,7 @@ public enum PlayerStatePermission implements PermissionNode {
     private String node;
 
     /**
-     * The default permission level
+     * The default permission level.
      */
     private DefaultPermission defaultPermission;
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -161,6 +161,9 @@ permissions:
   authme.admin.updatemessages:
     description: Permission to use the update messages command.
     default: op
+  authme.allowchatbeforelogin:
+    description: Permission to send chat messages before being logged in.
+    default: false
   authme.allowmultipleaccounts:
     description: Permission to be able to register multiple accounts.
     default: op


### PR DESCRIPTION
I went with a positive permission node (having this permission _allows_ you to chat) because it makes more sense IMHO. 

I think having permission nodes for such features is the way to go for the future. A lot of our configurations could eventually be replaced with permissions and it would offer better control to the server admins. The only downside is that the config is outside of our reach so we can't really perform any migrations on our permission nodes or anything (whereas we fully control our config.yml).