### PR TITLE
Do not create a welcome.txt file when boolean is false

### DIFF
--- a/src/main/java/fr/xephi/authme/settings/WelcomeMessageConfiguration.java
+++ b/src/main/java/fr/xephi/authme/settings/WelcomeMessageConfiguration.java
@@ -74,6 +74,8 @@ public class WelcomeMessageConfiguration implements Reloadable {
     @PostConstruct
     @Override
     public void reload() {
+        if (!service.getProperty(RegistrationSettings.USE_WELCOME_MESSAGE)) return;
+
         List<String> welcomeMessage = new ArrayList<>();
         for (String line : readWelcomeFile()) {
             welcomeMessage.add(ChatColor.translateAlternateColorCodes('&', line));
@@ -111,6 +113,8 @@ public class WelcomeMessageConfiguration implements Reloadable {
      * @return the lines of the welcome message file
      */
     private List<String> readWelcomeFile() {
+        if (!service.getProperty(RegistrationSettings.USE_WELCOME_MESSAGE)) return;
+
         File welcomeFile = new File(pluginFolder, "welcome.txt");
         if (copyFileFromResource(welcomeFile, "welcome.txt")) {
             try {


### PR DESCRIPTION
It would be nice if you would accept it as if the boolean is false and creates a file, but this is not good and unnecessary. Therefore, this should not create a file.