### PR TITLE
Update the copyright year to 2018 just in time.

### DIFF
--- a/src/main/java/fr/xephi/authme/command/executable/authme/VersionCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/VersionCommand.java
@@ -36,7 +36,7 @@ public class VersionCommand implements ExecutableCommand {
         sender.sendMessage(ChatColor.GOLD + "License: " + ChatColor.WHITE + "GNU GPL v3.0"
             + ChatColor.GRAY + ChatColor.ITALIC + " (See LICENSE file)");
         sender.sendMessage(ChatColor.GOLD + "Copyright: " + ChatColor.WHITE
-            + "Copyright (c) AuthMe-Team 2017. All rights reserved.");
+            + "Copyright (c) AuthMe-Team 2018. All rights reserved.");
     }
 
     /**


### PR DESCRIPTION
We can't just skip from 2017 to 2019.