### PR TITLE
Added NoCheatPlus kick for flying fix

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -570,6 +570,10 @@ Converter:
             user: ''
             # LoginSecurity MySQL: password for database user
             password: ''
+# NoCheatPlus settings
+NoCheatPlusKickFix:
+	# Set this to true if players get kicked for flying when they try to login
+	fixKickForFlying: false
 
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -572,8 +572,8 @@ Converter:
             password: ''
 # NoCheatPlus settings
 NoCheatPlusKickFix:
-	# Set this to true if players get kicked for flying when they try to login
-	fixKickForFlying: false
+    # Set this to true if players get kicked for flying when they try to login
+    fixKickForFlying: false
 
 ```
 

--- a/samples/NewConfig.yml
+++ b/samples/NewConfig.yml
@@ -492,8 +492,8 @@ Converter:
         # CrazyLogin database file
         fileName: accounts.db
 NoCheatPlus:
-	# Set this to true if players get kicked for flying when they try to login
-	fixKickForFlying: false
+    # Set this to true if players get kicked for flying when they try to login
+    fixKickForFlying: false
 Email:
     # Email SMTP server host
     mailSMTP: smtp.gmail.com

--- a/samples/NewConfig.yml
+++ b/samples/NewConfig.yml
@@ -491,6 +491,9 @@ Converter:
     CrazyLogin:
         # CrazyLogin database file
         fileName: accounts.db
+NoCheatPlus:
+	# Set this to true if players get kicked for flying when they try to login
+	fixKickForFlying: false
 Email:
     # Email SMTP server host
     mailSMTP: smtp.gmail.com

--- a/samples/NewPlugin.yml
+++ b/samples/NewPlugin.yml
@@ -13,6 +13,7 @@ softdepend:
     - Essentials
     - EssentialsSpawn
     - ProtocolLib
+    - NoCheatPlus
 commands:
     authme:
         description: AuthMe admin commands

--- a/src/main/java/fr/xephi/authme/AuthMe.java
+++ b/src/main/java/fr/xephi/authme/AuthMe.java
@@ -14,6 +14,7 @@ import fr.xephi.authme.initialization.SettingsProvider;
 import fr.xephi.authme.initialization.TaskCloser;
 import fr.xephi.authme.listener.BlockListener;
 import fr.xephi.authme.listener.EntityListener;
+import fr.xephi.authme.listener.NoCheatPlusListener;
 import fr.xephi.authme.listener.PlayerListener;
 import fr.xephi.authme.listener.PlayerListener111;
 import fr.xephi.authme.listener.PlayerListener19;
@@ -27,6 +28,7 @@ import fr.xephi.authme.service.bungeecord.BungeeReceiver;
 import fr.xephi.authme.service.yaml.YamlParseException;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.SettingsWarner;
+import fr.xephi.authme.settings.properties.NoCheatPlusFixSettings;
 import fr.xephi.authme.settings.properties.SecuritySettings;
 import fr.xephi.authme.task.CleanupTask;
 import fr.xephi.authme.task.purge.PurgeService;
@@ -131,6 +133,11 @@ public class AuthMe extends JavaPlugin {
                 + "causing exploit issues, please use AuthMeBungee instead! Aborting!");
             stopOrUnload();
             return;
+        }
+        
+        // Check if NoCheatPlus is enabled and the fly bug needs to be fixed
+        if (!getServer().getPluginManager().isPluginEnabled("NoCheatPlus") && NoCheatPlusFixSettings.ENABLE_FIX.isValidValue(true)) {
+        	 ConsoleLogger.warning("You enabled the NoCheatPlus fly kick fix, but NoCheatPlus is not enabled.");
         }
 
         // Initialize the plugin
@@ -286,6 +293,11 @@ public class AuthMe extends JavaPlugin {
         // Register listener for 1.11 events if available
         if (isClassLoaded("org.bukkit.event.entity.EntityAirChangeEvent")) {
             pluginManager.registerEvents(injector.getSingleton(PlayerListener111.class), this);
+        }
+        
+        // NoCheatPlus kick for fly fix
+        if (getServer().getPluginManager().isPluginEnabled("NoCheatPlus") && NoCheatPlusFixSettings.ENABLE_FIX.isValidValue(true)) {
+        	pluginManager.registerEvents(injector.getSingleton(NoCheatPlusListener.class), this);
         }
     }
 

--- a/src/main/java/fr/xephi/authme/AuthMe.java
+++ b/src/main/java/fr/xephi/authme/AuthMe.java
@@ -136,8 +136,9 @@ public class AuthMe extends JavaPlugin {
         }
         
         // Check if NoCheatPlus is enabled and the fly bug needs to be fixed
-        if (!getServer().getPluginManager().isPluginEnabled("NoCheatPlus") && NoCheatPlusFixSettings.ENABLE_FIX.isValidValue(true)) {
-        	 ConsoleLogger.warning("You enabled the NoCheatPlus fly kick fix, but NoCheatPlus is not enabled.");
+        if (!getServer().getPluginManager().isPluginEnabled("NoCheatPlus")
+                && NoCheatPlusFixSettings.ENABLE_FIX.isValidValue(true)) {
+            ConsoleLogger.warning("You enabled the NoCheatPlus fly kick fix, but NoCheatPlus is not enabled.");
         }
 
         // Initialize the plugin
@@ -296,8 +297,9 @@ public class AuthMe extends JavaPlugin {
         }
         
         // NoCheatPlus kick for fly fix
-        if (getServer().getPluginManager().isPluginEnabled("NoCheatPlus") && NoCheatPlusFixSettings.ENABLE_FIX.isValidValue(true)) {
-        	pluginManager.registerEvents(injector.getSingleton(NoCheatPlusListener.class), this);
+        if (getServer().getPluginManager().isPluginEnabled("NoCheatPlus")
+                && NoCheatPlusFixSettings.ENABLE_FIX.isValidValue(true)) {
+            pluginManager.registerEvents(injector.getSingleton(NoCheatPlusListener.class), this);
         }
     }
 

--- a/src/main/java/fr/xephi/authme/listener/NoCheatPlusListener.java
+++ b/src/main/java/fr/xephi/authme/listener/NoCheatPlusListener.java
@@ -15,32 +15,37 @@ import fr.xephi.authme.events.LoginEvent;
 
 public class NoCheatPlusListener implements Listener {
 
-	private HashMap<Player, List<CheckType>> exempted;
+    private HashMap<Player, List<CheckType>> exempted;
 
-	public NoCheatPlusListener() {
-		exempted = new HashMap<Player, List<CheckType>>();
-	}
+    public NoCheatPlusListener() {
+        exempted = new HashMap<Player, List<CheckType>>();
+    }
 
-	@EventHandler(ignoreCancelled = true)
-	public void onLogin(LoginEvent event) {
-		Player player = event.getPlayer();
-		for (CheckType type : exempted.get(player))
-			if (NCPExemptionManager.isExempted(player, type))
-				NCPExemptionManager.unexempt(player, type);
-	}
+    @EventHandler(ignoreCancelled = true)
+    public void onLogin(LoginEvent event) {
+        Player player = event.getPlayer();
+        for (CheckType type : exempted.get(player)) {
+            if (NCPExemptionManager.isExempted(player, type)) {
+                NCPExemptionManager.unexempt(player, type);
+            }
+        }
+    }
 
-	@EventHandler(ignoreCancelled = true)
-	public void onJoin(PlayerJoinEvent event) {
-		if (NCPExemptionManager.isExempted(event.getPlayer(), CheckType.ALL))
-			return;
+    @EventHandler(ignoreCancelled = true)
+    public void onJoin(PlayerJoinEvent event) {
+        if (NCPExemptionManager.isExempted(event.getPlayer(), CheckType.ALL)) {
+            return;
+        }
 
-		List<CheckType> exemptions = new ArrayList<CheckType>();
+        List<CheckType> exemptions = new ArrayList<CheckType>();
 
-		for (CheckType type : CheckType.values())
-			if (NCPExemptionManager.isExempted(event.getPlayer(), type))
-				exemptions.add(type);
+        for (CheckType type : CheckType.values()) {
+            if (NCPExemptionManager.isExempted(event.getPlayer(), type)) {
+                exemptions.add(type);
+            }
+        }
 
-		NCPExemptionManager.exemptPermanently(event.getPlayer());
-		exempted.put(event.getPlayer(), exemptions);
-	}
+        NCPExemptionManager.exemptPermanently(event.getPlayer());
+        exempted.put(event.getPlayer(), exemptions);
+    }
 }

--- a/src/main/java/fr/xephi/authme/listener/NoCheatPlusListener.java
+++ b/src/main/java/fr/xephi/authme/listener/NoCheatPlusListener.java
@@ -1,0 +1,46 @@
+package fr.xephi.authme.listener;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.hooks.NCPExemptionManager;
+import fr.xephi.authme.events.LoginEvent;
+
+public class NoCheatPlusListener implements Listener {
+
+	private HashMap<Player, List<CheckType>> exempted;
+
+	public NoCheatPlusListener() {
+		exempted = new HashMap<Player, List<CheckType>>();
+	}
+
+	@EventHandler(ignoreCancelled = true)
+	public void onLogin(LoginEvent event) {
+		Player player = event.getPlayer();
+		for (CheckType type : exempted.get(player))
+			if (NCPExemptionManager.isExempted(player, type))
+				NCPExemptionManager.unexempt(player, type);
+	}
+
+	@EventHandler(ignoreCancelled = true)
+	public void onJoin(PlayerJoinEvent event) {
+		if (NCPExemptionManager.isExempted(event.getPlayer(), CheckType.ALL))
+			return;
+
+		List<CheckType> exemptions = new ArrayList<CheckType>();
+
+		for (CheckType type : CheckType.values())
+			if (NCPExemptionManager.isExempted(event.getPlayer(), type))
+				exemptions.add(type);
+
+		NCPExemptionManager.exemptPermanently(event.getPlayer());
+		exempted.put(event.getPlayer(), exemptions);
+	}
+}

--- a/src/main/java/fr/xephi/authme/settings/properties/NoCheatPlusFixSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/NoCheatPlusFixSettings.java
@@ -8,7 +8,9 @@ import ch.jalu.configme.properties.Property;
 
 public class NoCheatPlusFixSettings implements SettingsHolder {
 
-	@Comment("Set this to true if players get kicked for flying when they try to login")
-	public static final Property<Boolean> ENABLE_FIX = newProperty("NoCheatPlus.fixKickForFlying", false);
+    @Comment("Set this to true if players get kicked for flying when they try to login")
+    public static final Property<Boolean> ENABLE_FIX = newProperty("NoCheatPlus.fixKickForFlying", false);
 
+    private NoCheatPlusFixSettings() {
+    }
 }

--- a/src/main/java/fr/xephi/authme/settings/properties/NoCheatPlusFixSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/NoCheatPlusFixSettings.java
@@ -1,0 +1,14 @@
+package fr.xephi.authme.settings.properties;
+
+import static ch.jalu.configme.properties.PropertyInitializer.newProperty;
+
+import ch.jalu.configme.Comment;
+import ch.jalu.configme.SettingsHolder;
+import ch.jalu.configme.properties.Property;
+
+public class NoCheatPlusFixSettings implements SettingsHolder {
+
+	@Comment("Set this to true if players get kicked for flying when they try to login")
+	public static final Property<Boolean> ENABLE_FIX = newProperty("NoCheatPlus.fixKickForFlying", false);
+
+}


### PR DESCRIPTION
When someone logs into a server with authmereloaded and is in a position where they are essentially floating, Authme places them back to login. Servers with NoCheatPlus will have the issue that those players are kicked from the server for survivalfly.