### PR TITLE
Create permission to bypass bungeecord server teleportation

### DIFF
--- a/docs/permission_nodes.md
+++ b/docs/permission_nodes.md
@@ -32,6 +32,7 @@ The following are the permission nodes that are currently supported by the lates
 - **authme.admin.updatemessages** – Permission to use the update messages command.
 - **authme.allowchatbeforelogin** – Permission to send chat messages before being logged in.
 - **authme.allowmultipleaccounts** – Permission to be able to register multiple accounts.
+- **authme.bypassbungeesend** – Permission node to bypass BungeeCord server teleportation.
 - **authme.bypassantibot** – Permission node to bypass AntiBot protection.
 - **authme.bypasscountrycheck** – Permission to bypass the GeoIp country code check.
 - **authme.bypassforcesurvival** – Permission for users to bypass force-survival mode.

--- a/src/main/java/fr/xephi/authme/permission/PlayerStatePermission.java
+++ b/src/main/java/fr/xephi/authme/permission/PlayerStatePermission.java
@@ -12,6 +12,11 @@ public enum PlayerStatePermission implements PermissionNode {
     BYPASS_ANTIBOT("authme.bypassantibot", DefaultPermission.OP_ONLY),
 
     /**
+     * Permission node to bypass BungeeCord server teleportation.
+     */
+    BYPASS_BUNGEE_SEND("authme.bypassbungeesend", DefaultPermission.OP_ONLY),
+
+    /**
      * Permission for users to bypass force-survival mode.
      */
     BYPASS_FORCE_SURVIVAL("authme.bypassforcesurvival", DefaultPermission.OP_ONLY),

--- a/src/main/java/fr/xephi/authme/process/login/ProcessSyncPlayerLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/ProcessSyncPlayerLogin.java
@@ -6,6 +6,8 @@ import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.LoginEvent;
 import fr.xephi.authme.events.RestoreInventoryEvent;
+import fr.xephi.authme.permission.PermissionsManager;
+import fr.xephi.authme.permission.PlayerStatePermission;
 import fr.xephi.authme.process.SynchronousProcess;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.service.CommonService;
@@ -51,6 +53,9 @@ public class ProcessSyncPlayerLogin implements SynchronousProcess {
 
     @Inject
     private JoinMessageService joinMessageService;
+
+    @Inject
+    private PermissionsManager permissionsManager;
 
     ProcessSyncPlayerLogin() {
     }
@@ -106,7 +111,9 @@ public class ProcessSyncPlayerLogin implements SynchronousProcess {
         }
         commandManager.runCommandsOnLogin(player, authsWithSameIp);
 
-        // Send Bungee stuff. The service will check if it is enabled or not.
-        bungeeSender.connectPlayerOnLogin(player);
+        if (!permissionsManager.hasPermission(player, PlayerStatePermission.BYPASS_BUNGEE_SEND)) {
+            // Send Bungee stuff. The service will check if it is enabled or not.
+            bungeeSender.connectPlayerOnLogin(player);
+        }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -168,6 +168,9 @@ permissions:
   authme.allowmultipleaccounts:
     description: Permission to be able to register multiple accounts.
     default: op
+  authme.bypassbungeesend:
+    description: Permission node to bypass BungeeCord server teleportation.
+    default: op
   authme.bypassantibot:
     description: Permission node to bypass AntiBot protection.
     default: op


### PR DESCRIPTION
Based on issue #1623 I created a permission to allow administrators to bypass the bungeecord server teleportation after login.

The permission is **authme.bypassbungeesend**