### PR TITLE
#1874 Introduce individual ConsoleLogger instance per class

### DIFF
--- a/src/main/java/fr/xephi/authme/ConsoleLogger.java
+++ b/src/main/java/fr/xephi/authme/ConsoleLogger.java
@@ -1,15 +1,19 @@
 package fr.xephi.authme;
 
 import com.google.common.base.Throwables;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.output.LogLevel;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.PluginSettings;
 import fr.xephi.authme.settings.properties.SecuritySettings;
 import fr.xephi.authme.util.ExceptionUtils;
 
+import java.io.Closeable;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -20,62 +24,71 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
- * The plugin's static logger.
+ * AuthMe logger.
  */
 public final class ConsoleLogger {
 
     private static final String NEW_LINE = System.getProperty("line.separator");
     private static final DateFormat DATE_FORMAT = new SimpleDateFormat("[MM-dd HH:mm:ss]");
-    private static Logger logger;
-    private static LogLevel logLevel = LogLevel.INFO;
-    private static boolean useLogging = false;
-    private static File logFile;
-    private static FileWriter fileWriter;
 
-    private ConsoleLogger() {
+    // Outside references
+    private static File logFile;
+    private static Logger logger;
+
+    // Shared state
+    private static OutputStreamWriter fileWriter;
+
+    // Individual state
+    private final String name;
+    private LogLevel logLevel = LogLevel.INFO;
+
+    /**
+     * Constructor.
+     *
+     * @param name the name of this logger (the fully qualified class name using it)
+     */
+    public ConsoleLogger(String name) {
+        this.name = name;
     }
 
     // --------
     // Configurations
     // --------
 
-    /**
-     * Set the logger to use.
-     *
-     * @param logger The logger
-     */
-    public static void setLogger(Logger logger) {
+    public static void initialize(Logger logger, File logFile) {
         ConsoleLogger.logger = logger;
-    }
-
-    /**
-     * Set the file to log to if enabled.
-     *
-     * @param logFile The log file
-     */
-    public static void setLogFile(File logFile) {
         ConsoleLogger.logFile = logFile;
     }
 
     /**
-     * Load the required settings.
+     * Sets logging settings which are shared by all logger instances.
      *
-     * @param settings The settings instance
+     * @param settings the settings to read from
      */
-    public static void setLoggingOptions(Settings settings) {
-        ConsoleLogger.logLevel = settings.getProperty(PluginSettings.LOG_LEVEL);
-        ConsoleLogger.useLogging = settings.getProperty(SecuritySettings.USE_LOGGING);
+    public static void initializeSharedSettings(Settings settings) {
+        boolean useLogging = settings.getProperty(SecuritySettings.USE_LOGGING);
         if (useLogging) {
-            if (fileWriter == null) {
-                try {
-                    fileWriter = new FileWriter(logFile, true);
-                } catch (IOException e) {
-                    ConsoleLogger.logException("Failed to create the log file:", e);
-                }
-            }
+            initializeFileWriter();
         } else {
-            close();
+            closeFileWriter();
         }
+    }
+
+    /**
+     * Sets logging settings which are individual to all loggers.
+     *
+     * @param settings the settings to read from
+     */
+    public void initializeSettings(Settings settings) {
+        this.logLevel = settings.getProperty(PluginSettings.LOG_LEVEL);
+    }
+
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
+
+    public String getName() {
+        return name;
     }
 
 
@@ -88,7 +101,7 @@ public final class ConsoleLogger {
      *
      * @param message The message to log
      */
-    public static void warning(String message) {
+    public void warning(String message) {
         logger.warning(message);
         writeLog("[WARN] " + message);
     }
@@ -100,7 +113,7 @@ public final class ConsoleLogger {
      * @param message The message to accompany the exception
      * @param th      The Throwable to log
      */
-    public static void logException(String message, Throwable th) {
+    public void logException(String message, Throwable th) {
         warning(message + " " + ExceptionUtils.formatException(th));
         writeLog(Throwables.getStackTraceAsString(th));
     }
@@ -110,7 +123,7 @@ public final class ConsoleLogger {
      *
      * @param message The message to log
      */
-    public static void info(String message) {
+    public void info(String message) {
         logger.info(message);
         writeLog("[INFO] " + message);
     }
@@ -123,7 +136,7 @@ public final class ConsoleLogger {
      *
      * @param message The message to log
      */
-    public static void fine(String message) {
+    public void fine(String message) {
         if (logLevel.includes(LogLevel.FINE)) {
             logger.info(message);
             writeLog("[FINE] " + message);
@@ -142,7 +155,7 @@ public final class ConsoleLogger {
      *
      * @param message The message to log
      */
-    public static void debug(String message) {
+    public void debug(String message) {
         if (logLevel.includes(LogLevel.DEBUG)) {
             String debugMessage = "[DEBUG] " + message;
             logger.info(debugMessage);
@@ -155,7 +168,7 @@ public final class ConsoleLogger {
      *
      * @param msgSupplier the message supplier
      */
-    public static void debug(Supplier<String> msgSupplier) {
+    public void debug(Supplier<String> msgSupplier) {
         if (logLevel.includes(LogLevel.DEBUG)) {
             String debugMessage = "[DEBUG] " + msgSupplier.get();
             logger.info(debugMessage);
@@ -169,7 +182,7 @@ public final class ConsoleLogger {
      * @param message the message
      * @param param1 parameter to replace in the message
      */
-    public static void debug(String message, Object param1) {
+    public void debug(String message, Object param1) {
         if (logLevel.includes(LogLevel.DEBUG)) {
             String debugMessage = "[DEBUG] " + message;
             logger.log(Level.INFO, debugMessage, param1);
@@ -185,7 +198,7 @@ public final class ConsoleLogger {
      * @param param2 second param to replace in message
      */
     // Avoids array creation if DEBUG level is disabled
-    public static void debug(String message, Object param1, Object param2) {
+    public void debug(String message, Object param1, Object param2) {
         if (logLevel.includes(LogLevel.DEBUG)) {
             debug(message, new Object[]{param1, param2});
         }
@@ -197,7 +210,7 @@ public final class ConsoleLogger {
      * @param message the message
      * @param params the params to replace in the message
      */
-    public static void debug(String message, Object... params) {
+    public void debug(String message, Object... params) {
         if (logLevel.includes(LogLevel.DEBUG)) {
             String debugMessage = "[DEBUG] " + message;
             logger.log(Level.INFO, debugMessage, params);
@@ -206,21 +219,21 @@ public final class ConsoleLogger {
         }
     }
 
-
     // --------
     // Helpers
     // --------
 
     /**
-     * Close all file handles.
+     * Closes the file writer.
      */
-    public static void close() {
+    public static void closeFileWriter() {
         if (fileWriter != null) {
             try {
                 fileWriter.flush();
-                fileWriter.close();
-                fileWriter = null;
             } catch (IOException ignored) {
+            } finally {
+                closeSilently(fileWriter);
+                fileWriter = null;
             }
         }
     }
@@ -231,7 +244,7 @@ public final class ConsoleLogger {
      * @param message The message to write to the log
      */
     private static void writeLog(String message) {
-        if (useLogging) {
+        if (fileWriter != null) {
             String dateTime;
             synchronized (DATE_FORMAT) {
                 dateTime = DATE_FORMAT.format(new Date());
@@ -243,6 +256,33 @@ public final class ConsoleLogger {
                 fileWriter.write(NEW_LINE);
                 fileWriter.flush();
             } catch (IOException ignored) {
+            }
+        }
+    }
+
+    private static void closeSilently(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    /**
+     * Populates the {@link #fileWriter} field if it is null, handling any exceptions that might
+     * arise during its creation.
+     */
+    private static void initializeFileWriter() {
+        if (fileWriter == null) {
+            FileOutputStream fos = null;
+            try {
+                fos = new FileOutputStream(logFile, true);
+                fileWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+            } catch (Exception e) {
+                closeSilently(fos);
+                ConsoleLoggerFactory.get(ConsoleLogger.class)
+                    .logException("Failed to create the log file:", e);
             }
         }
     }

--- a/src/main/java/fr/xephi/authme/command/executable/authme/ConverterCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/ConverterCommand.java
@@ -14,6 +14,7 @@ import fr.xephi.authme.datasource.converter.RoyalAuthConverter;
 import fr.xephi.authme.datasource.converter.SqliteToSql;
 import fr.xephi.authme.datasource.converter.VAuthConverter;
 import fr.xephi.authme.datasource.converter.XAuthConverter;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.service.CommonService;
@@ -30,6 +31,8 @@ public class ConverterCommand implements ExecutableCommand {
 
     @VisibleForTesting
     static final Map<String, Class<? extends Converter>> CONVERTERS = getConverters();
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(ConverterCommand.class);
 
     @Inject
     private CommonService commonService;
@@ -59,7 +62,7 @@ public class ConverterCommand implements ExecutableCommand {
                     converter.execute(sender);
                 } catch (Exception e) {
                     commonService.send(sender, MessageKey.ERROR);
-                    ConsoleLogger.logException("Error during conversion:", e);
+                    logger.logException("Error during conversion:", e);
                 }
             }
         });

--- a/src/main/java/fr/xephi/authme/command/executable/authme/RegisterAdminCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/RegisterAdminCommand.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.command.ExecutableCommand;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.security.PasswordSecurity;
 import fr.xephi.authme.security.crypts.HashedPassword;
@@ -21,6 +22,8 @@ import java.util.List;
  * Admin command to register a user.
  */
 public class RegisterAdminCommand implements ExecutableCommand {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(RegisterAdminCommand.class);
 
     @Inject
     private PasswordSecurity passwordSecurity;
@@ -70,7 +73,7 @@ public class RegisterAdminCommand implements ExecutableCommand {
             }
 
             commonService.send(sender, MessageKey.REGISTER_SUCCESS);
-            ConsoleLogger.info(sender.getName() + " registered " + playerName);
+            logger.info(sender.getName() + " registered " + playerName);
             final Player player = bukkitService.getPlayerExact(playerName);
             if (player != null) {
                 bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(() ->

--- a/src/main/java/fr/xephi/authme/command/executable/authme/ReloadCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/ReloadCommand.java
@@ -7,6 +7,7 @@ import fr.xephi.authme.command.ExecutableCommand;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.Reloadable;
 import fr.xephi.authme.initialization.SettingsDependent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.service.CommonService;
 import fr.xephi.authme.settings.Settings;
@@ -22,6 +23,8 @@ import java.util.List;
  * The reload command.
  */
 public class ReloadCommand implements ExecutableCommand {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(ReloadCommand.class);
 
     @Inject
     private AuthMe plugin;
@@ -48,7 +51,7 @@ public class ReloadCommand implements ExecutableCommand {
     public void executeCommand(CommandSender sender, List<String> arguments) {
         try {
             settings.reload();
-            ConsoleLogger.setLoggingOptions(settings);
+            ConsoleLoggerFactory.reloadSettings(settings);
             settingsWarner.logWarningsForMisconfigurations();
 
             // We do not change database type for consistency issues, but we'll output a note in the logs
@@ -59,7 +62,7 @@ public class ReloadCommand implements ExecutableCommand {
             commonService.send(sender, MessageKey.CONFIG_RELOAD_SUCCESS);
         } catch (Exception e) {
             sender.sendMessage("Error occurred during reload of AuthMe: aborting");
-            ConsoleLogger.logException("Aborting! Encountered exception during reload of AuthMe:", e);
+            logger.logException("Aborting! Encountered exception during reload of AuthMe:", e);
             plugin.stopOrUnload();
         }
     }

--- a/src/main/java/fr/xephi/authme/command/executable/authme/TotpDisableAdminCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/TotpDisableAdminCommand.java
@@ -6,6 +6,7 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.BukkitService;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -18,6 +19,8 @@ import java.util.List;
  * Command to disable two-factor authentication for a user.
  */
 public class TotpDisableAdminCommand implements ExecutableCommand {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(TotpDisableAdminCommand.class);
 
     @Inject
     private DataSource dataSource;
@@ -45,7 +48,7 @@ public class TotpDisableAdminCommand implements ExecutableCommand {
     private void removeTotpKey(CommandSender sender, String player) {
         if (dataSource.removeTotpKey(player)) {
             sender.sendMessage("Disabled two-factor authentication successfully for '" + player + "'");
-            ConsoleLogger.info(sender.getName() + " disable two-factor authentication for '" + player + "'");
+            logger.info(sender.getName() + " disable two-factor authentication for '" + player + "'");
 
             Player onlinePlayer = bukkitService.getPlayerExact(player);
             if (onlinePlayer != null) {

--- a/src/main/java/fr/xephi/authme/command/executable/authme/UpdateHelpMessagesCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/UpdateHelpMessagesCommand.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.command.executable.authme;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.command.ExecutableCommand;
 import fr.xephi.authme.command.help.HelpMessagesService;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.HelpTranslationGenerator;
 import org.bukkit.command.CommandSender;
 
@@ -17,6 +18,8 @@ import java.util.List;
  */
 public class UpdateHelpMessagesCommand implements ExecutableCommand {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(UpdateHelpMessagesCommand.class);
+
     @Inject
     private HelpTranslationGenerator helpTranslationGenerator;
     @Inject
@@ -30,7 +33,7 @@ public class UpdateHelpMessagesCommand implements ExecutableCommand {
             helpMessagesService.reloadMessagesFile();
         } catch (IOException e) {
             sender.sendMessage("Could not update help file: " + e.getMessage());
-            ConsoleLogger.logException("Could not update help file:", e);
+            logger.logException("Could not update help file:", e);
         }
     }
 }

--- a/src/main/java/fr/xephi/authme/command/executable/authme/debug/DebugSectionUtils.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/debug/DebugSectionUtils.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.datasource.CacheDataSource;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import org.bukkit.Location;
 
 import java.lang.reflect.Field;
@@ -19,6 +20,7 @@ import java.util.function.Function;
  */
 final class DebugSectionUtils {
 
+    private static ConsoleLogger logger = ConsoleLoggerFactory.get(DebugSectionUtils.class);
     private static Field limboEntriesField;
 
     private DebugSectionUtils() {
@@ -72,7 +74,7 @@ final class DebugSectionUtils {
                 field.setAccessible(true);
                 limboEntriesField = field;
             } catch (Exception e) {
-                ConsoleLogger.logException("Could not retrieve LimboService entries field:", e);
+                logger.logException("Could not retrieve LimboService entries field:", e);
             }
         }
         return limboEntriesField;
@@ -95,7 +97,7 @@ final class DebugSectionUtils {
             try {
                 return function.apply((Map) limboEntriesField.get(limboService));
             } catch (Exception e) {
-                ConsoleLogger.logException("Could not retrieve LimboService values:", e);
+                logger.logException("Could not retrieve LimboService values:", e);
             }
         }
         return null;
@@ -119,7 +121,7 @@ final class DebugSectionUtils {
                 source.setAccessible(true);
                 return (DataSource) source.get(dataSource);
             } catch (NoSuchFieldException | IllegalAccessException e) {
-                ConsoleLogger.logException("Could not get source of CacheDataSource:", e);
+                logger.logException("Could not get source of CacheDataSource:", e);
                 return null;
             }
         }

--- a/src/main/java/fr/xephi/authme/command/executable/authme/debug/MySqlDefaultChanger.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/debug/MySqlDefaultChanger.java
@@ -5,6 +5,7 @@ import com.google.common.annotations.VisibleForTesting;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.datasource.MySQL;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.permission.DebugSectionPermissions;
 import fr.xephi.authme.permission.PermissionNode;
 import fr.xephi.authme.settings.Settings;
@@ -42,6 +43,8 @@ class MySqlDefaultChanger implements DebugSection {
 
     private static final String NOT_NULL_SUFFIX = ChatColor.DARK_AQUA + "@" + ChatColor.RESET;
     private static final String DEFAULT_VALUE_SUFFIX = ChatColor.GOLD + "#" + ChatColor.RESET;
+
+    private ConsoleLogger logger = ConsoleLoggerFactory.get(MySqlDefaultChanger.class);
 
     @Inject
     private Settings settings;
@@ -98,7 +101,7 @@ class MySqlDefaultChanger implements DebugSection {
                         throw new IllegalStateException("Unknown operation '" + operation + "'");
                 }
             } catch (SQLException | IllegalStateException e) {
-                ConsoleLogger.logException("Failed to perform MySQL default altering operation:", e);
+                logger.logException("Failed to perform MySQL default altering operation:", e);
             }
         }
     }
@@ -134,7 +137,7 @@ class MySqlDefaultChanger implements DebugSection {
         }
 
         // Log success message
-        ConsoleLogger.info("Changed MySQL column '" + columnName + "' to be NOT NULL, as initiated by '"
+        logger.info("Changed MySQL column '" + columnName + "' to be NOT NULL, as initiated by '"
             + sender.getName() + "'");
     }
 
@@ -168,7 +171,7 @@ class MySqlDefaultChanger implements DebugSection {
             + "') to be NULL, modifying " + updatedRows + " entries");
 
         // Log success message
-        ConsoleLogger.info("Changed MySQL column '" + columnName + "' to allow NULL, as initiated by '"
+        logger.info("Changed MySQL column '" + columnName + "' to allow NULL, as initiated by '"
             + sender.getName() + "'");
     }
 
@@ -191,7 +194,7 @@ class MySqlDefaultChanger implements DebugSection {
                     + " (" + columnName + "): " + isNullText + ", " + defaultText);
             }
         } catch (SQLException e) {
-            ConsoleLogger.logException("Failed while showing column details:", e);
+            logger.logException("Failed while showing column details:", e);
             sender.sendMessage("Failed while showing column details. See log for info");
         }
 
@@ -228,7 +231,7 @@ class MySqlDefaultChanger implements DebugSection {
             }
             return String.join(ChatColor.RESET + ", ", formattedColumns);
         } catch (SQLException e) {
-            ConsoleLogger.logException("Failed to construct column list:", e);
+            logger.logException("Failed to construct column list:", e);
             return ChatColor.RED + "An error occurred! Please see the console for details.";
         }
     }

--- a/src/main/java/fr/xephi/authme/command/executable/authme/debug/TestEmailSender.java
+++ b/src/main/java/fr/xephi/authme/command/executable/authme/debug/TestEmailSender.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.command.executable.authme.debug;
 import ch.jalu.datasourcecolumns.data.DataSourceValue;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.mail.SendMailSsl;
 import fr.xephi.authme.permission.DebugSectionPermissions;
 import fr.xephi.authme.permission.PermissionNode;
@@ -21,6 +22,8 @@ import java.util.List;
  * Sends out a test email.
  */
 class TestEmailSender implements DebugSection {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(TestEmailSender.class);
 
     @Inject
     private DataSource dataSource;
@@ -110,7 +113,7 @@ class TestEmailSender implements DebugSection {
         try {
             htmlEmail = sendMailSsl.initializeMail(email);
         } catch (EmailException e) {
-            ConsoleLogger.logException("Failed to create email for sample email:", e);
+            logger.logException("Failed to create email for sample email:", e);
             return false;
         }
 

--- a/src/main/java/fr/xephi/authme/command/executable/email/EmailSetPasswordCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/email/EmailSetPasswordCommand.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.command.executable.email;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.command.PlayerCommand;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.security.PasswordSecurity;
 import fr.xephi.authme.security.crypts.HashedPassword;
@@ -19,6 +20,8 @@ import java.util.List;
  * Command for changing password following successful recovery.
  */
 public class EmailSetPasswordCommand extends PlayerCommand {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(EmailSetPasswordCommand.class);
 
     @Inject
     private DataSource dataSource;
@@ -46,7 +49,7 @@ public class EmailSetPasswordCommand extends PlayerCommand {
                 HashedPassword hashedPassword = passwordSecurity.computeHash(password, name);
                 dataSource.updatePassword(name, hashedPassword);
                 recoveryService.removeFromSuccessfulRecovery(player);
-                ConsoleLogger.info("Player '" + name + "' has changed their password from recovery");
+                logger.info("Player '" + name + "' has changed their password from recovery");
                 commonService.send(player, MessageKey.PASSWORD_CHANGED_SUCCESS);
             } else {
                 commonService.send(player, result.getMessageKey(), result.getArgs());

--- a/src/main/java/fr/xephi/authme/command/executable/email/RecoverEmailCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/email/RecoverEmailCommand.java
@@ -5,6 +5,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.command.PlayerCommand;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.mail.EmailService;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.service.BukkitService;
@@ -21,6 +22,8 @@ import java.util.List;
  * Command for password recovery by email.
  */
 public class RecoverEmailCommand extends PlayerCommand {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(RecoverEmailCommand.class);
 
     @Inject
     private CommonService commonService;
@@ -49,7 +52,7 @@ public class RecoverEmailCommand extends PlayerCommand {
         final String playerName = player.getName();
 
         if (!emailService.hasAllInformation()) {
-            ConsoleLogger.warning("Mail API is not set");
+            logger.warning("Mail API is not set");
             commonService.send(player, MessageKey.INCOMPLETE_EMAIL_SETTINGS);
             return;
         }

--- a/src/main/java/fr/xephi/authme/command/executable/register/RegisterCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/register/RegisterCommand.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.command.executable.register;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.command.PlayerCommand;
 import fr.xephi.authme.data.captcha.RegistrationCaptchaManager;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.mail.EmailService;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.process.Management;
@@ -33,6 +34,8 @@ import static fr.xephi.authme.settings.properties.RegistrationSettings.REGISTER_
  * Command for /register.
  */
 public class RegisterCommand extends PlayerCommand {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(RegisterCommand.class);
 
     @Inject
     private Management management;
@@ -155,7 +158,7 @@ public class RegisterCommand extends PlayerCommand {
     private void handleEmailRegistration(Player player, List<String> arguments) {
         if (!emailService.hasAllInformation()) {
             commonService.send(player, MessageKey.INCOMPLETE_EMAIL_SETTINGS);
-            ConsoleLogger.warning("Cannot register player '" + player.getName() + "': no email or password is set "
+            logger.warning("Cannot register player '" + player.getName() + "': no email or password is set "
                 + "to send emails from. Please adjust your config at " + EmailSettings.MAIL_ACCOUNT.getPath());
             return;
         }

--- a/src/main/java/fr/xephi/authme/command/executable/totp/ConfirmTotpCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/totp/ConfirmTotpCommand.java
@@ -5,6 +5,7 @@ import fr.xephi.authme.command.PlayerCommand;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
 import fr.xephi.authme.security.totp.GenerateTotpService;
@@ -18,6 +19,8 @@ import java.util.List;
  * Command to enable TOTP by supplying the proper code as confirmation.
  */
 public class ConfirmTotpCommand extends PlayerCommand {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(ConfirmTotpCommand.class);
 
     @Inject
     private GenerateTotpService generateTotpService;
@@ -63,7 +66,7 @@ public class ConfirmTotpCommand extends PlayerCommand {
             messages.send(player, MessageKey.TWO_FACTOR_ENABLE_SUCCESS);
             auth.setTotpKey(totpDetails.getTotpKey());
             playerCache.updatePlayer(auth);
-            ConsoleLogger.info("Player '" + player.getName() + "' has successfully added a TOTP key to their account");
+            logger.info("Player '" + player.getName() + "' has successfully added a TOTP key to their account");
         } else {
             messages.send(player, MessageKey.ERROR);
         }

--- a/src/main/java/fr/xephi/authme/command/executable/totp/RemoveTotpCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/totp/RemoveTotpCommand.java
@@ -5,6 +5,7 @@ import fr.xephi.authme.command.PlayerCommand;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
 import fr.xephi.authme.security.totp.TotpAuthenticator;
@@ -17,6 +18,8 @@ import java.util.List;
  * Command for a player to remove 2FA authentication.
  */
 public class RemoveTotpCommand extends PlayerCommand {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(RemoveTotpCommand.class);
 
     @Inject
     private DataSource dataSource;
@@ -51,7 +54,7 @@ public class RemoveTotpCommand extends PlayerCommand {
             auth.setTotpKey(null);
             playerCache.updatePlayer(auth);
             messages.send(player, MessageKey.TWO_FACTOR_REMOVED_SUCCESS);
-            ConsoleLogger.info("Player '" + player.getName() + "' removed their TOTP key");
+            logger.info("Player '" + player.getName() + "' removed their TOTP key");
         } else {
             messages.send(player, MessageKey.ERROR);
         }

--- a/src/main/java/fr/xephi/authme/command/executable/totp/TotpCodeCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/totp/TotpCodeCommand.java
@@ -8,6 +8,7 @@ import fr.xephi.authme.data.limbo.LimboPlayer;
 import fr.xephi.authme.data.limbo.LimboPlayerState;
 import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
 import fr.xephi.authme.process.login.AsynchronousLogin;
@@ -21,6 +22,8 @@ import java.util.List;
  * TOTP code command for processing the 2FA code during the login process.
  */
 public class TotpCodeCommand extends PlayerCommand {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(TotpCodeCommand.class);
 
     @Inject
     private LimboService limboService;
@@ -57,7 +60,7 @@ public class TotpCodeCommand extends PlayerCommand {
         if (limbo != null && limbo.getState() == LimboPlayerState.TOTP_REQUIRED) {
             processCode(player, auth, arguments.get(0));
         } else {
-            ConsoleLogger.debug(() -> "Aborting TOTP check for player '" + player.getName()
+            logger.debug(() -> "Aborting TOTP check for player '" + player.getName()
                 + "'. Invalid limbo state: " + (limbo == null ? "no limbo" : limbo.getState()));
             messages.send(player, MessageKey.LOGIN_MESSAGE);
         }
@@ -66,10 +69,10 @@ public class TotpCodeCommand extends PlayerCommand {
     private void processCode(Player player, PlayerAuth auth, String inputCode) {
         boolean isCodeValid = totpAuthenticator.checkCode(auth, inputCode);
         if (isCodeValid) {
-            ConsoleLogger.debug("Successfully checked TOTP code for `{0}`", player.getName());
+            logger.debug("Successfully checked TOTP code for `{0}`", player.getName());
             asynchronousLogin.performLogin(player, auth);
         } else {
-            ConsoleLogger.debug("Input TOTP code was invalid for player `{0}`", player.getName());
+            logger.debug("Input TOTP code was invalid for player `{0}`", player.getName());
             messages.send(player, MessageKey.TWO_FACTOR_INVALID_CODE);
         }
     }

--- a/src/main/java/fr/xephi/authme/command/executable/verification/VerificationCommand.java
+++ b/src/main/java/fr/xephi/authme/command/executable/verification/VerificationCommand.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.command.executable.verification;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.command.PlayerCommand;
 import fr.xephi.authme.data.VerificationCodeManager;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.service.CommonService;
 import org.bukkit.entity.Player;
@@ -15,6 +16,8 @@ import java.util.List;
  */
 public class VerificationCommand extends PlayerCommand {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(VerificationCommand.class);
+
     @Inject
     private CommonService commonService;
 
@@ -26,7 +29,7 @@ public class VerificationCommand extends PlayerCommand {
         final String playerName = player.getName();
 
         if (!codeManager.canSendMail()) {
-            ConsoleLogger.warning("Mail API is not set");
+            logger.warning("Mail API is not set");
             commonService.send(player, MessageKey.INCOMPLETE_EMAIL_SETTINGS);
             return;
         }

--- a/src/main/java/fr/xephi/authme/data/limbo/AuthGroupHandler.java
+++ b/src/main/java/fr/xephi/authme/data/limbo/AuthGroupHandler.java
@@ -2,6 +2,7 @@ package fr.xephi.authme.data.limbo;
 
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.permission.PermissionsManager;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.PluginSettings;
@@ -25,6 +26,8 @@ import java.util.Collections;
  * be in at least one group, this will mean that the player is not removed from his primary group.
  */
 class AuthGroupHandler implements Reloadable {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(AuthGroupHandler.class);
 
     @Inject
     private PermissionsManager permissionsManager;
@@ -78,7 +81,7 @@ class AuthGroupHandler implements Reloadable {
                 throw new IllegalStateException("Encountered unhandled auth group type '" + groupType + "'");
         }
 
-        ConsoleLogger.debug(() -> player.getName() + " changed to "
+        logger.debug(() -> player.getName() + " changed to "
             + groupType + ": has groups " + permissionsManager.getGroups(player));
     }
 
@@ -95,7 +98,7 @@ class AuthGroupHandler implements Reloadable {
 
         // Make sure group support is available
         if (!permissionsManager.hasGroupSupport()) {
-            ConsoleLogger.warning("The current permissions system doesn't have group support, unable to set group!");
+            logger.warning("The current permissions system doesn't have group support, unable to set group!");
             return false;
         }
         return true;

--- a/src/main/java/fr/xephi/authme/data/limbo/LimboService.java
+++ b/src/main/java/fr/xephi/authme/data/limbo/LimboService.java
@@ -2,6 +2,7 @@ package fr.xephi.authme.data.limbo;
 
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.limbo.persistence.LimboPersistence;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.SpawnLoader;
 import org.bukkit.Location;
@@ -21,6 +22,8 @@ import static fr.xephi.authme.settings.properties.LimboSettings.RESTORE_WALK_SPE
  * put in which have joined but not yet logged in.
  */
 public class LimboService {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(LimboService.class);
 
     private final Map<String, LimboPlayer> entries = new ConcurrentHashMap<>();
 
@@ -56,13 +59,13 @@ public class LimboService {
 
         LimboPlayer limboFromDisk = persistence.getLimboPlayer(player);
         if (limboFromDisk != null) {
-            ConsoleLogger.debug("LimboPlayer for `{0}` already exists on disk", name);
+            logger.debug("LimboPlayer for `{0}` already exists on disk", name);
         }
 
         LimboPlayer existingLimbo = entries.remove(name);
         if (existingLimbo != null) {
             existingLimbo.clearTasks();
-            ConsoleLogger.debug("LimboPlayer for `{0}` already present in memory", name);
+            logger.debug("LimboPlayer for `{0}` already present in memory", name);
         }
 
         Location location = spawnLoader.getPlayerLocationOrSpawn(player);
@@ -112,14 +115,14 @@ public class LimboService {
         LimboPlayer limbo = entries.remove(lowerName);
 
         if (limbo == null) {
-            ConsoleLogger.debug("No LimboPlayer found for `{0}` - cannot restore", lowerName);
+            logger.debug("No LimboPlayer found for `{0}` - cannot restore", lowerName);
         } else {
             player.setOp(limbo.isOperator());
             settings.getProperty(RESTORE_ALLOW_FLIGHT).restoreAllowFlight(player, limbo);
             settings.getProperty(RESTORE_FLY_SPEED).restoreFlySpeed(player, limbo);
             settings.getProperty(RESTORE_WALK_SPEED).restoreWalkSpeed(player, limbo);
             limbo.clearTasks();
-            ConsoleLogger.debug("Restored LimboPlayer stats for `{0}`", lowerName);
+            logger.debug("Restored LimboPlayer stats for `{0}`", lowerName);
             persistence.removeLimboPlayer(player);
         }
         authGroupHandler.setGroup(player, limbo, AuthGroupType.LOGGED_IN);
@@ -177,7 +180,7 @@ public class LimboService {
     private Optional<LimboPlayer> getLimboOrLogError(Player player, String context) {
         LimboPlayer limbo = entries.get(player.getName().toLowerCase());
         if (limbo == null) {
-            ConsoleLogger.debug("No LimboPlayer found for `{0}`. Action: {1}", player.getName(), context);
+            logger.debug("No LimboPlayer found for `{0}`. Action: {1}", player.getName(), context);
         }
         return Optional.ofNullable(limbo);
     }

--- a/src/main/java/fr/xephi/authme/data/limbo/LimboServiceHelper.java
+++ b/src/main/java/fr/xephi/authme/data/limbo/LimboServiceHelper.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.data.limbo;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.permission.PermissionsManager;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.LimboSettings;
@@ -18,6 +19,8 @@ import static fr.xephi.authme.util.Utils.isCollectionEmpty;
  * Helper class for the LimboService.
  */
 class LimboServiceHelper {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(LimboServiceHelper.class);
 
     @Inject
     private PermissionsManager permissionsManager;
@@ -41,7 +44,7 @@ class LimboServiceHelper {
         float flySpeed = player.getFlySpeed();
         Collection<String> playerGroups = permissionsManager.hasGroupSupport()
             ? permissionsManager.getGroups(player) : Collections.emptyList();
-        ConsoleLogger.debug("Player `{0}` has groups `{1}`", player.getName(), String.join(", ", playerGroups));
+        logger.debug("Player `{0}` has groups `{1}`", player.getName(), String.join(", ", playerGroups));
 
         return new LimboPlayer(location, isOperator, playerGroups, flyEnabled, walkSpeed, flySpeed);
     }
@@ -98,9 +101,8 @@ class LimboServiceHelper {
         return first == null ? second : first;
     }
 
-    private static Collection<String> getLimboGroups(Collection<String> oldLimboGroups,
-                                                     Collection<String> newLimboGroups) {
-        ConsoleLogger.debug("Limbo merge: new and old groups are `{0}` and `{1}`", newLimboGroups, oldLimboGroups);
+    private Collection<String> getLimboGroups(Collection<String> oldLimboGroups, Collection<String> newLimboGroups) {
+        logger.debug("Limbo merge: new and old groups are `{0}` and `{1}`", newLimboGroups, oldLimboGroups);
         return isCollectionEmpty(oldLimboGroups) ? newLimboGroups : oldLimboGroups;
     }
 }

--- a/src/main/java/fr/xephi/authme/data/limbo/WalkFlySpeedRestoreType.java
+++ b/src/main/java/fr/xephi/authme/data/limbo/WalkFlySpeedRestoreType.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.data.limbo;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import org.bukkit.entity.Player;
 
 /**
@@ -15,14 +16,14 @@ public enum WalkFlySpeedRestoreType {
     RESTORE {
         @Override
         public void restoreFlySpeed(Player player, LimboPlayer limbo) {
-            ConsoleLogger.debug("Restoring fly speed for LimboPlayer " + player.getName() + " to "
+            logger.debug(() -> "Restoring fly speed for LimboPlayer " + player.getName() + " to "
                 + limbo.getFlySpeed() + " (RESTORE mode)");
             player.setFlySpeed(limbo.getFlySpeed());
         }
 
         @Override
         public void restoreWalkSpeed(Player player, LimboPlayer limbo) {
-            ConsoleLogger.debug("Restoring walk speed for LimboPlayer " + player.getName() + " to "
+            logger.debug(() -> "Restoring walk speed for LimboPlayer " + player.getName() + " to "
                 + limbo.getWalkSpeed() + " (RESTORE mode)");
             player.setWalkSpeed(limbo.getWalkSpeed());
         }
@@ -36,11 +37,11 @@ public enum WalkFlySpeedRestoreType {
         public void restoreFlySpeed(Player player, LimboPlayer limbo) {
             float limboFlySpeed = limbo.getFlySpeed();
             if (limboFlySpeed > 0.01f) {
-                ConsoleLogger.debug("Restoring fly speed for LimboPlayer " + player.getName() + " to "
+                logger.debug(() -> "Restoring fly speed for LimboPlayer " + player.getName() + " to "
                     + limboFlySpeed + " (RESTORE_NO_ZERO mode)");
                 player.setFlySpeed(limboFlySpeed);
             } else {
-                ConsoleLogger.debug("Restoring fly speed for LimboPlayer " + player.getName()
+                logger.debug(() -> "Restoring fly speed for LimboPlayer " + player.getName()
                     + " to DEFAULT, it was 0! (RESTORE_NO_ZERO mode)");
                 player.setFlySpeed(LimboPlayer.DEFAULT_FLY_SPEED);
             }
@@ -50,11 +51,11 @@ public enum WalkFlySpeedRestoreType {
         public void restoreWalkSpeed(Player player, LimboPlayer limbo) {
             float limboWalkSpeed = limbo.getWalkSpeed();
             if (limboWalkSpeed > 0.01f) {
-                ConsoleLogger.debug("Restoring walk speed for LimboPlayer " + player.getName() + " to "
+                logger.debug(() -> "Restoring walk speed for LimboPlayer " + player.getName() + " to "
                     + limboWalkSpeed + " (RESTORE_NO_ZERO mode)");
                 player.setWalkSpeed(limboWalkSpeed);
             } else {
-                ConsoleLogger.debug("Restoring walk speed for LimboPlayer " + player.getName() + ""
+                logger.debug(() -> "Restoring walk speed for LimboPlayer " + player.getName() + ""
                     + " to DEFAULT, it was 0! (RESTORE_NO_ZERO mode)");
                 player.setWalkSpeed(LimboPlayer.DEFAULT_WALK_SPEED);
             }
@@ -68,7 +69,7 @@ public enum WalkFlySpeedRestoreType {
         @Override
         public void restoreFlySpeed(Player player, LimboPlayer limbo) {
             float newSpeed = Math.max(player.getFlySpeed(), limbo.getFlySpeed());
-            ConsoleLogger.debug("Restoring fly speed for LimboPlayer " + player.getName() + " to " + newSpeed
+            logger.debug(() -> "Restoring fly speed for LimboPlayer " + player.getName() + " to " + newSpeed
                 + " (Current: " + player.getFlySpeed() + ", Limbo: " + limbo.getFlySpeed() + ") (MAX_RESTORE mode)");
             player.setFlySpeed(newSpeed);
         }
@@ -76,7 +77,7 @@ public enum WalkFlySpeedRestoreType {
         @Override
         public void restoreWalkSpeed(Player player, LimboPlayer limbo) {
             float newSpeed = Math.max(player.getWalkSpeed(), limbo.getWalkSpeed());
-            ConsoleLogger.debug("Restoring walk speed for LimboPlayer " + player.getName() + " to " + newSpeed
+            logger.debug(() -> "Restoring walk speed for LimboPlayer " + player.getName() + " to " + newSpeed
                 + " (Current: " + player.getWalkSpeed() + ", Limbo: " + limbo.getWalkSpeed() + ") (MAX_RESTORE mode)");
             player.setWalkSpeed(newSpeed);
         }
@@ -88,18 +89,20 @@ public enum WalkFlySpeedRestoreType {
     DEFAULT {
         @Override
         public void restoreFlySpeed(Player player, LimboPlayer limbo) {
-            ConsoleLogger.debug("Restoring fly speed for LimboPlayer " + player.getName()
+            logger.debug(() -> "Restoring fly speed for LimboPlayer " + player.getName()
                 + " to DEFAULT (DEFAULT mode)");
             player.setFlySpeed(LimboPlayer.DEFAULT_FLY_SPEED);
         }
 
         @Override
         public void restoreWalkSpeed(Player player, LimboPlayer limbo) {
-            ConsoleLogger.debug("Restoring walk speed for LimboPlayer " + player.getName()
+            logger.debug(() -> "Restoring walk speed for LimboPlayer " + player.getName()
                 + " to DEFAULT (DEFAULT mode)");
             player.setWalkSpeed(LimboPlayer.DEFAULT_WALK_SPEED);
         }
     };
+
+    private static final ConsoleLogger logger = ConsoleLoggerFactory.get(WalkFlySpeedRestoreType.class);
 
     /**
      * Restores the fly speed from Limbo to Player according to the restoration type.

--- a/src/main/java/fr/xephi/authme/data/limbo/persistence/DistributedFilesPersistenceHandler.java
+++ b/src/main/java/fr/xephi/authme/data/limbo/persistence/DistributedFilesPersistenceHandler.java
@@ -7,6 +7,7 @@ import com.google.gson.GsonBuilder;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.limbo.LimboPlayer;
 import fr.xephi.authme.initialization.DataFolder;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.LimboSettings;
@@ -33,6 +34,7 @@ class DistributedFilesPersistenceHandler implements LimboPersistenceHandler {
 
     private static final Type LIMBO_MAP_TYPE = new TypeToken<Map<String, LimboPlayer>>(){}.getType();
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(DistributedFilesPersistenceHandler.class);
     private final File cacheFolder;
     private final Gson gson;
     private final SegmentNameBuilder segmentNameBuilder;
@@ -103,7 +105,7 @@ class DistributedFilesPersistenceHandler implements LimboPersistenceHandler {
         try (FileWriter fw = new FileWriter(file)) {
             gson.toJson(entries, fw);
         } catch (Exception e) {
-            ConsoleLogger.logException("Could not write to '" + file + "':", e);
+            logger.logException("Could not write to '" + file + "':", e);
         }
     }
 
@@ -115,7 +117,7 @@ class DistributedFilesPersistenceHandler implements LimboPersistenceHandler {
         try {
             return gson.fromJson(Files.asCharSource(file, StandardCharsets.UTF_8).read(), LIMBO_MAP_TYPE);
         } catch (Exception e) {
-            ConsoleLogger.logException("Failed reading '" + file + "':", e);
+            logger.logException("Failed reading '" + file + "':", e);
         }
         return null;
     }
@@ -164,7 +166,7 @@ class DistributedFilesPersistenceHandler implements LimboPersistenceHandler {
     private void saveToNewSegments(Map<String, LimboPlayer> limbosFromOldSegments) {
         Map<String, Map<String, LimboPlayer>> limboBySegment = groupBySegment(limbosFromOldSegments);
 
-        ConsoleLogger.info("Saving " + limbosFromOldSegments.size() + " LimboPlayers from old segments into "
+        logger.info("Saving " + limbosFromOldSegments.size() + " LimboPlayers from old segments into "
             + limboBySegment.size() + " current segments");
         for (Map.Entry<String, Map<String, LimboPlayer>> entry : limboBySegment.entrySet()) {
             File file = getSegmentFile(entry.getKey());
@@ -203,7 +205,7 @@ class DistributedFilesPersistenceHandler implements LimboPersistenceHandler {
             .filter(f -> isLimboJsonFile(f) && f.length() < 3)
             .peek(FileUtils::delete)
             .count();
-        ConsoleLogger.debug("Limbo: Deleted {0} empty segment files", deletedFiles);
+        logger.debug("Limbo: Deleted {0} empty segment files", deletedFiles);
     }
 
     /**
@@ -215,10 +217,10 @@ class DistributedFilesPersistenceHandler implements LimboPersistenceHandler {
         return name.startsWith("seg") && name.endsWith("-limbo.json");
     }
 
-    private static File[] listFiles(File folder) {
+    private File[] listFiles(File folder) {
         File[] files = folder.listFiles();
         if (files == null) {
-            ConsoleLogger.warning("Could not get files of '" + folder + "'");
+            logger.warning("Could not get files of '" + folder + "'");
             return new File[0];
         }
         return files;

--- a/src/main/java/fr/xephi/authme/data/limbo/persistence/IndividualFilesPersistenceHandler.java
+++ b/src/main/java/fr/xephi/authme/data/limbo/persistence/IndividualFilesPersistenceHandler.java
@@ -6,6 +6,7 @@ import com.google.gson.GsonBuilder;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.limbo.LimboPlayer;
 import fr.xephi.authme.initialization.DataFolder;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.util.FileUtils;
 import org.bukkit.entity.Player;
@@ -20,6 +21,8 @@ import java.nio.charset.StandardCharsets;
  */
 class IndividualFilesPersistenceHandler implements LimboPersistenceHandler {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(IndividualFilesPersistenceHandler.class);
+
     private final Gson gson;
     private final File cacheDir;
 
@@ -27,7 +30,7 @@ class IndividualFilesPersistenceHandler implements LimboPersistenceHandler {
     IndividualFilesPersistenceHandler(@DataFolder File dataFolder, BukkitService bukkitService) {
         cacheDir = new File(dataFolder, "playerdata");
         if (!cacheDir.exists() && !cacheDir.isDirectory() && !cacheDir.mkdir()) {
-            ConsoleLogger.warning("Failed to create playerdata directory '" + cacheDir + "'");
+            logger.warning("Failed to create playerdata directory '" + cacheDir + "'");
         }
         gson = new GsonBuilder()
             .registerTypeAdapter(LimboPlayer.class, new LimboPlayerSerializer())
@@ -48,7 +51,7 @@ class IndividualFilesPersistenceHandler implements LimboPersistenceHandler {
             String str = Files.asCharSource(file, StandardCharsets.UTF_8).read();
             return gson.fromJson(str, LimboPlayer.class);
         } catch (IOException e) {
-            ConsoleLogger.logException("Could not read player data on disk for '" + player.getName() + "'", e);
+            logger.logException("Could not read player data on disk for '" + player.getName() + "'", e);
             return null;
         }
     }
@@ -62,7 +65,7 @@ class IndividualFilesPersistenceHandler implements LimboPersistenceHandler {
             Files.touch(file);
             Files.write(gson.toJson(limboPlayer), file, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            ConsoleLogger.logException("Failed to write " + player.getName() + " data:", e);
+            logger.logException("Failed to write " + player.getName() + " data:", e);
         }
     }
 

--- a/src/main/java/fr/xephi/authme/data/limbo/persistence/LimboPersistence.java
+++ b/src/main/java/fr/xephi/authme/data/limbo/persistence/LimboPersistence.java
@@ -4,6 +4,7 @@ import ch.jalu.injector.factory.Factory;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.limbo.LimboPlayer;
 import fr.xephi.authme.initialization.SettingsDependent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.LimboSettings;
 import org.bukkit.entity.Player;
@@ -14,6 +15,8 @@ import javax.inject.Inject;
  * Handles the persistence of LimboPlayers.
  */
 public class LimboPersistence implements SettingsDependent {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(LimboPersistence.class);
 
     private final Factory<LimboPersistenceHandler> handlerFactory;
 
@@ -35,7 +38,7 @@ public class LimboPersistence implements SettingsDependent {
         try {
             return handler.getLimboPlayer(player);
         } catch (Exception e) {
-            ConsoleLogger.logException("Could not get LimboPlayer for '" + player.getName() + "'", e);
+            logger.logException("Could not get LimboPlayer for '" + player.getName() + "'", e);
         }
         return null;
     }
@@ -50,7 +53,7 @@ public class LimboPersistence implements SettingsDependent {
         try {
             handler.saveLimboPlayer(player, limbo);
         } catch (Exception e) {
-            ConsoleLogger.logException("Could not save LimboPlayer for '" + player.getName() + "'", e);
+            logger.logException("Could not save LimboPlayer for '" + player.getName() + "'", e);
         }
     }
 
@@ -63,7 +66,7 @@ public class LimboPersistence implements SettingsDependent {
         try {
             handler.removeLimboPlayer(player);
         } catch (Exception e) {
-            ConsoleLogger.logException("Could not remove LimboPlayer for '" + player.getName() + "'", e);
+            logger.logException("Could not remove LimboPlayer for '" + player.getName() + "'", e);
         }
     }
 
@@ -72,7 +75,7 @@ public class LimboPersistence implements SettingsDependent {
         LimboPersistenceType persistenceType = settings.getProperty(LimboSettings.LIMBO_PERSISTENCE_TYPE);
         // If we're changing from an existing handler, output a quick hint that nothing is converted.
         if (handler != null && handler.getType() != persistenceType) {
-            ConsoleLogger.info("Limbo persistence type has changed! Note that the data is not converted.");
+            logger.info("Limbo persistence type has changed! Note that the data is not converted.");
         }
         handler = handlerFactory.newInstance(persistenceType.getImplementationClass());
     }

--- a/src/main/java/fr/xephi/authme/datasource/CacheDataSource.java
+++ b/src/main/java/fr/xephi/authme/datasource/CacheDataSource.java
@@ -12,6 +12,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.security.crypts.HashedPassword;
 import fr.xephi.authme.util.Utils;
 
@@ -24,6 +25,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class CacheDataSource implements DataSource {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(CacheDataSource.class);
 
     private final DataSource source;
     private final PlayerCache playerCache;
@@ -164,7 +167,7 @@ public class CacheDataSource implements DataSource {
         try {
             executorService.awaitTermination(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            ConsoleLogger.logException("Could not close executor service:", e);
+            logger.logException("Could not close executor service:", e);
         }
         cachedAuths.invalidateAll();
         source.closeConnection();

--- a/src/main/java/fr/xephi/authme/datasource/MySQL.java
+++ b/src/main/java/fr/xephi/authme/datasource/MySQL.java
@@ -8,6 +8,7 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.columnshandler.AuthMeColumnsHandler;
 import fr.xephi.authme.datasource.mysqlextensions.MySqlExtension;
 import fr.xephi.authme.datasource.mysqlextensions.MySqlExtensionsFactory;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.DatabaseSettings;
 import fr.xephi.authme.settings.properties.HooksSettings;
@@ -32,6 +33,7 @@ import static fr.xephi.authme.datasource.SqlDataSourceUtils.logSqlException;
  */
 @SuppressWarnings({"checkstyle:AbbreviationAsWordInName"}) // Justification: Class name cannot be changed anymore
 public class MySQL extends AbstractSqlDataSource {
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(MySQL.class);
 
     private boolean useSsl;
     private boolean serverCertificateVerification;
@@ -56,14 +58,14 @@ public class MySQL extends AbstractSqlDataSource {
             this.setConnectionArguments();
         } catch (RuntimeException e) {
             if (e instanceof IllegalArgumentException) {
-                ConsoleLogger.warning("Invalid database arguments! Please check your configuration!");
-                ConsoleLogger.warning("If this error persists, please report it to the developer!");
+                logger.warning("Invalid database arguments! Please check your configuration!");
+                logger.warning("If this error persists, please report it to the developer!");
             }
             if (e instanceof PoolInitializationException) {
-                ConsoleLogger.warning("Can't initialize database connection! Please check your configuration!");
-                ConsoleLogger.warning("If this error persists, please report it to the developer!");
+                logger.warning("Can't initialize database connection! Please check your configuration!");
+                logger.warning("If this error persists, please report it to the developer!");
             }
-            ConsoleLogger.warning("Can't use the Hikari Connection Pool! Please, report this error to the developer!");
+            logger.warning("Can't use the Hikari Connection Pool! Please, report this error to the developer!");
             throw e;
         }
 
@@ -72,8 +74,8 @@ public class MySQL extends AbstractSqlDataSource {
             checkTablesAndColumns();
         } catch (SQLException e) {
             closeConnection();
-            ConsoleLogger.logException("Can't initialize the MySQL database:", e);
-            ConsoleLogger.warning("Please check your database settings in the config.yml file!");
+            logger.logException("Can't initialize the MySQL database:", e);
+            logger.warning("Please check your database settings in the config.yml file!");
             throw e;
         }
     }
@@ -147,7 +149,7 @@ public class MySQL extends AbstractSqlDataSource {
         ds.addDataSourceProperty("prepStmtCacheSize", "275");
         ds.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
 
-        ConsoleLogger.info("Connection arguments loaded, Hikari ConnectionPool ready!");
+        logger.info("Connection arguments loaded, Hikari ConnectionPool ready!");
     }
 
     @Override
@@ -156,7 +158,7 @@ public class MySQL extends AbstractSqlDataSource {
             ds.close();
         }
         setConnectionArguments();
-        ConsoleLogger.info("Hikari ConnectionPool arguments reloaded!");
+        logger.info("Hikari ConnectionPool arguments reloaded!");
     }
 
     private Connection getConnection() throws SQLException {
@@ -265,7 +267,7 @@ public class MySQL extends AbstractSqlDataSource {
                     + " ADD COLUMN " + col.TOTP_KEY + " VARCHAR(16);");
             }
         }
-        ConsoleLogger.info("MySQL setup finished");
+        logger.info("MySQL setup finished");
     }
 
     private boolean isColumnMissing(DatabaseMetaData metaData, String columnName) throws SQLException {

--- a/src/main/java/fr/xephi/authme/datasource/MySqlMigrater.java
+++ b/src/main/java/fr/xephi/authme/datasource/MySqlMigrater.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.datasource;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -12,6 +13,8 @@ import java.sql.Types;
  * Performs migrations on the MySQL data source if necessary.
  */
 final class MySqlMigrater {
+    
+    private static ConsoleLogger logger = ConsoleLoggerFactory.get(MySqlMigrater.class);
 
     private MySqlMigrater() {
     }
@@ -35,7 +38,7 @@ final class MySqlMigrater {
             String sql = String.format("ALTER TABLE %s MODIFY %s VARCHAR(40) CHARACTER SET ascii COLLATE ascii_bin",
                 tableName, col.LAST_IP);
             st.execute(sql);
-            ConsoleLogger.info("Changed last login column to allow NULL values. Please verify the registration feature "
+            logger.info("Changed last login column to allow NULL values. Please verify the registration feature "
                 + "if you are hooking into a forum.");
         }
     }
@@ -53,7 +56,7 @@ final class MySqlMigrater {
         final int columnType;
         try (ResultSet rs = metaData.getColumns(null, null, tableName, col.LAST_LOGIN)) {
             if (!rs.next()) {
-                ConsoleLogger.warning("Could not get LAST_LOGIN meta data. This should never happen!");
+                logger.warning("Could not get LAST_LOGIN meta data. This should never happen!");
                 return;
             }
             columnType = rs.getInt("DATA_TYPE");
@@ -75,7 +78,7 @@ final class MySqlMigrater {
      */
     private static void migrateLastLoginColumnFromInt(Statement st, String tableName, Columns col) throws SQLException {
         // Change from int to bigint
-        ConsoleLogger.info("Migrating lastlogin column from int to bigint");
+        logger.info("Migrating lastlogin column from int to bigint");
         String sql = String.format("ALTER TABLE %s MODIFY %s BIGINT;", tableName, col.LAST_LOGIN);
         st.execute(sql);
 
@@ -86,7 +89,7 @@ final class MySqlMigrater {
             tableName, col.LAST_LOGIN, col.LAST_LOGIN, col.LAST_LOGIN, rangeStart, col.LAST_LOGIN, rangeEnd);
         int changedRows = st.executeUpdate(sql);
 
-        ConsoleLogger.warning("You may have entries with invalid timestamps. Please check your data "
+        logger.warning("You may have entries with invalid timestamps. Please check your data "
             + "before purging. " + changedRows + " rows were migrated from seconds to milliseconds.");
     }
 
@@ -107,7 +110,7 @@ final class MySqlMigrater {
         long currentTimestamp = System.currentTimeMillis();
         int updatedRows = st.executeUpdate(String.format("UPDATE %s SET %s = %d;",
             tableName, col.REGISTRATION_DATE, currentTimestamp));
-        ConsoleLogger.info("Created column '" + col.REGISTRATION_DATE + "' and set the current timestamp, "
+        logger.info("Created column '" + col.REGISTRATION_DATE + "' and set the current timestamp, "
             + currentTimestamp + ", to all " + updatedRows + " rows");
     }
 }

--- a/src/main/java/fr/xephi/authme/datasource/PostgreSqlDataSource.java
+++ b/src/main/java/fr/xephi/authme/datasource/PostgreSqlDataSource.java
@@ -8,6 +8,7 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.columnshandler.AuthMeColumnsHandler;
 import fr.xephi.authme.datasource.mysqlextensions.MySqlExtension;
 import fr.xephi.authme.datasource.mysqlextensions.MySqlExtensionsFactory;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.DatabaseSettings;
 import fr.xephi.authme.settings.properties.HooksSettings;
@@ -32,6 +33,8 @@ import static fr.xephi.authme.datasource.SqlDataSourceUtils.logSqlException;
  */
 public class PostgreSqlDataSource extends AbstractSqlDataSource {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(PostgreSqlDataSource.class);
+
     private String host;
     private String port;
     private String username;
@@ -53,14 +56,14 @@ public class PostgreSqlDataSource extends AbstractSqlDataSource {
             this.setConnectionArguments();
         } catch (RuntimeException e) {
             if (e instanceof IllegalArgumentException) {
-                ConsoleLogger.warning("Invalid database arguments! Please check your configuration!");
-                ConsoleLogger.warning("If this error persists, please report it to the developer!");
+                logger.warning("Invalid database arguments! Please check your configuration!");
+                logger.warning("If this error persists, please report it to the developer!");
             }
             if (e instanceof PoolInitializationException) {
-                ConsoleLogger.warning("Can't initialize database connection! Please check your configuration!");
-                ConsoleLogger.warning("If this error persists, please report it to the developer!");
+                logger.warning("Can't initialize database connection! Please check your configuration!");
+                logger.warning("If this error persists, please report it to the developer!");
             }
-            ConsoleLogger.warning("Can't use the Hikari Connection Pool! Please, report this error to the developer!");
+            logger.warning("Can't use the Hikari Connection Pool! Please, report this error to the developer!");
             throw e;
         }
 
@@ -69,8 +72,8 @@ public class PostgreSqlDataSource extends AbstractSqlDataSource {
             checkTablesAndColumns();
         } catch (SQLException e) {
             closeConnection();
-            ConsoleLogger.logException("Can't initialize the PostgreSQL database:", e);
-            ConsoleLogger.warning("Please check your database settings in the config.yml file!");
+            logger.logException("Can't initialize the PostgreSQL database:", e);
+            logger.warning("Please check your database settings in the config.yml file!");
             throw e;
         }
     }
@@ -129,7 +132,7 @@ public class PostgreSqlDataSource extends AbstractSqlDataSource {
         ds.addDataSourceProperty("cachePrepStmts", "true");
         ds.addDataSourceProperty("preparedStatementCacheQueries", "275");
 
-        ConsoleLogger.info("Connection arguments loaded, Hikari ConnectionPool ready!");
+        logger.info("Connection arguments loaded, Hikari ConnectionPool ready!");
     }
 
     @Override
@@ -138,7 +141,7 @@ public class PostgreSqlDataSource extends AbstractSqlDataSource {
             ds.close();
         }
         setConnectionArguments();
-        ConsoleLogger.info("Hikari ConnectionPool arguments reloaded!");
+        logger.info("Hikari ConnectionPool arguments reloaded!");
     }
 
     private Connection getConnection() throws SQLException {
@@ -242,7 +245,7 @@ public class PostgreSqlDataSource extends AbstractSqlDataSource {
                     + " ADD COLUMN " + col.TOTP_KEY + " VARCHAR(16);");
             }
         }
-        ConsoleLogger.info("PostgreSQL setup finished");
+        logger.info("PostgreSQL setup finished");
     }
 
     private boolean isColumnMissing(DatabaseMetaData metaData, String columnName) throws SQLException {

--- a/src/main/java/fr/xephi/authme/datasource/SQLite.java
+++ b/src/main/java/fr/xephi/authme/datasource/SQLite.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.columnshandler.AuthMeColumnsHandler;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.DatabaseSettings;
 
@@ -30,6 +31,7 @@ import static fr.xephi.authme.datasource.SqlDataSourceUtils.logSqlException;
 @SuppressWarnings({"checkstyle:AbbreviationAsWordInName"}) // Justification: Class name cannot be changed anymore
 public class SQLite extends AbstractSqlDataSource {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(SQLite.class);
     private final Settings settings;
     private final File dataFolder;
     private final String database;
@@ -57,7 +59,7 @@ public class SQLite extends AbstractSqlDataSource {
             this.setup();
             this.migrateIfNeeded();
         } catch (Exception ex) {
-            ConsoleLogger.logException("Error during SQLite initialization:", ex);
+            logger.logException("Error during SQLite initialization:", ex);
             throw ex;
         }
     }
@@ -85,7 +87,7 @@ public class SQLite extends AbstractSqlDataSource {
             throw new IllegalStateException("Failed to load SQLite JDBC class", e);
         }
 
-        ConsoleLogger.debug("SQLite driver loaded");
+        logger.debug("SQLite driver loaded");
         this.con = DriverManager.getConnection("jdbc:sqlite:plugins/AuthMe/" + database + ".db");
         this.columnsHandler = AuthMeColumnsHandler.createForSqlite(con, settings);
     }
@@ -183,7 +185,7 @@ public class SQLite extends AbstractSqlDataSource {
                     + " ADD COLUMN " + col.TOTP_KEY + " VARCHAR(16);");
             }
         }
-        ConsoleLogger.info("SQLite Setup finished");
+        logger.info("SQLite Setup finished");
     }
 
     /**
@@ -214,7 +216,7 @@ public class SQLite extends AbstractSqlDataSource {
             this.setup();
             this.migrateIfNeeded();
         } catch (SQLException ex) {
-            ConsoleLogger.logException("Error while reloading SQLite:", ex);
+            logger.logException("Error while reloading SQLite:", ex);
         }
     }
 
@@ -393,7 +395,7 @@ public class SQLite extends AbstractSqlDataSource {
         long currentTimestamp = System.currentTimeMillis();
         int updatedRows = st.executeUpdate(String.format("UPDATE %s SET %s = %d;",
             tableName, col.REGISTRATION_DATE, currentTimestamp));
-        ConsoleLogger.info("Created column '" + col.REGISTRATION_DATE + "' and set the current timestamp, "
+        logger.info("Created column '" + col.REGISTRATION_DATE + "' and set the current timestamp, "
             + currentTimestamp + ", to all " + updatedRows + " rows");
     }
 

--- a/src/main/java/fr/xephi/authme/datasource/SqLiteMigrater.java
+++ b/src/main/java/fr/xephi/authme/datasource/SqLiteMigrater.java
@@ -2,6 +2,7 @@ package fr.xephi.authme.datasource;
 
 import com.google.common.io.Files;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.DatabaseSettings;
 import fr.xephi.authme.util.FileUtils;
@@ -19,6 +20,7 @@ import java.sql.Statement;
  */
 class SqLiteMigrater {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(SqLiteMigrater.class);
     private final File dataFolder;
     private final String databaseName;
     private final String tableName;
@@ -53,13 +55,13 @@ class SqLiteMigrater {
      * @param sqLite the instance to migrate
      */
     void performMigration(SQLite sqLite) throws SQLException {
-        ConsoleLogger.warning("YOUR SQLITE DATABASE NEEDS MIGRATING! DO NOT TURN OFF YOUR SERVER");
+        logger.warning("YOUR SQLITE DATABASE NEEDS MIGRATING! DO NOT TURN OFF YOUR SERVER");
 
         String backupName = createBackup();
-        ConsoleLogger.info("Made a backup of your database at 'backups/" + backupName + "'");
+        logger.info("Made a backup of your database at 'backups/" + backupName + "'");
 
         recreateDatabaseWithNewDefinitions(sqLite);
-        ConsoleLogger.info("SQLite database migrated successfully");
+        logger.info("SQLite database migrated successfully");
     }
 
     private String createBackup() {
@@ -104,7 +106,7 @@ class SqLiteMigrater {
                 + " CASE WHEN $email = 'your@email.com' THEN NULL ELSE $email END, $isLogged"
                 + " FROM " + tempTable + ";";
             int insertedEntries = st.executeUpdate(replaceColumnVariables(copySql));
-            ConsoleLogger.info("Copied over " + insertedEntries + " from the old table to the new one");
+            logger.info("Copied over " + insertedEntries + " from the old table to the new one");
 
             st.execute("DROP TABLE " + tempTable + ";");
         }

--- a/src/main/java/fr/xephi/authme/datasource/SqlDataSourceUtils.java
+++ b/src/main/java/fr/xephi/authme/datasource/SqlDataSourceUtils.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.datasource;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -11,6 +12,8 @@ import java.sql.SQLException;
  */
 public final class SqlDataSourceUtils {
 
+    private static final ConsoleLogger logger = ConsoleLoggerFactory.get(SqlDataSourceUtils.class);
+
     private SqlDataSourceUtils() {
     }
 
@@ -20,7 +23,7 @@ public final class SqlDataSourceUtils {
      * @param e the exception to log
      */
     public static void logSqlException(SQLException e) {
-        ConsoleLogger.logException("Error during SQL operation:", e);
+        logger.logException("Error during SQL operation:", e);
     }
 
     /**
@@ -58,7 +61,7 @@ public final class SqlDataSourceUtils {
             if (nullableCode == DatabaseMetaData.columnNoNulls) {
                 return true;
             } else if (nullableCode == DatabaseMetaData.columnNullableUnknown) {
-                ConsoleLogger.warning("Unknown nullable status for column '" + columnName + "'");
+                logger.warning("Unknown nullable status for column '" + columnName + "'");
             }
         }
         return false;

--- a/src/main/java/fr/xephi/authme/datasource/converter/AbstractDataSourceConverter.java
+++ b/src/main/java/fr/xephi/authme/datasource/converter/AbstractDataSourceConverter.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.datasource.DataSourceType;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import org.bukkit.command.CommandSender;
 
 import java.util.ArrayList;
@@ -18,8 +19,10 @@ import static fr.xephi.authme.util.Utils.logAndSendMessage;
  */
 public abstract class AbstractDataSourceConverter<S extends DataSource> implements Converter {
 
-    private DataSource destination;
-    private DataSourceType destinationType;
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(MySqlToSqlite.class);
+
+    private final DataSource destination;
+    private final DataSourceType destinationType;
 
     /**
      * Constructor.
@@ -51,7 +54,7 @@ public abstract class AbstractDataSourceConverter<S extends DataSource> implemen
             source = getSource();
         } catch (Exception e) {
             logAndSendMessage(sender, "The data source to convert from could not be initialized");
-            ConsoleLogger.logException("Could not initialize source:", e);
+            logger.logException("Could not initialize source:", e);
             return;
         }
 
@@ -60,7 +63,6 @@ public abstract class AbstractDataSourceConverter<S extends DataSource> implemen
             if (destination.isAuthAvailable(auth.getNickname())) {
                 skippedPlayers.add(auth.getNickname());
             } else {
-                adaptPlayerAuth(auth);
                 destination.saveAuth(auth);
                 destination.updateSession(auth);
                 destination.updateQuitLoc(auth);
@@ -73,15 +75,6 @@ public abstract class AbstractDataSourceConverter<S extends DataSource> implemen
         }
         logAndSendMessage(sender, "Database successfully converted from " + source.getType()
             + " to " + destinationType);
-    }
-
-    /**
-     * Adapts the PlayerAuth from the source before it is saved in the destination.
-     *
-     * @param auth the auth from the source
-     */
-    protected void adaptPlayerAuth(PlayerAuth auth) {
-        // noop
     }
 
     /**

--- a/src/main/java/fr/xephi/authme/datasource/converter/CrazyLoginConverter.java
+++ b/src/main/java/fr/xephi/authme/datasource/converter/CrazyLoginConverter.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.DataFolder;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.ConverterSettings;
 import org.bukkit.command.CommandSender;
@@ -18,6 +19,8 @@ import java.io.IOException;
  * Converter for CrazyLogin to AuthMe.
  */
 public class CrazyLoginConverter implements Converter {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(CrazyLoginConverter.class);
 
     private final DataSource database;
     private final Settings settings;
@@ -46,10 +49,10 @@ public class CrazyLoginConverter implements Converter {
                     migrateAccount(line);
                 }
             }
-            ConsoleLogger.info("CrazyLogin database has been imported correctly");
+            logger.info("CrazyLogin database has been imported correctly");
         } catch (IOException ex) {
-            ConsoleLogger.warning("Can't open the crazylogin database file! Does it exist?");
-            ConsoleLogger.logException("Encountered", ex);
+            logger.warning("Can't open the crazylogin database file! Does it exist?");
+            logger.logException("Encountered", ex);
         }
     }
 

--- a/src/main/java/fr/xephi/authme/datasource/converter/LoginSecurityConverter.java
+++ b/src/main/java/fr/xephi/authme/datasource/converter/LoginSecurityConverter.java
@@ -5,6 +5,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.DataFolder;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.ConverterSettings;
 import org.bukkit.command.CommandSender;
@@ -29,6 +30,7 @@ import static fr.xephi.authme.util.Utils.logAndSendMessage;
  */
 public class LoginSecurityConverter implements Converter {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(LoginSecurityConverter.class);
     private final File dataFolder;
     private final DataSource dataSource;
 
@@ -58,7 +60,7 @@ public class LoginSecurityConverter implements Converter {
             }
         } catch (SQLException e) {
             sender.sendMessage("Failed to convert from SQLite. Please see the log for more info");
-            ConsoleLogger.logException("Could not fetch or migrate data:", e);
+            logger.logException("Could not fetch or migrate data:", e);
         }
     }
 
@@ -185,7 +187,7 @@ public class LoginSecurityConverter implements Converter {
             return DriverManager.getConnection(
                 "jdbc:sqlite:" + path, "trump", "donald");
         } catch (SQLException e) {
-            ConsoleLogger.logException("Could not connect to SQLite database", e);
+            logger.logException("Could not connect to SQLite database", e);
             return null;
         }
     }
@@ -195,7 +197,7 @@ public class LoginSecurityConverter implements Converter {
             return DriverManager.getConnection(
                 "jdbc:mysql://" + mySqlHost + "/" + mySqlDatabase, mySqlUser, mySqlPassword);
         } catch (SQLException e) {
-            ConsoleLogger.logException("Could not connect to SQLite database", e);
+            logger.logException("Could not connect to SQLite database", e);
             return null;
         }
     }

--- a/src/main/java/fr/xephi/authme/datasource/converter/RakamakConverter.java
+++ b/src/main/java/fr/xephi/authme/datasource/converter/RakamakConverter.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.DataFolder;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.security.PasswordSecurity;
 import fr.xephi.authme.security.crypts.HashedPassword;
 import fr.xephi.authme.settings.Settings;
@@ -25,6 +26,7 @@ import java.util.Map.Entry;
  */
 public class RakamakConverter implements Converter {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(RakamakConverter.class);
     private final DataSource database;
     private final Settings settings;
     private final File pluginFolder;
@@ -88,7 +90,7 @@ public class RakamakConverter implements Converter {
             }
             Utils.logAndSendMessage(sender, "Rakamak database has been imported successfully");
         } catch (IOException ex) {
-            ConsoleLogger.logException("Can't open the rakamak database file! Does it exist?", ex);
+            logger.logException("Can't open the rakamak database file! Does it exist?", ex);
         }
     }
 }

--- a/src/main/java/fr/xephi/authme/datasource/converter/RoyalAuthConverter.java
+++ b/src/main/java/fr/xephi/authme/datasource/converter/RoyalAuthConverter.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -18,6 +19,9 @@ public class RoyalAuthConverter implements Converter {
 
     private static final String LAST_LOGIN_PATH = "timestamps.quit";
     private static final String PASSWORD_PATH = "login.password";
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(RoyalAuthConverter.class);
+
     private final AuthMe plugin;
     private final DataSource dataSource;
 
@@ -48,7 +52,7 @@ public class RoyalAuthConverter implements Converter {
                 dataSource.saveAuth(auth);
                 dataSource.updateSession(auth);
             } catch (Exception e) {
-                ConsoleLogger.logException("Error while trying to import " + player.getName() + " RoyalAuth data", e);
+                logger.logException("Error while trying to import " + player.getName() + " RoyalAuth data", e);
             }
         }
     }

--- a/src/main/java/fr/xephi/authme/datasource/converter/VAuthConverter.java
+++ b/src/main/java/fr/xephi/authme/datasource/converter/VAuthConverter.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.DataFolder;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
@@ -18,6 +19,7 @@ import static fr.xephi.authme.util.FileUtils.makePath;
 
 public class VAuthConverter implements Converter {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(VAuthConverter.class);
     private final DataSource dataSource;
     private final File vAuthPasswordsFile;
 
@@ -58,7 +60,7 @@ public class VAuthConverter implements Converter {
                 dataSource.saveAuth(auth);
             }
         } catch (IOException e) {
-            ConsoleLogger.logException("Error while trying to import some vAuth data", e);
+            logger.logException("Error while trying to import some vAuth data", e);
         }
     }
 

--- a/src/main/java/fr/xephi/authme/initialization/DataSourceProvider.java
+++ b/src/main/java/fr/xephi/authme/initialization/DataSourceProvider.java
@@ -9,6 +9,7 @@ import fr.xephi.authme.datasource.MySQL;
 import fr.xephi.authme.datasource.PostgreSqlDataSource;
 import fr.xephi.authme.datasource.SQLite;
 import fr.xephi.authme.datasource.mysqlextensions.MySqlExtensionsFactory;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.DatabaseSettings;
@@ -16,7 +17,6 @@ import fr.xephi.authme.settings.properties.DatabaseSettings;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import java.io.File;
-import java.io.IOException;
 import java.sql.SQLException;
 
 /**
@@ -25,6 +25,8 @@ import java.sql.SQLException;
 public class DataSourceProvider implements Provider<DataSource> {
 
     private static final int SQLITE_MAX_SIZE = 4000;
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(DataSourceProvider.class);
 
     @Inject
     @DataFolder
@@ -46,7 +48,7 @@ public class DataSourceProvider implements Provider<DataSource> {
         try {
             return createDataSource();
         } catch (Exception e) {
-            ConsoleLogger.logException("Could not create data source:", e);
+            logger.logException("Could not create data source:", e);
             throw new IllegalStateException("Error during initialization of data source", e);
         }
     }
@@ -54,11 +56,10 @@ public class DataSourceProvider implements Provider<DataSource> {
     /**
      * Sets up the data source.
      *
-     * @return the constructed datasource
-     * @throws SQLException           when initialization of a SQL datasource failed
-     * @throws IOException            if flat file cannot be read
+     * @return the constructed data source
+     * @throws SQLException when initialization of a SQL data source failed
      */
-    private DataSource createDataSource() throws SQLException, IOException {
+    private DataSource createDataSource() throws SQLException {
         DataSourceType dataSourceType = settings.getProperty(DatabaseSettings.BACKEND);
         DataSource dataSource;
         switch (dataSourceType) {
@@ -88,7 +89,7 @@ public class DataSourceProvider implements Provider<DataSource> {
         bukkitService.runTaskAsynchronously(() -> {
             int accounts = dataSource.getAccountsRegistered();
             if (accounts >= SQLITE_MAX_SIZE) {
-                ConsoleLogger.warning("YOU'RE USING THE SQLITE DATABASE WITH "
+                logger.warning("YOU'RE USING THE SQLITE DATABASE WITH "
                     + accounts + "+ ACCOUNTS; FOR BETTER PERFORMANCE, PLEASE UPGRADE TO MYSQL!!");
             }
         });

--- a/src/main/java/fr/xephi/authme/initialization/OnStartupTasks.java
+++ b/src/main/java/fr/xephi/authme/initialization/OnStartupTasks.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.initialization;
 import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
 import fr.xephi.authme.output.ConsoleFilter;
@@ -27,6 +28,8 @@ import static fr.xephi.authme.settings.properties.EmailSettings.RECALL_PLAYERS;
  * Contains actions such as migrations that should be performed on startup.
  */
 public class OnStartupTasks {
+
+    private static ConsoleLogger consoleLogger = ConsoleLoggerFactory.get(OnStartupTasks.class);
 
     @Inject
     private DataSource dataSource;
@@ -58,17 +61,16 @@ public class OnStartupTasks {
     /**
      * Sets up the console filter if enabled.
      *
-     * @param settings the settings
-     * @param logger   the plugin logger
+     * @param logger the plugin logger
      */
-    public static void setupConsoleFilter(Settings settings, Logger logger) {
+    public static void setupConsoleFilter(Logger logger) {
         // Try to set the log4j filter
         try {
             Class.forName("org.apache.logging.log4j.core.filter.AbstractFilter");
             setLog4JFilter();
         } catch (ClassNotFoundException | NoClassDefFoundError e) {
             // log4j is not available
-            ConsoleLogger.info("You're using Minecraft 1.6.x or older, Log4J support will be disabled");
+            consoleLogger.info("You're using Minecraft 1.6.x or older, Log4J support will be disabled");
             ConsoleFilter filter = new ConsoleFilter();
             logger.setFilter(filter);
             Bukkit.getLogger().setFilter(filter);

--- a/src/main/java/fr/xephi/authme/listener/EntityListener.java
+++ b/src/main/java/fr/xephi/authme/listener/EntityListener.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.listener;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -22,18 +23,21 @@ import java.lang.reflect.Method;
 
 public class EntityListener implements Listener {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(EntityListener.class);
     private final ListenerService listenerService;
+
     private Method getShooter;
     private boolean shooterIsLivingEntity;
 
     @Inject
     EntityListener(ListenerService listenerService) {
         this.listenerService = listenerService;
+
         try {
             getShooter = Projectile.class.getDeclaredMethod("getShooter");
             shooterIsLivingEntity = getShooter.getReturnType() == LivingEntity.class;
         } catch (NoSuchMethodException | SecurityException e) {
-            ConsoleLogger.logException("Cannot load getShooter() method on Projectile class", e);
+            logger.logException("Cannot load getShooter() method on Projectile class", e);
         }
     }
 
@@ -107,7 +111,7 @@ public class EntityListener implements Listener {
                 }
                 shooterRaw = getShooter.invoke(projectile);
             } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                ConsoleLogger.logException("Error getting shooter", e);
+                logger.logException("Error getting shooter", e);
             }
         } else {
             shooterRaw = projectile.getShooter();

--- a/src/main/java/fr/xephi/authme/listener/OnJoinVerifier.java
+++ b/src/main/java/fr/xephi/authme/listener/OnJoinVerifier.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
 import fr.xephi.authme.permission.PermissionsManager;
@@ -30,6 +31,8 @@ import java.util.regex.Pattern;
  * Service for performing various verifications when a player joins.
  */
 public class OnJoinVerifier implements Reloadable {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(OnJoinVerifier.class);
 
     @Inject
     private Settings settings;
@@ -139,7 +142,7 @@ public class OnJoinVerifier implements Reloadable {
             event.allow();
             return false;
         } else {
-            ConsoleLogger.info("VIP player " + player.getName() + " tried to join, but the server was full");
+            logger.info("VIP player " + player.getName() + " tried to join, but the server was full");
             event.setKickMessage(messages.retrieveSingle(player, MessageKey.KICK_FULL_SERVER));
             return true;
         }

--- a/src/main/java/fr/xephi/authme/listener/PlayerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/PlayerListener.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.QuickCommandsProtectionManager;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
 import fr.xephi.authme.permission.PermissionsManager;
@@ -68,6 +69,8 @@ import static fr.xephi.authme.settings.properties.RestrictionSettings.ALLOW_UNAU
  * Listener class for player events.
  */
 public class PlayerListener implements Listener {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(PlayerListener.class);
 
     @Inject
     private Settings settings;
@@ -289,7 +292,7 @@ public class PlayerListener implements Listener {
         try {
             permissionsManager.loadUserData(event.getUniqueId());
         } catch (PermissionLoadUserException e) {
-            ConsoleLogger.logException("Unable to load the permission data of user " + name, e);
+            logger.logException("Unable to load the permission data of user " + name, e);
         }
 
         // getAddress() sometimes returning null if not yet resolved

--- a/src/main/java/fr/xephi/authme/listener/ServerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/ServerListener.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.listener;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.listener.protocollib.ProtocolLibService;
 import fr.xephi.authme.permission.PermissionsManager;
 import fr.xephi.authme.service.PluginHookService;
@@ -14,8 +15,11 @@ import org.bukkit.event.server.PluginEnableEvent;
 import javax.inject.Inject;
 
 /**
+ * Listener for server events.
  */
 public class ServerListener implements Listener {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(ServerListener.class);
 
     @Inject
     private PluginHookService pluginHookService;
@@ -40,20 +44,20 @@ public class ServerListener implements Listener {
 
         if ("Essentials".equalsIgnoreCase(pluginName)) {
             pluginHookService.unhookEssentials();
-            ConsoleLogger.info("Essentials has been disabled: unhooking");
+            logger.info("Essentials has been disabled: unhooking");
         } else if ("CMI".equalsIgnoreCase(pluginName)) {
             pluginHookService.unhookCmi();
             spawnLoader.unloadCmiSpawn();
-            ConsoleLogger.info("CMI has been disabled: unhooking");
+            logger.info("CMI has been disabled: unhooking");
         } else if ("Multiverse-Core".equalsIgnoreCase(pluginName)) {
             pluginHookService.unhookMultiverse();
-            ConsoleLogger.info("Multiverse-Core has been disabled: unhooking");
+            logger.info("Multiverse-Core has been disabled: unhooking");
         } else if ("EssentialsSpawn".equalsIgnoreCase(pluginName)) {
             spawnLoader.unloadEssentialsSpawn();
-            ConsoleLogger.info("EssentialsSpawn has been disabled: unhooking");
+            logger.info("EssentialsSpawn has been disabled: unhooking");
         } else if ("ProtocolLib".equalsIgnoreCase(pluginName)) {
             protocolLibService.disable();
-            ConsoleLogger.warning("ProtocolLib has been disabled, unhooking packet adapters!");
+            logger.warning("ProtocolLib has been disabled, unhooking packet adapters!");
         }
     }
 

--- a/src/main/java/fr/xephi/authme/listener/protocollib/InventoryPacketAdapter.java
+++ b/src/main/java/fr/xephi/authme/listener/protocollib/InventoryPacketAdapter.java
@@ -28,8 +28,8 @@ import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.BukkitService;
-
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -48,6 +48,7 @@ class InventoryPacketAdapter extends PacketAdapter {
     private static final int MAIN_SIZE = 27;
     private static final int HOTBAR_SIZE = 9;
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(InventoryPacketAdapter.class);
     private final PlayerCache playerCache;
     private final DataSource dataSource;
 
@@ -106,7 +107,7 @@ class InventoryPacketAdapter extends PacketAdapter {
         try {
             protocolManager.sendServerPacket(player, inventoryPacket, false);
         } catch (InvocationTargetException invocationExc) {
-            ConsoleLogger.logException("Error during sending blank inventory", invocationExc);
+            logger.logException("Error during sending blank inventory", invocationExc);
         }
     }
 }

--- a/src/main/java/fr/xephi/authme/listener/protocollib/ProtocolLibService.java
+++ b/src/main/java/fr/xephi/authme/listener/protocollib/ProtocolLibService.java
@@ -6,6 +6,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.SettingsDependent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.RestrictionSettings;
@@ -15,6 +16,8 @@ import javax.inject.Inject;
 
 @NoFieldScan
 public class ProtocolLibService implements SettingsDependent {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(ProtocolLibService.class);
 
     /* Packet Adapters */
     private InventoryPacketAdapter inventoryPacketAdapter;
@@ -26,10 +29,10 @@ public class ProtocolLibService implements SettingsDependent {
 
     /* Service */
     private boolean isEnabled;
-    private AuthMe plugin;
-    private BukkitService bukkitService;
-    private PlayerCache playerCache;
-    private DataSource dataSource;
+    private final AuthMe plugin;
+    private final BukkitService bukkitService;
+    private final PlayerCache playerCache;
+    private final DataSource dataSource;
 
     @Inject
     ProtocolLibService(AuthMe plugin, Settings settings, BukkitService bukkitService, PlayerCache playerCache,
@@ -48,11 +51,11 @@ public class ProtocolLibService implements SettingsDependent {
         // Check if ProtocolLib is enabled on the server.
         if (!plugin.getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
             if (protectInvBeforeLogin) {
-                ConsoleLogger.warning("WARNING! The protectInventory feature requires ProtocolLib! Disabling it...");
+                logger.warning("WARNING! The protectInventory feature requires ProtocolLib! Disabling it...");
             }
 
             if (denyTabCompleteBeforeLogin) {
-                ConsoleLogger.warning("WARNING! The denyTabComplete feature requires ProtocolLib! Disabling it...");
+                logger.warning("WARNING! The denyTabComplete feature requires ProtocolLib! Disabling it...");
             }
 
             this.isEnabled = false;

--- a/src/main/java/fr/xephi/authme/listener/protocollib/TabCompletePacketAdapter.java
+++ b/src/main/java/fr/xephi/authme/listener/protocollib/TabCompletePacketAdapter.java
@@ -9,9 +9,11 @@ import com.comphenix.protocol.reflect.FieldAccessException;
 import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerCache;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 
 class TabCompletePacketAdapter extends PacketAdapter {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(TabCompletePacketAdapter.class);
     private final PlayerCache playerCache;
 
     TabCompletePacketAdapter(AuthMe plugin, PlayerCache playerCache) {
@@ -27,7 +29,7 @@ class TabCompletePacketAdapter extends PacketAdapter {
                     event.setCancelled(true);
                 }
             } catch (FieldAccessException e) {
-                ConsoleLogger.logException("Couldn't access field:", e);
+                logger.logException("Couldn't access field:", e);
             }
         }
     }

--- a/src/main/java/fr/xephi/authme/mail/EmailService.java
+++ b/src/main/java/fr/xephi/authme/mail/EmailService.java
@@ -2,6 +2,7 @@ package fr.xephi.authme.mail;
 
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.initialization.DataFolder;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.EmailSettings;
 import fr.xephi.authme.settings.properties.PluginSettings;
@@ -21,6 +22,8 @@ import java.io.IOException;
  * Creates emails and sends them.
  */
 public class EmailService {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(EmailService.class);
 
     private final File dataFolder;
     private final Settings settings;
@@ -48,7 +51,7 @@ public class EmailService {
      */
     public boolean sendPasswordMail(String name, String mailAddress, String newPass) {
         if (!hasAllInformation()) {
-            ConsoleLogger.warning("Cannot perform email registration: not all email settings are complete");
+            logger.warning("Cannot perform email registration: not all email settings are complete");
             return false;
         }
 
@@ -56,7 +59,7 @@ public class EmailService {
         try {
             email = sendMailSsl.initializeMail(mailAddress);
         } catch (EmailException e) {
-            ConsoleLogger.logException("Failed to create email with the given settings:", e);
+            logger.logException("Failed to create email with the given settings:", e);
             return false;
         }
 
@@ -68,7 +71,7 @@ public class EmailService {
                 file = generatePasswordImage(name, newPass);
                 mailText = embedImageIntoEmailContent(file, email, mailText);
             } catch (IOException | EmailException e) {
-                ConsoleLogger.logException(
+                logger.logException(
                     "Unable to send new password as image for email " + mailAddress + ":", e);
             }
         }
@@ -88,7 +91,7 @@ public class EmailService {
      */
     public boolean sendVerificationMail(String name, String mailAddress, String code) {
         if (!hasAllInformation()) {
-            ConsoleLogger.warning("Cannot send verification email: not all email settings are complete");
+            logger.warning("Cannot send verification email: not all email settings are complete");
             return false;
         }
 
@@ -96,7 +99,7 @@ public class EmailService {
         try {
             email = sendMailSsl.initializeMail(mailAddress);
         } catch (EmailException e) {
-            ConsoleLogger.logException("Failed to create verification email with the given settings:", e);
+            logger.logException("Failed to create verification email with the given settings:", e);
             return false;
         }
 
@@ -118,7 +121,7 @@ public class EmailService {
         try {
             htmlEmail = sendMailSsl.initializeMail(email);
         } catch (EmailException e) {
-            ConsoleLogger.logException("Failed to create email for recovery code:", e);
+            logger.logException("Failed to create email for recovery code:", e);
             return false;
         }
 

--- a/src/main/java/fr/xephi/authme/mail/SendMailSsl.java
+++ b/src/main/java/fr/xephi/authme/mail/SendMailSsl.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.mail;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.output.LogLevel;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.EmailSettings;
@@ -25,6 +26,8 @@ import static fr.xephi.authme.settings.properties.EmailSettings.MAIL_PASSWORD;
  * Sends emails to players on behalf of the server.
  */
 public class SendMailSsl {
+
+    private ConsoleLogger logger = ConsoleLoggerFactory.get(SendMailSsl.class);
 
     @Inject
     private Settings settings;
@@ -96,14 +99,14 @@ public class SendMailSsl {
             email.setHtmlMsg(content);
             email.setTextMsg(content);
         } catch (EmailException e) {
-            ConsoleLogger.logException("Your email.html config contains an error and cannot be sent:", e);
+            logger.logException("Your email.html config contains an error and cannot be sent:", e);
             return false;
         }
         try {
             email.send();
             return true;
         } catch (EmailException e) {
-            ConsoleLogger.logException("Failed to send a mail to " + email.getToAddresses() + ":", e);
+            logger.logException("Failed to send a mail to " + email.getToAddresses() + ":", e);
             return false;
         }
     }

--- a/src/main/java/fr/xephi/authme/message/AbstractMessageFileHandler.java
+++ b/src/main/java/fr/xephi/authme/message/AbstractMessageFileHandler.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.initialization.DataFolder;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.PluginSettings;
 import fr.xephi.authme.util.FileUtils;
@@ -20,6 +21,8 @@ import static fr.xephi.authme.message.MessagePathHelper.DEFAULT_LANGUAGE;
  * Handles a YAML message file with a default file fallback.
  */
 public abstract class AbstractMessageFileHandler implements Reloadable {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(AbstractMessageFileHandler.class);
 
     @DataFolder
     @Inject
@@ -116,8 +119,7 @@ public abstract class AbstractMessageFileHandler implements Reloadable {
         if (FileUtils.copyFileFromResource(file, defaultFile)) {
             return file;
         } else {
-            ConsoleLogger.warning("Wanted to copy default messages file '" + defaultFile
-                + "' from JAR but it didn't exist");
+            logger.warning("Wanted to copy default messages file '" + defaultFile + "' from JAR but it didn't exist");
             return null;
         }
     }

--- a/src/main/java/fr/xephi/authme/message/HelpMessagesFileHandler.java
+++ b/src/main/java/fr/xephi/authme/message/HelpMessagesFileHandler.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.message;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.util.FileUtils;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -15,6 +16,8 @@ import static fr.xephi.authme.message.MessagePathHelper.DEFAULT_LANGUAGE;
  * File handler for the help_xx.yml resource.
  */
 public class HelpMessagesFileHandler extends AbstractMessageFileHandler {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(HelpMessagesFileHandler.class);
 
     private FileConfiguration defaultConfiguration;
 
@@ -33,7 +36,7 @@ public class HelpMessagesFileHandler extends AbstractMessageFileHandler {
         String message = getMessageIfExists(key);
 
         if (message == null) {
-            ConsoleLogger.warning("Error getting message with key '" + key + "'. "
+            logger.warning("Error getting message with key '" + key + "'. "
                 + "Please update your config file '" + getFilename() + "' or run /authme messages help");
             return getDefault(key);
         }

--- a/src/main/java/fr/xephi/authme/message/Messages.java
+++ b/src/main/java/fr/xephi/authme/message/Messages.java
@@ -2,6 +2,8 @@ package fr.xephi.authme.message;
 
 import com.google.common.collect.ImmutableMap;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
+import fr.xephi.authme.mail.EmailService;
 import fr.xephi.authme.util.expiring.Duration;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -36,6 +38,8 @@ public class Messages {
         .put(TimeUnit.MINUTES, MessageKey.MINUTES)
         .put(TimeUnit.HOURS, MessageKey.HOURS)
         .put(TimeUnit.DAYS, MessageKey.DAYS).build();
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(EmailService.class);
 
     private MessagesFileHandler messagesFileHandler;
 
@@ -162,7 +166,7 @@ public class Messages {
                 message = message.replace(tags[i], replacements[i]);
             }
         } else {
-            ConsoleLogger.warning("Invalid number of replacements for message key '" + key + "'");
+            logger.warning("Invalid number of replacements for message key '" + key + "'");
         }
         return message;
     }
@@ -185,7 +189,7 @@ public class Messages {
                 message = message.replace(tags[i], replacements[i]);
             }
         } else {
-            ConsoleLogger.warning("Invalid number of replacements for message key '" + key + "'");
+            logger.warning("Invalid number of replacements for message key '" + key + "'");
         }
         return message;
     }

--- a/src/main/java/fr/xephi/authme/message/MessagesFileHandler.java
+++ b/src/main/java/fr/xephi/authme/message/MessagesFileHandler.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.message;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.updater.MessageUpdater;
 
 import javax.inject.Inject;
@@ -11,6 +12,8 @@ import static fr.xephi.authme.message.MessagePathHelper.DEFAULT_LANGUAGE;
  * File handler for the messages_xx.yml resource.
  */
 public class MessagesFileHandler extends AbstractMessageFileHandler {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(MessagesFileHandler.class);
 
     @Inject
     private MessageUpdater messageUpdater;
@@ -31,7 +34,7 @@ public class MessagesFileHandler extends AbstractMessageFileHandler {
             getUserLanguageFile(), createFilePath(language), createFilePath(DEFAULT_LANGUAGE));
         if (hasChange) {
             if (isFromReload) {
-                ConsoleLogger.warning("Migration after reload attempt");
+                logger.warning("Migration after reload attempt");
             } else {
                 reloadInternal(true);
             }

--- a/src/main/java/fr/xephi/authme/message/updater/JarMessageSource.java
+++ b/src/main/java/fr/xephi/authme/message/updater/JarMessageSource.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.message.updater;
 import ch.jalu.configme.properties.Property;
 import ch.jalu.configme.resource.PropertyReader;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.util.FileUtils;
 
 import java.io.IOException;
@@ -14,6 +15,7 @@ import java.io.InputStream;
  */
 public class JarMessageSource {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(JarMessageSource.class);
     private final PropertyReader localJarMessages;
     private final PropertyReader defaultJarMessages;
 
@@ -42,15 +44,15 @@ public class JarMessageSource {
         return reader == null ? null : reader.getString(path);
     }
 
-    private static MessageMigraterPropertyReader loadJarFile(String jarPath) {
+    private MessageMigraterPropertyReader loadJarFile(String jarPath) {
         try (InputStream stream = FileUtils.getResourceFromJar(jarPath)) {
             if (stream == null) {
-                ConsoleLogger.debug("Could not load '" + jarPath + "' from JAR");
+                logger.debug("Could not load '" + jarPath + "' from JAR");
                 return null;
             }
             return MessageMigraterPropertyReader.loadFromStream(stream);
         } catch (IOException e) {
-            ConsoleLogger.logException("Exception while handling JAR path '" + jarPath + "'", e);
+            logger.logException("Exception while handling JAR path '" + jarPath + "'", e);
         }
         return null;
     }

--- a/src/main/java/fr/xephi/authme/message/updater/MessageUpdater.java
+++ b/src/main/java/fr/xephi/authme/message/updater/MessageUpdater.java
@@ -9,6 +9,7 @@ import ch.jalu.configme.resource.PropertyResource;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.util.FileUtils;
 
@@ -28,6 +29,8 @@ import static java.util.Collections.singletonList;
  * Migrates the used messages file to a complete, up-to-date version when necessary.
  */
 public class MessageUpdater {
+
+    private ConsoleLogger logger = ConsoleLoggerFactory.get(MessageUpdater.class);
 
     /**
      * Applies any necessary migrations to the user's messages file and saves it if it has been modified.
@@ -68,7 +71,7 @@ public class MessageUpdater {
             backupMessagesFile(userFile);
 
             userResource.exportProperties(configurationData);
-            ConsoleLogger.debug("Successfully saved {0}", userFile);
+            logger.debug("Successfully saved {0}", userFile);
             return true;
         }
         return false;
@@ -91,7 +94,7 @@ public class MessageUpdater {
     private boolean migrateOldKeys(PropertyReader propertyReader, MessageKeyConfigurationData configurationData) {
         boolean hasChange = OldMessageKeysMigrater.migrateOldPaths(propertyReader, configurationData);
         if (hasChange) {
-            ConsoleLogger.info("Old keys have been moved to the new ones in your messages_xx.yml file");
+            logger.info("Old keys have been moved to the new ones in your messages_xx.yml file");
         }
         return hasChange;
     }
@@ -106,7 +109,7 @@ public class MessageUpdater {
             }
         }
         if (!addedKeys.isEmpty()) {
-            ConsoleLogger.info(
+            logger.info(
                 "Added " + addedKeys.size() + " missing keys to your messages_xx.yml file: " + addedKeys);
             return true;
         }

--- a/src/main/java/fr/xephi/authme/output/ConsoleLoggerFactory.java
+++ b/src/main/java/fr/xephi/authme/output/ConsoleLoggerFactory.java
@@ -1,0 +1,51 @@
+package fr.xephi.authme.output;
+
+import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.settings.Settings;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Creates and keeps track of {@link ConsoleLogger} instances.
+ */
+public final class ConsoleLoggerFactory {
+
+    private static final Map<String, ConsoleLogger> consoleLoggers = new ConcurrentHashMap<>();
+    private static Settings settings;
+
+    private ConsoleLoggerFactory() {
+    }
+
+    /**
+     * Creates or returns the already existing logger associated with the given class.
+     *
+     * @param owningClass the class whose logger should be retrieved
+     * @return logger for the given class
+     */
+    public static ConsoleLogger get(Class<?> owningClass) {
+        String name = owningClass.getCanonicalName();
+        return consoleLoggers.computeIfAbsent(name, ConsoleLoggerFactory::createLogger);
+    }
+
+    /**
+     * Sets up all loggers according to the properties returned by the settings instance.
+     *
+     * @param settings the settings instance
+     */
+    public static void reloadSettings(Settings settings) {
+        ConsoleLoggerFactory.settings = settings;
+        ConsoleLogger.initializeSharedSettings(settings);
+
+        consoleLoggers.values()
+            .forEach(logger -> logger.initializeSettings(settings));
+    }
+
+    private static ConsoleLogger createLogger(String name) {
+        ConsoleLogger logger = new ConsoleLogger(name);
+        if (settings != null) {
+            logger.initializeSettings(settings);
+        }
+        return logger;
+    }
+}

--- a/src/main/java/fr/xephi/authme/permission/PermissionsManager.java
+++ b/src/main/java/fr/xephi/authme/permission/PermissionsManager.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.permission;
 import com.google.common.annotations.VisibleForTesting;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.listener.JoiningPlayer;
 import fr.xephi.authme.permission.handlers.LuckPermsHandler;
 import fr.xephi.authme.permission.handlers.PermissionHandler;
@@ -40,6 +41,7 @@ import java.util.UUID;
  */
 public class PermissionsManager implements Reloadable {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(PermissionsManager.class);
     private final Server server;
     private final PluginManager pluginManager;
     private final Settings settings;
@@ -78,11 +80,11 @@ public class PermissionsManager implements Reloadable {
                 if (handler != null) {
                     // Show a success message and return
                     this.handler = handler;
-                    ConsoleLogger.info("Hooked into " + PermissionsSystemType.VAULT.getDisplayName() + "!");
+                    logger.info("Hooked into " + PermissionsSystemType.VAULT.getDisplayName() + "!");
                     return;
                 }
             } catch (PermissionHandlerException e) {
-                ConsoleLogger.logException("Failed to create Vault hook (forced):", e);
+                logger.logException("Failed to create Vault hook (forced):", e);
             }
         } else {
             // Loop through all the available permissions system types
@@ -92,18 +94,18 @@ public class PermissionsManager implements Reloadable {
                     if (handler != null) {
                         // Show a success message and return
                         this.handler = handler;
-                        ConsoleLogger.info("Hooked into " + type.getDisplayName() + "!");
+                        logger.info("Hooked into " + type.getDisplayName() + "!");
                         return;
                     }
                 } catch (Exception ex) {
                     // An error occurred, show a warning message
-                    ConsoleLogger.logException("Error while hooking into " + type.getDisplayName(), ex);
+                    logger.logException("Error while hooking into " + type.getDisplayName(), ex);
                 }
             }
         }
 
         // No recognized permissions system found, show a message and return
-        ConsoleLogger.info("No supported permissions system found! Permissions are disabled!");
+        logger.info("No supported permissions system found! Permissions are disabled!");
     }
 
     /**
@@ -125,7 +127,7 @@ public class PermissionsManager implements Reloadable {
 
         // Make sure the plugin is enabled before hooking
         if (!plugin.isEnabled()) {
-            ConsoleLogger.info("Not hooking into " + type.getDisplayName() + " because it's disabled!");
+            logger.info("Not hooking into " + type.getDisplayName() + " because it's disabled!");
             return null;
         }
 
@@ -151,7 +153,7 @@ public class PermissionsManager implements Reloadable {
         this.handler = null;
 
         // Print a status message to the console
-        ConsoleLogger.info("Unhooked from Permissions!");
+        logger.info("Unhooked from Permissions!");
     }
 
     /**
@@ -174,7 +176,7 @@ public class PermissionsManager implements Reloadable {
     public void onPluginEnable(String pluginName) {
         // Check if any known permissions system is enabling
         if (PermissionsSystemType.isPermissionSystem(pluginName)) {
-            ConsoleLogger.info(pluginName + " plugin enabled, dynamically updating permissions hooks!");
+            logger.info(pluginName + " plugin enabled, dynamically updating permissions hooks!");
             setup();
         }
     }
@@ -187,7 +189,7 @@ public class PermissionsManager implements Reloadable {
     public void onPluginDisable(String pluginName) {
         // Check if any known permission system is being disabled
         if (PermissionsSystemType.isPermissionSystem(pluginName)) {
-            ConsoleLogger.info(pluginName + " plugin disabled, updating hooks!");
+            logger.info(pluginName + " plugin disabled, updating hooks!");
             setup();
         }
     }
@@ -454,7 +456,7 @@ public class PermissionsManager implements Reloadable {
         try {
             loadUserData(offlinePlayer.getUniqueId());
         } catch (PermissionLoadUserException e) {
-            ConsoleLogger.logException("Unable to load the permission data of user " + offlinePlayer.getName(), e);
+            logger.logException("Unable to load the permission data of user " + offlinePlayer.getName(), e);
             return false;
         }
         return true;

--- a/src/main/java/fr/xephi/authme/permission/handlers/LuckPermsHandler.java
+++ b/src/main/java/fr/xephi/authme/permission/handlers/LuckPermsHandler.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.permission.handlers;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.permission.PermissionNode;
 import fr.xephi.authme.permission.PermissionsSystemType;
 import me.lucko.luckperms.LuckPerms;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
  */
 public class LuckPermsHandler implements PermissionHandler {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(LuckPermsHandler.class);
     private LuckPermsApi luckPermsApi;
 
     public LuckPermsHandler() throws PermissionHandlerException {
@@ -79,7 +81,7 @@ public class LuckPermsHandler implements PermissionHandler {
     public boolean hasPermissionOffline(String name, PermissionNode node) {
         User user = luckPermsApi.getUser(name);
         if (user == null) {
-            ConsoleLogger.warning("LuckPermsHandler: tried to check permission for offline user "
+            logger.warning("LuckPermsHandler: tried to check permission for offline user "
                 + name + " but it isn't loaded!");
             return false;
         }
@@ -96,7 +98,7 @@ public class LuckPermsHandler implements PermissionHandler {
     public boolean isInGroup(OfflinePlayer player, String group) {
         User user = luckPermsApi.getUser(player.getName());
         if (user == null) {
-            ConsoleLogger.warning("LuckPermsHandler: tried to check group for offline user "
+            logger.warning("LuckPermsHandler: tried to check group for offline user "
                 + player.getName() + " but it isn't loaded!");
             return false;
         }
@@ -112,7 +114,7 @@ public class LuckPermsHandler implements PermissionHandler {
     public boolean removeFromGroup(OfflinePlayer player, String group) {
         User user = luckPermsApi.getUser(player.getName());
         if (user == null) {
-            ConsoleLogger.warning("LuckPermsHandler: tried to remove group for offline user "
+            logger.warning("LuckPermsHandler: tried to remove group for offline user "
                 + player.getName() + " but it isn't loaded!");
             return false;
         }
@@ -133,7 +135,7 @@ public class LuckPermsHandler implements PermissionHandler {
     public boolean setGroup(OfflinePlayer player, String group) {
         User user = luckPermsApi.getUser(player.getName());
         if (user == null) {
-            ConsoleLogger.warning("LuckPermsHandler: tried to set group for offline user "
+            logger.warning("LuckPermsHandler: tried to set group for offline user "
                 + player.getName() + " but it isn't loaded!");
             return false;
         }
@@ -157,7 +159,7 @@ public class LuckPermsHandler implements PermissionHandler {
     public List<String> getGroups(OfflinePlayer player) {
         User user = luckPermsApi.getUser(player.getName());
         if (user == null) {
-            ConsoleLogger.warning("LuckPermsHandler: tried to get groups for offline user "
+            logger.warning("LuckPermsHandler: tried to get groups for offline user "
                 + player.getName() + " but it isn't loaded!");
             return Collections.emptyList();
         }

--- a/src/main/java/fr/xephi/authme/process/changepassword/AsyncChangePassword.java
+++ b/src/main/java/fr/xephi/authme/process/changepassword/AsyncChangePassword.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.process.AsynchronousProcess;
 import fr.xephi.authme.security.PasswordSecurity;
@@ -17,6 +18,8 @@ import org.bukkit.entity.Player;
 import javax.inject.Inject;
 
 public class AsyncChangePassword implements AsynchronousProcess {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(AsyncChangePassword.class);
 
     @Inject
     private DataSource dataSource;
@@ -58,7 +61,7 @@ public class AsyncChangePassword implements AsynchronousProcess {
 
             playerCache.updatePlayer(auth);
             commonService.send(player, MessageKey.PASSWORD_CHANGED_SUCCESS);
-            ConsoleLogger.info(player.getName() + " changed his password");
+            logger.info(player.getName() + " changed his password");
         } else {
             commonService.send(player, MessageKey.WRONG_PASSWORD);
         }
@@ -75,7 +78,7 @@ public class AsyncChangePassword implements AsynchronousProcess {
         final String lowerCaseName = playerName.toLowerCase();
         if (!(playerCache.isAuthenticated(lowerCaseName) || dataSource.isAuthAvailable(lowerCaseName))) {
             if (sender == null) {
-                ConsoleLogger.warning("Tried to change password for user " + lowerCaseName + " but it doesn't exist!");
+                logger.warning("Tried to change password for user " + lowerCaseName + " but it doesn't exist!");
             } else {
                 commonService.send(sender, MessageKey.UNKNOWN_USER);
             }
@@ -87,15 +90,15 @@ public class AsyncChangePassword implements AsynchronousProcess {
             bungeeSender.sendAuthMeBungeecordMessage(MessageType.REFRESH_PASSWORD, lowerCaseName);
             if (sender != null) {
                 commonService.send(sender, MessageKey.PASSWORD_CHANGED_SUCCESS);
-                ConsoleLogger.info(sender.getName() + " changed password of " + lowerCaseName);
+                logger.info(sender.getName() + " changed password of " + lowerCaseName);
             } else {
-                ConsoleLogger.info("Changed password of " + lowerCaseName);
+                logger.info("Changed password of " + lowerCaseName);
             }
         } else {
             if (sender != null) {
                 commonService.send(sender, MessageKey.ERROR);
             }
-            ConsoleLogger.warning("An error occurred while changing password for user " + lowerCaseName + "!");
+            logger.warning("An error occurred while changing password for user " + lowerCaseName + "!");
         }
     }
 }

--- a/src/main/java/fr/xephi/authme/process/email/AsyncAddEmail.java
+++ b/src/main/java/fr/xephi/authme/process/email/AsyncAddEmail.java
@@ -5,6 +5,7 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.EmailChangedEvent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.process.AsynchronousProcess;
 import fr.xephi.authme.service.BukkitService;
@@ -21,6 +22,8 @@ import javax.inject.Inject;
  * Async task to add an email to an account.
  */
 public class AsyncAddEmail implements AsynchronousProcess {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(AsyncAddEmail.class);
 
     @Inject
     private CommonService service;
@@ -65,7 +68,7 @@ public class AsyncAddEmail implements AsynchronousProcess {
                 EmailChangedEvent event = bukkitService.createAndCallEvent(isAsync
                     -> new EmailChangedEvent(player, null, email, isAsync));
                 if (event.isCancelled()) {
-                    ConsoleLogger.info("Could not add email to player '" + player + "' – event was cancelled");
+                    logger.info("Could not add email to player '" + player + "' – event was cancelled");
                     service.send(player, MessageKey.EMAIL_ADD_NOT_ALLOWED);
                     return;
                 }
@@ -75,7 +78,7 @@ public class AsyncAddEmail implements AsynchronousProcess {
                     bungeeSender.sendAuthMeBungeecordMessage(MessageType.REFRESH_EMAIL, playerName);
                     service.send(player, MessageKey.EMAIL_ADDED_SUCCESS);
                 } else {
-                    ConsoleLogger.warning("Could not save email for player '" + player + "'");
+                    logger.warning("Could not save email for player '" + player + "'");
                     service.send(player, MessageKey.ERROR);
                 }
             }

--- a/src/main/java/fr/xephi/authme/process/email/AsyncChangeEmail.java
+++ b/src/main/java/fr/xephi/authme/process/email/AsyncChangeEmail.java
@@ -5,6 +5,7 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.EmailChangedEvent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.process.AsynchronousProcess;
 import fr.xephi.authme.service.BukkitService;
@@ -20,6 +21,8 @@ import javax.inject.Inject;
  * Async task for changing the email.
  */
 public class AsyncChangeEmail implements AsynchronousProcess {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(AsyncChangeEmail.class);
 
     @Inject
     private CommonService service;
@@ -83,7 +86,7 @@ public class AsyncChangeEmail implements AsynchronousProcess {
         EmailChangedEvent event = bukkitService.createAndCallEvent(isAsync
             -> new EmailChangedEvent(player, oldEmail, newEmail, isAsync));
         if (event.isCancelled()) {
-            ConsoleLogger.info("Could not change email for player '" + player + "' – event was cancelled");
+            logger.info("Could not change email for player '" + player + "' – event was cancelled");
             service.send(player, MessageKey.EMAIL_CHANGE_NOT_ALLOWED);
             return;
         }

--- a/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
+++ b/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.ProtectInventoryEvent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.permission.PlayerStatePermission;
 import fr.xephi.authme.process.AsynchronousProcess;
@@ -35,6 +36,8 @@ import static fr.xephi.authme.settings.properties.RestrictionSettings.PROTECT_IN
  * Asynchronous process for when a player joins.
  */
 public class AsynchronousJoin implements AsynchronousProcess {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(AsynchronousJoin.class);
 
     @Inject
     private Server server;
@@ -112,7 +115,7 @@ public class AsynchronousJoin implements AsynchronousProcess {
                     isAsync -> new ProtectInventoryEvent(player, isAsync));
                 if (ev.isCancelled()) {
                     player.updateInventory();
-                    ConsoleLogger.fine("ProtectInventoryEvent has been cancelled for " + player.getName() + "...");
+                    logger.fine("ProtectInventoryEvent has been cancelled for " + player.getName() + "...");
                 }
             }
 

--- a/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
@@ -12,6 +12,7 @@ import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.AuthMeAsyncPreLoginEvent;
 import fr.xephi.authme.events.FailedLoginEvent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.mail.EmailService;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.permission.AdminPermission;
@@ -44,6 +45,8 @@ import java.util.List;
  * Asynchronous task for a player login.
  */
 public class AsynchronousLogin implements AsynchronousProcess {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(AsynchronousLogin.class);
 
     @Inject
     private DataSource dataSource;
@@ -199,7 +202,7 @@ public class AsynchronousLogin implements AsynchronousProcess {
      * @param ip the ip address of the player
      */
     private void handleWrongPassword(Player player, PlayerAuth auth, String ip) {
-        ConsoleLogger.fine(player.getName() + " used the wrong password");
+        logger.fine(player.getName() + " used the wrong password");
 
         bukkitService.createAndCallEvent(isAsync -> new FailedLoginEvent(player, isAsync));
         if (tempbanManager.shouldTempban(ip)) {
@@ -256,7 +259,7 @@ public class AsynchronousLogin implements AsynchronousProcess {
                 service.send(player, MessageKey.ADD_EMAIL_MESSAGE);
             }
 
-            ConsoleLogger.fine(player.getName() + " logged in!");
+            logger.fine(player.getName() + " logged in!");
 
             // makes player loggedin
             playerCache.updatePlayer(auth);
@@ -270,7 +273,7 @@ public class AsynchronousLogin implements AsynchronousProcess {
             // processed in other order.
             syncProcessManager.processSyncPlayerLogin(player, isFirstLogin, auths);
         } else {
-            ConsoleLogger.warning("Player '" + player.getName() + "' wasn't online during login process, aborted...");
+            logger.warning("Player '" + player.getName() + "' wasn't online during login process, aborted...");
         }
     }
 
@@ -297,8 +300,8 @@ public class AsynchronousLogin implements AsynchronousProcess {
 
         String message = ChatColor.GRAY + String.join(", ", formattedNames) + ".";
 
-        ConsoleLogger.fine("The user " + player.getName() + " has " + auths.size() + " accounts:");
-        ConsoleLogger.fine(message);
+        logger.fine("The user " + player.getName() + " has " + auths.size() + " accounts:");
+        logger.fine(message);
 
         for (Player onlinePlayer : bukkitService.getOnlinePlayers()) {
             if (onlinePlayer.getName().equalsIgnoreCase(player.getName())

--- a/src/main/java/fr/xephi/authme/process/logout/ProcessSyncPlayerLogout.java
+++ b/src/main/java/fr/xephi/authme/process/logout/ProcessSyncPlayerLogout.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.process.logout;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.events.LogoutEvent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.listener.protocollib.ProtocolLibService;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.process.SynchronousProcess;
@@ -22,6 +23,8 @@ import static fr.xephi.authme.service.BukkitService.TICKS_PER_SECOND;
 
 
 public class ProcessSyncPlayerLogout implements SynchronousProcess {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(ProcessSyncPlayerLogout.class);
 
     @Inject
     private CommonService service;
@@ -61,7 +64,7 @@ public class ProcessSyncPlayerLogout implements SynchronousProcess {
         bukkitService.callEvent(new LogoutEvent(player));
 
         service.send(player, MessageKey.LOGOUT_SUCCESS);
-        ConsoleLogger.info(player.getName() + " logged out");
+        logger.info(player.getName() + " logged out");
     }
 
     private void applyLogoutEffect(Player player) {

--- a/src/main/java/fr/xephi/authme/process/register/ProcessSyncEmailRegister.java
+++ b/src/main/java/fr/xephi/authme/process/register/ProcessSyncEmailRegister.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.process.register;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.events.RegisterEvent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.process.SynchronousProcess;
 import fr.xephi.authme.service.BukkitService;
@@ -16,6 +17,8 @@ import javax.inject.Inject;
  * Performs synchronous tasks after a successful {@link RegistrationType#EMAIL email registration}.
  */
 public class ProcessSyncEmailRegister implements SynchronousProcess {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(ProcessSyncEmailRegister.class);
 
     @Inject
     private BukkitService bukkitService;
@@ -40,7 +43,7 @@ public class ProcessSyncEmailRegister implements SynchronousProcess {
 
         player.saveData();
         bukkitService.callEvent(new RegisterEvent(player));
-        ConsoleLogger.fine(player.getName() + " registered " + PlayerUtils.getPlayerIp(player));
+        logger.fine(player.getName() + " registered " + PlayerUtils.getPlayerIp(player));
     }
 
 }

--- a/src/main/java/fr/xephi/authme/process/register/ProcessSyncPasswordRegister.java
+++ b/src/main/java/fr/xephi/authme/process/register/ProcessSyncPasswordRegister.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.process.register;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.events.RegisterEvent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.process.SynchronousProcess;
 import fr.xephi.authme.service.BukkitService;
@@ -20,6 +21,8 @@ import javax.inject.Inject;
  * Performs synchronous tasks after a successful {@link RegistrationType#PASSWORD password registration}.
  */
 public class ProcessSyncPasswordRegister implements SynchronousProcess {
+
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(ProcessSyncPasswordRegister.class);
 
     @Inject
     private BungeeSender bungeeSender;
@@ -66,7 +69,7 @@ public class ProcessSyncPasswordRegister implements SynchronousProcess {
 
         player.saveData();
         bukkitService.callEvent(new RegisterEvent(player));
-        ConsoleLogger.fine(player.getName() + " registered " + PlayerUtils.getPlayerIp(player));
+        logger.fine(player.getName() + " registered " + PlayerUtils.getPlayerIp(player));
 
         // Kick Player after Registration is enabled, kick the player
         if (service.getProperty(RegistrationSettings.FORCE_KICK_AFTER_REGISTER)) {

--- a/src/main/java/fr/xephi/authme/process/unregister/AsynchronousUnregister.java
+++ b/src/main/java/fr/xephi/authme/process/unregister/AsynchronousUnregister.java
@@ -7,6 +7,7 @@ import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.UnregisterByAdminEvent;
 import fr.xephi.authme.events.UnregisterByPlayerEvent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.process.AsynchronousProcess;
 import fr.xephi.authme.security.PasswordSecurity;
@@ -28,6 +29,8 @@ import javax.inject.Inject;
 import static fr.xephi.authme.service.BukkitService.TICKS_PER_SECOND;
 
 public class AsynchronousUnregister implements AsynchronousProcess {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(AsynchronousUnregister.class);
 
     @Inject
     private DataSource dataSource;
@@ -72,7 +75,7 @@ public class AsynchronousUnregister implements AsynchronousProcess {
         if (passwordSecurity.comparePassword(password, cachedAuth.getPassword(), name)) {
             if (dataSource.removeAuth(name)) {
                 performPostUnregisterActions(name, player);
-                ConsoleLogger.info(name + " unregistered himself");
+                logger.info(name + " unregistered himself");
                 bukkitService.createAndCallEvent(isAsync -> new UnregisterByPlayerEvent(player, isAsync));
             } else {
                 service.send(player, MessageKey.ERROR);
@@ -97,9 +100,9 @@ public class AsynchronousUnregister implements AsynchronousProcess {
             bukkitService.createAndCallEvent(isAsync -> new UnregisterByAdminEvent(player, name, isAsync, initiator));
 
             if (initiator == null) {
-                ConsoleLogger.info(name + " was unregistered");
+                logger.info(name + " was unregistered");
             } else {
-                ConsoleLogger.info(name + " was unregistered by " + initiator.getName());
+                logger.info(name + " was unregistered by " + initiator.getName());
                 service.send(initiator, MessageKey.UNREGISTERED_SUCCESS);
             }
         } else if (initiator != null) {

--- a/src/main/java/fr/xephi/authme/security/crypts/Argon2.java
+++ b/src/main/java/fr/xephi/authme/security/crypts/Argon2.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.security.crypts;
 import de.mkammerer.argon2.Argon2Constants;
 import de.mkammerer.argon2.Argon2Factory;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.security.crypts.description.HasSalt;
 import fr.xephi.authme.security.crypts.description.Recommendation;
 import fr.xephi.authme.security.crypts.description.SaltType;
@@ -13,6 +14,8 @@ import fr.xephi.authme.security.crypts.description.Usage;
 // Note: Argon2 is actually a salted algorithm but salt generation is handled internally
 // and isn't exposed to the outside, so we treat it as an unsalted implementation
 public class Argon2 extends UnsaltedMethod {
+
+    private static ConsoleLogger logger = ConsoleLoggerFactory.get(Argon2.class);
 
     private de.mkammerer.argon2.Argon2 argon2;
 
@@ -30,7 +33,7 @@ public class Argon2 extends UnsaltedMethod {
             System.loadLibrary("argon2");
             return true;
         } catch (UnsatisfiedLinkError e) {
-            ConsoleLogger.logException(
+            logger.logException(
                 "Cannot find argon2 library: https://github.com/AuthMe/AuthMeReloaded/wiki/Argon2-as-Password-Hash", e);
         }
         return false;

--- a/src/main/java/fr/xephi/authme/security/crypts/Pbkdf2.java
+++ b/src/main/java/fr/xephi/authme/security/crypts/Pbkdf2.java
@@ -5,6 +5,7 @@ import de.rtner.misc.BinTools;
 import de.rtner.security.auth.spi.PBKDF2Engine;
 import de.rtner.security.auth.spi.PBKDF2Parameters;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.security.crypts.description.Recommendation;
 import fr.xephi.authme.security.crypts.description.Usage;
 import fr.xephi.authme.settings.Settings;
@@ -16,6 +17,7 @@ import javax.inject.Inject;
 public class Pbkdf2 extends HexSaltedMethod {
 
     private static final int DEFAULT_ROUNDS = 10_000;
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(Pbkdf2.class);
     private int numberOfRounds;
 
     @Inject
@@ -41,7 +43,7 @@ public class Pbkdf2 extends HexSaltedMethod {
         }
         Integer iterations = Ints.tryParse(line[1]);
         if (iterations == null) {
-            ConsoleLogger.warning("Cannot read number of rounds for Pbkdf2: '" + line[1] + "'");
+            logger.warning("Cannot read number of rounds for Pbkdf2: '" + line[1] + "'");
             return false;
         }
 

--- a/src/main/java/fr/xephi/authme/security/crypts/Pbkdf2Django.java
+++ b/src/main/java/fr/xephi/authme/security/crypts/Pbkdf2Django.java
@@ -4,6 +4,7 @@ import com.google.common.primitives.Ints;
 import de.rtner.security.auth.spi.PBKDF2Engine;
 import de.rtner.security.auth.spi.PBKDF2Parameters;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.security.crypts.description.AsciiRestricted;
 
 import java.util.Base64;
@@ -12,6 +13,7 @@ import java.util.Base64;
 public class Pbkdf2Django extends HexSaltedMethod {
 
     private static final int DEFAULT_ITERATIONS = 24000;
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(Pbkdf2Django.class);
 
     @Override
     public String computeHash(String password, String salt, String name) {
@@ -30,7 +32,7 @@ public class Pbkdf2Django extends HexSaltedMethod {
         }
         Integer iterations = Ints.tryParse(line[1]);
         if (iterations == null) {
-            ConsoleLogger.warning("Cannot read number of rounds for Pbkdf2Django: '" + line[1] + "'");
+            logger.warning("Cannot read number of rounds for Pbkdf2Django: '" + line[1] + "'");
             return false;
         }
 

--- a/src/main/java/fr/xephi/authme/security/crypts/TwoFactor.java
+++ b/src/main/java/fr/xephi/authme/security/crypts/TwoFactor.java
@@ -5,6 +5,7 @@ import com.google.common.io.BaseEncoding;
 import com.google.common.net.UrlEscapers;
 import com.google.common.primitives.Ints;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.security.crypts.description.HasSalt;
 import fr.xephi.authme.security.crypts.description.Recommendation;
 import fr.xephi.authme.security.crypts.description.SaltType;
@@ -34,6 +35,8 @@ public class TwoFactor extends UnsaltedMethod {
 
     private static final int TIME_PRECISION = 3;
     private static final String CRYPTO_ALGO = "HmacSHA1";
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(TwoFactor.class);
 
     /**
      * Creates a link to a QR barcode with the provided secret.
@@ -71,7 +74,7 @@ public class TwoFactor extends UnsaltedMethod {
         try {
             return checkPassword(hashedPassword.getHash(), password);
         } catch (Exception e) {
-            ConsoleLogger.logException("Failed to verify two auth code:", e);
+            logger.logException("Failed to verify two auth code:", e);
             return false;
         }
     }

--- a/src/main/java/fr/xephi/authme/security/crypts/Wbb4.java
+++ b/src/main/java/fr/xephi/authme/security/crypts/Wbb4.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.security.crypts;
 import at.favre.lib.crypto.bcrypt.BCrypt;
 import at.favre.lib.crypto.bcrypt.IllegalBCryptFormatException;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.security.crypts.description.HasSalt;
 import fr.xephi.authme.security.crypts.description.Recommendation;
 import fr.xephi.authme.security.crypts.description.SaltType;
@@ -19,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @HasSalt(value = SaltType.TEXT, length = SALT_LENGTH_ENCODED)
 public class Wbb4 implements EncryptionMethod {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(Wbb4.class);
     private BCryptHasher bCryptHasher = new BCryptHasher(BCrypt.Version.VERSION_2A, 8);
     private SecureRandom random = new SecureRandom();
 
@@ -44,7 +46,7 @@ public class Wbb4 implements EncryptionMethod {
             String computedHash = hashInternal(password, salt);
             return isEqual(hashedPassword.getHash(), computedHash);
         } catch (IllegalBCryptFormatException | IllegalArgumentException e) {
-            ConsoleLogger.logException("Invalid WBB4 hash:", e);
+            logger.logException("Invalid WBB4 hash:", e);
         }
         return false;
     }

--- a/src/main/java/fr/xephi/authme/service/BackupService.java
+++ b/src/main/java/fr/xephi/authme/service/BackupService.java
@@ -3,6 +3,8 @@ package fr.xephi.authme.service;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSourceType;
 import fr.xephi.authme.initialization.DataFolder;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
+import fr.xephi.authme.mail.EmailService;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.BackupSettings;
 import fr.xephi.authme.settings.properties.DatabaseSettings;
@@ -25,9 +27,12 @@ import static fr.xephi.authme.util.Utils.logAndSendWarning;
  */
 public class BackupService {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(EmailService.class);
+
     private final File dataFolder;
     private final File backupFolder;
     private final Settings settings;
+
 
     /**
      * Constructor.
@@ -89,7 +94,7 @@ public class BackupService {
                 String dbName = settings.getProperty(DatabaseSettings.MYSQL_DATABASE);
                 return performFileBackup(dbName + ".db");
             default:
-                ConsoleLogger.warning("Unknown data source type '" + dataSourceType + "' for backup");
+                logger.warning("Unknown data source type '" + dataSourceType + "' for backup");
         }
 
         return false;
@@ -114,13 +119,13 @@ public class BackupService {
             Process runtimeProcess = Runtime.getRuntime().exec(backupCommand);
             int processComplete = runtimeProcess.waitFor();
             if (processComplete == 0) {
-                ConsoleLogger.info("Backup created successfully. (Using Windows = " + isUsingWindows + ")");
+                logger.info("Backup created successfully. (Using Windows = " + isUsingWindows + ")");
                 return true;
             } else {
-                ConsoleLogger.warning("Could not create the backup! (Using Windows = " + isUsingWindows + ")");
+                logger.warning("Could not create the backup! (Using Windows = " + isUsingWindows + ")");
             }
         } catch (IOException | InterruptedException e) {
-            ConsoleLogger.logException("Error during backup (using Windows = " + isUsingWindows + "):", e);
+            logger.logException("Error during backup (using Windows = " + isUsingWindows + "):", e);
         }
         return false;
     }
@@ -133,7 +138,7 @@ public class BackupService {
             copy(new File(dataFolder, filename), backupFile);
             return true;
         } catch (IOException ex) {
-            ConsoleLogger.logException("Encountered an error during file backup:", ex);
+            logger.logException("Encountered an error during file backup:", ex);
         }
         return false;
     }
@@ -145,13 +150,13 @@ public class BackupService {
      * @param windowsPath The path to check
      * @return True if the path is correct, false if it is incorrect or the OS is not Windows
      */
-    private static boolean useWindowsCommand(String windowsPath) {
+    private boolean useWindowsCommand(String windowsPath) {
         String isWin = System.getProperty("os.name").toLowerCase();
         if (isWin.contains("win")) {
             if (new File(windowsPath + "\\bin\\mysqldump.exe").exists()) {
                 return true;
             } else {
-                ConsoleLogger.warning("Mysql Windows Path is incorrect. Please check it");
+                logger.warning("Mysql Windows Path is incorrect. Please check it");
                 return false;
             }
         }

--- a/src/main/java/fr/xephi/authme/service/MigrationService.java
+++ b/src/main/java/fr/xephi/authme/service/MigrationService.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.service;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.security.HashAlgorithm;
 import fr.xephi.authme.security.crypts.HashedPassword;
 import fr.xephi.authme.security.crypts.Sha256;
@@ -15,6 +16,8 @@ import java.util.List;
  * Migrations to perform during the initialization of AuthMe.
  */
 public final class MigrationService {
+    
+    private static ConsoleLogger logger = ConsoleLoggerFactory.get(MigrationService.class);
 
     private MigrationService() {
     }
@@ -29,14 +32,14 @@ public final class MigrationService {
     public static void changePlainTextToSha256(Settings settings, DataSource dataSource,
                                                Sha256 authmeSha256) {
         if (HashAlgorithm.PLAINTEXT == settings.getProperty(SecuritySettings.PASSWORD_HASH)) {
-            ConsoleLogger.warning("Your HashAlgorithm has been detected as plaintext and is now deprecated;"
+            logger.warning("Your HashAlgorithm has been detected as plaintext and is now deprecated;"
                 + " it will be changed and hashed now to the AuthMe default hashing method");
-            ConsoleLogger.warning("Don't stop your server; wait for the conversion to have been completed!");
+            logger.warning("Don't stop your server; wait for the conversion to have been completed!");
             List<PlayerAuth> allAuths = dataSource.getAllAuths();
             for (PlayerAuth auth : allAuths) {
                 String hash = auth.getPassword().getHash();
                 if (hash.startsWith("$SHA$")) {
-                    ConsoleLogger.warning("Skipping conversion for " + auth.getNickname() + "; detected SHA hash");
+                    logger.warning("Skipping conversion for " + auth.getNickname() + "; detected SHA hash");
                 } else {
                     HashedPassword hashedPassword = authmeSha256.computeHash(hash, auth.getNickname());
                     auth.setPassword(hashedPassword);
@@ -45,7 +48,7 @@ public final class MigrationService {
             }
             settings.setProperty(SecuritySettings.PASSWORD_HASH, HashAlgorithm.SHA256);
             settings.save();
-            ConsoleLogger.info("Migrated " + allAuths.size() + " accounts from plaintext to SHA256");
+            logger.info("Migrated " + allAuths.size() + " accounts from plaintext to SHA256");
         }
     }
 }

--- a/src/main/java/fr/xephi/authme/service/PasswordRecoveryService.java
+++ b/src/main/java/fr/xephi/authme/service/PasswordRecoveryService.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.HasCleanup;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.mail.EmailService;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
@@ -27,6 +28,8 @@ import static fr.xephi.authme.settings.properties.EmailSettings.RECOVERY_PASSWOR
  * Manager for password recovery.
  */
 public class PasswordRecoveryService implements Reloadable, HasCleanup {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(PasswordRecoveryService.class);
 
     @Inject
     private CommonService commonService;
@@ -95,7 +98,7 @@ public class PasswordRecoveryService implements Reloadable, HasCleanup {
         String thePass = RandomStringUtils.generate(commonService.getProperty(RECOVERY_PASSWORD_LENGTH));
         HashedPassword hashNew = passwordSecurity.computeHash(thePass, name);
 
-        ConsoleLogger.info("Generating new password for '" + name + "'");
+        logger.info("Generating new password for '" + name + "'");
 
         dataSource.updatePassword(name, hashNew);
         boolean couldSendMail = emailService.sendPasswordMail(name, email, thePass);

--- a/src/main/java/fr/xephi/authme/service/PluginHookService.java
+++ b/src/main/java/fr/xephi/authme/service/PluginHookService.java
@@ -5,6 +5,7 @@ import com.earth2me.essentials.Essentials;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -20,6 +21,7 @@ import java.io.File;
 @NoFieldScan
 public class PluginHookService {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(PluginHookService.class);
     private final PluginManager pluginManager;
     private Essentials essentials;
     private Plugin cmi;
@@ -182,11 +184,11 @@ public class PluginHookService {
     // Helpers
     // ------
 
-    private static <T extends Plugin> T getPlugin(PluginManager pluginManager, String name, Class<T> clazz)
+    private <T extends Plugin> T getPlugin(PluginManager pluginManager, String name, Class<T> clazz)
         throws Exception, NoClassDefFoundError {
         if (pluginManager.isPluginEnabled(name)) {
             T plugin = clazz.cast(pluginManager.getPlugin(name));
-            ConsoleLogger.info("Hooked successfully into " + name);
+            logger.info("Hooked successfully into " + name);
             return plugin;
         }
         return null;

--- a/src/main/java/fr/xephi/authme/service/SessionService.java
+++ b/src/main/java/fr/xephi/authme/service/SessionService.java
@@ -5,6 +5,7 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.RestoreSessionEvent;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.settings.properties.PluginSettings;
 import fr.xephi.authme.util.PlayerUtils;
@@ -19,6 +20,7 @@ import static fr.xephi.authme.util.Utils.MILLIS_PER_MINUTE;
  */
 public class SessionService implements Reloadable {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(SessionService.class);
     private final CommonService service;
     private final BukkitService bukkitService;
     private final DataSource database;
@@ -68,7 +70,7 @@ public class SessionService implements Reloadable {
      */
     private SessionState fetchSessionStatus(PlayerAuth auth, Player player) {
         if (auth == null) {
-            ConsoleLogger.warning("No PlayerAuth in database for '" + player.getName() + "' during session check");
+            logger.warning("No PlayerAuth in database for '" + player.getName() + "' during session check");
             return SessionState.NOT_VALID;
         } else if (auth.getLastLogin() == null) {
             return SessionState.NOT_VALID;

--- a/src/main/java/fr/xephi/authme/service/TeleportationService.java
+++ b/src/main/java/fr/xephi/authme/service/TeleportationService.java
@@ -10,6 +10,7 @@ import fr.xephi.authme.events.AuthMeTeleportEvent;
 import fr.xephi.authme.events.FirstSpawnTeleportEvent;
 import fr.xephi.authme.events.SpawnTeleportEvent;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.SpawnLoader;
 import fr.xephi.authme.settings.properties.RestrictionSettings;
@@ -28,6 +29,8 @@ import static fr.xephi.authme.settings.properties.RestrictionSettings.TELEPORT_U
  * Handles teleportation (placement of player to spawn).
  */
 public class TeleportationService implements Reloadable {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(TeleportationService.class);
 
     @Inject
     private Settings settings;
@@ -64,7 +67,7 @@ public class TeleportationService implements Reloadable {
     public void teleportOnJoin(final Player player) {
         if (!settings.getProperty(RestrictionSettings.NO_TELEPORT)
             && settings.getProperty(TELEPORT_UNAUTHED_TO_SPAWN)) {
-            ConsoleLogger.debug("Teleport on join for player `{0}`", player.getName());
+            logger.debug("Teleport on join for player `{0}`", player.getName());
             teleportToSpawn(player, playerCache.isAuthenticated(player.getName()));
         }
     }
@@ -88,7 +91,7 @@ public class TeleportationService implements Reloadable {
                 return null;
             }
 
-            ConsoleLogger.debug("Returning custom location for >1.9 join event for player `{0}`", player.getName());
+            logger.debug("Returning custom location for >1.9 join event for player `{0}`", player.getName());
             return location;
         }
         return null;
@@ -110,7 +113,7 @@ public class TeleportationService implements Reloadable {
         }
 
         if (!player.hasPlayedBefore() || !dataSource.isAuthAvailable(player.getName())) {
-            ConsoleLogger.debug("Attempting to teleport player `{0}` to first spawn", player.getName());
+            logger.debug("Attempting to teleport player `{0}` to first spawn", player.getName());
             performTeleportation(player, new FirstSpawnTeleportEvent(player, firstSpawn));
         }
     }
@@ -134,15 +137,15 @@ public class TeleportationService implements Reloadable {
 
         // The world in LimboPlayer is from where the player comes, before any teleportation by AuthMe
         if (mustForceSpawnAfterLogin(worldName)) {
-            ConsoleLogger.debug("Teleporting `{0}` to spawn because of 'force-spawn after login'", player.getName());
+            logger.debug("Teleporting `{0}` to spawn because of 'force-spawn after login'", player.getName());
             teleportToSpawn(player, true);
         } else if (settings.getProperty(TELEPORT_UNAUTHED_TO_SPAWN)) {
             if (settings.getProperty(RestrictionSettings.SAVE_QUIT_LOCATION) && auth.getQuitLocY() != 0) {
                 Location location = buildLocationFromAuth(player, auth);
-                ConsoleLogger.debug("Teleporting `{0}` after login, based on the player auth", player.getName());
+                logger.debug("Teleporting `{0}` after login, based on the player auth", player.getName());
                 teleportBackFromSpawn(player, location);
             } else if (limbo != null && limbo.getLocation() != null) {
-                ConsoleLogger.debug("Teleporting `{0}` after login, based on the limbo player", player.getName());
+                logger.debug("Teleporting `{0}` after login, based on the limbo player", player.getName());
                 teleportBackFromSpawn(player, limbo.getLocation());
             }
         }

--- a/src/main/java/fr/xephi/authme/service/ValidationService.java
+++ b/src/main/java/fr/xephi/authme/service/ValidationService.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Multimap;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.permission.PermissionsManager;
 import fr.xephi.authme.permission.PlayerStatePermission;
@@ -33,6 +34,8 @@ import static fr.xephi.authme.util.StringUtils.isInsideString;
  * Validation service.
  */
 public class ValidationService implements Reloadable {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(ValidationService.class);
 
     @Inject
     private Settings settings;
@@ -125,7 +128,7 @@ public class ValidationService implements Reloadable {
         String countryCode = geoIpService.getCountryCode(hostAddress);
         boolean isCountryAllowed = validateWhitelistAndBlacklist(countryCode,
             ProtectionSettings.COUNTRIES_WHITELIST, ProtectionSettings.COUNTRIES_BLACKLIST);
-        ConsoleLogger.debug("Country code `{0}` for `{1}` is allowed: {2}", countryCode, hostAddress, isCountryAllowed);
+        logger.debug("Country code `{0}` for `{1}` is allowed: {2}", countryCode, hostAddress, isCountryAllowed);
         return isCountryAllowed;
     }
 
@@ -211,7 +214,7 @@ public class ValidationService implements Reloadable {
                 String[] data = restriction.split(";");
                 restrictions.put(data[0].toLowerCase(), data[1]);
             } else {
-                ConsoleLogger.warning("Restricted user rule must have a ';' separating name from restriction,"
+                logger.warning("Restricted user rule must have a ';' separating name from restriction,"
                     + " but found: '" + restriction + "'");
             }
         }

--- a/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
+++ b/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
@@ -6,6 +6,7 @@ import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.SettingsDependent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.process.Management;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.settings.Settings;
@@ -18,6 +19,8 @@ import javax.inject.Inject;
 import java.util.Optional;
 
 public class BungeeReceiver implements PluginMessageListener, SettingsDependent {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(BungeeReceiver.class);
 
     private final AuthMe plugin;
     private final BukkitService bukkitService;
@@ -59,7 +62,7 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
         final String typeId = dataIn.readUTF();
         final Optional<MessageType> type = MessageType.fromId(typeId);
         if (!type.isPresent()) {
-            ConsoleLogger.debug("Received unsupported forwarded bungeecord message type! ({0})", typeId);
+            logger.debug("Received unsupported forwarded bungeecord message type! ({0})", typeId);
             return;
         }
 
@@ -68,7 +71,8 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
         try {
             argument = dataIn.readUTF();
         } catch (IllegalStateException e) {
-            ConsoleLogger.warning("Received invalid forwarded plugin message of type " + type.get().name() + ": argument is missing!");
+            logger.warning("Received invalid forwarded plugin message of type " + type.get().name()
+                + ": argument is missing!");
             return;
         }
 
@@ -92,7 +96,7 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
         final String typeId = in.readUTF();
         final Optional<MessageType> type = MessageType.fromId(typeId);
         if (!type.isPresent()) {
-            ConsoleLogger.debug("Received unsupported bungeecord message type! ({0})", typeId);
+            logger.debug("Received unsupported bungeecord message type! ({0})", typeId);
             return;
         }
 
@@ -101,7 +105,7 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
         try {
             argument = in.readUTF();
         } catch (IllegalStateException e) {
-            ConsoleLogger.warning("Received invalid plugin message of type " + type.get().name()
+            logger.warning("Received invalid plugin message of type " + type.get().name()
                 + ": argument is missing!");
             return;
         }
@@ -136,7 +140,7 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
         Player player = bukkitService.getPlayerExact(name);
         if (player != null && player.isOnline()) {
             management.forceLogin(player);
-            ConsoleLogger.info("The user " + player.getName() + " has been automatically logged in, "
+            logger.info("The user " + player.getName() + " has been automatically logged in, "
                 + "as requested via plugin messaging.");
         }
     }

--- a/src/main/java/fr/xephi/authme/service/bungeecord/BungeeSender.java
+++ b/src/main/java/fr/xephi/authme/service/bungeecord/BungeeSender.java
@@ -6,6 +6,7 @@ import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.SettingsDependent;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.HooksSettings;
@@ -16,6 +17,7 @@ import javax.inject.Inject;
 
 public class BungeeSender implements SettingsDependent {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(BungeeSender.class);
     private final AuthMe plugin;
     private final BukkitService bukkitService;
     private final DataSource dataSource;
@@ -97,7 +99,7 @@ public class BungeeSender implements SettingsDependent {
     public void sendAuthMeBungeecordMessage(final MessageType type, final String playerName) {
         if (isEnabled) {
             if (!plugin.isEnabled()) {
-                ConsoleLogger.debug("Tried to send a " + type + " bungeecord message but the plugin was disabled!");
+                logger.debug("Tried to send a " + type + " bungeecord message but the plugin was disabled!");
                 return;
             }
             if (type.isRequiresCaching() && !dataSource.isCached()) {

--- a/src/main/java/fr/xephi/authme/settings/Settings.java
+++ b/src/main/java/fr/xephi/authme/settings/Settings.java
@@ -6,6 +6,7 @@ import ch.jalu.configme.migration.MigrationService;
 import ch.jalu.configme.resource.PropertyResource;
 import com.google.common.io.Files;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,6 +19,7 @@ import static fr.xephi.authme.util.FileUtils.copyFileFromResource;
  */
 public class Settings extends SettingsManagerImpl {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(Settings.class);
     private final File pluginFolder;
     private String passwordEmailMessage;
     private String verificationEmailMessage;
@@ -89,10 +91,10 @@ public class Settings extends SettingsManagerImpl {
             try {
                 return Files.asCharSource(file, StandardCharsets.UTF_8).read();
             } catch (IOException e) {
-                ConsoleLogger.logException("Failed to read file '" + filename + "':", e);
+                logger.logException("Failed to read file '" + filename + "':", e);
             }
         } else {
-            ConsoleLogger.warning("Failed to copy file '" + filename + "' from JAR");
+            logger.warning("Failed to copy file '" + filename + "' from JAR");
         }
         return "";
     }

--- a/src/main/java/fr/xephi/authme/settings/SettingsWarner.java
+++ b/src/main/java/fr/xephi/authme/settings/SettingsWarner.java
@@ -2,6 +2,7 @@ package fr.xephi.authme.settings;
 
 import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.security.HashAlgorithm;
 import fr.xephi.authme.security.crypts.Argon2;
 import fr.xephi.authme.service.BukkitService;
@@ -22,6 +23,8 @@ import java.util.Optional;
  * see {@link SettingsMigrationService}.
  */
 public class SettingsWarner {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(SettingsWarner.class);
 
     @Inject
     private Settings settings;
@@ -41,25 +44,25 @@ public class SettingsWarner {
     public void logWarningsForMisconfigurations() {
         // Force single session disabled
         if (!settings.getProperty(RestrictionSettings.FORCE_SINGLE_SESSION)) {
-            ConsoleLogger.warning("WARNING!!! By disabling ForceSingleSession, your server protection is inadequate!");
+            logger.warning("WARNING!!! By disabling ForceSingleSession, your server protection is inadequate!");
         }
 
         // Use TLS property only affects port 25
         if (!settings.getProperty(EmailSettings.PORT25_USE_TLS)
             && settings.getProperty(EmailSettings.SMTP_PORT) != 25) {
-            ConsoleLogger.warning("Note: You have set Email.useTls to false but this only affects mail over port 25");
+            logger.warning("Note: You have set Email.useTls to false but this only affects mail over port 25");
         }
 
         // Output hint if sessions are enabled that the timeout must be positive
         if (settings.getProperty(PluginSettings.SESSIONS_ENABLED)
             && settings.getProperty(PluginSettings.SESSIONS_TIMEOUT) <= 0) {
-            ConsoleLogger.warning("Warning: Session timeout needs to be positive in order to work!");
+            logger.warning("Warning: Session timeout needs to be positive in order to work!");
         }
 
         // Warn if spigot.yml has settings.bungeecord set to true but config.yml has Hooks.bungeecord set to false
         if (isTrue(bukkitService.isBungeeCordConfiguredForSpigot())
             && !settings.getProperty(HooksSettings.BUNGEECORD)) {
-            ConsoleLogger.warning("Note: Hooks.bungeecord is set to false but your server appears to be running in"
+            logger.warning("Note: Hooks.bungeecord is set to false but your server appears to be running in"
                 + " bungeecord mode (see your spigot.yml). In order to allow the datasource caching and the"
                 + " AuthMeBungee add-on to work properly you have to enable this option!");
         }
@@ -67,7 +70,7 @@ public class SettingsWarner {
         // Check if argon2 library is present and can be loaded
         if (settings.getProperty(SecuritySettings.PASSWORD_HASH).equals(HashAlgorithm.ARGON2)
             && !Argon2.isLibraryLoaded()) {
-            ConsoleLogger.warning("WARNING!!! You use Argon2 Hash Algorithm method but we can't find the Argon2 "
+            logger.warning("WARNING!!! You use Argon2 Hash Algorithm method but we can't find the Argon2 "
                 + "library on your system! See https://github.com/AuthMe/AuthMeReloaded/wiki/Argon2-as-Password-Hash");
             authMe.stopOrUnload();
         }

--- a/src/main/java/fr/xephi/authme/settings/SpawnLoader.java
+++ b/src/main/java/fr/xephi/authme/settings/SpawnLoader.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.settings;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.initialization.DataFolder;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.PluginHookService;
 import fr.xephi.authme.settings.properties.HooksSettings;
 import fr.xephi.authme.settings.properties.RestrictionSettings;
@@ -29,6 +30,8 @@ import java.io.IOException;
  */
 public class SpawnLoader implements Reloadable {
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(SpawnLoader.class);
+    
     private final File authMeConfigurationFile;
     private final Settings settings;
     private final PluginHookService pluginHookService;
@@ -120,7 +123,7 @@ public class SpawnLoader implements Reloadable {
                 YamlConfiguration.loadConfiguration(essentialsSpawnFile), "spawns.default");
         } else {
             essentialsSpawn = null;
-            ConsoleLogger.info("Essentials spawn file not found: '" + essentialsSpawnFile.getAbsolutePath() + "'");
+            logger.info("Essentials spawn file not found: '" + essentialsSpawnFile.getAbsolutePath() + "'");
         }
     }
 
@@ -145,7 +148,7 @@ public class SpawnLoader implements Reloadable {
             cmiSpawn = getLocationFromCmiConfiguration(YamlConfiguration.loadConfiguration(cmiConfig));
         } else {
             cmiSpawn = null;
-            ConsoleLogger.info("CMI config file not found: '" + cmiConfig.getAbsolutePath() + "'");
+            logger.info("CMI config file not found: '" + cmiConfig.getAbsolutePath() + "'");
         }
     }
 
@@ -198,11 +201,11 @@ public class SpawnLoader implements Reloadable {
                     // ignore
             }
             if (spawnLoc != null) {
-                ConsoleLogger.debug("Spawn location determined as `{0}` for world `{1}`", spawnLoc, world.getName());
+                logger.debug("Spawn location determined as `{0}` for world `{1}`", spawnLoc, world.getName());
                 return spawnLoc;
             }
         }
-        ConsoleLogger.debug("Fall back to default world spawn location. World: `{0}`", world.getName());
+        logger.debug("Fall back to default world spawn location. World: `{0}`", world.getName());
         return world.getSpawnLocation(); // return default location
     }
 
@@ -232,7 +235,7 @@ public class SpawnLoader implements Reloadable {
             authMeConfiguration.save(authMeConfigurationFile);
             return true;
         } catch (IOException e) {
-            ConsoleLogger.logException("Could not save spawn config (" + authMeConfigurationFile + ")", e);
+            logger.logException("Could not save spawn config (" + authMeConfigurationFile + ")", e);
         }
         return false;
     }

--- a/src/main/java/fr/xephi/authme/settings/WelcomeMessageConfiguration.java
+++ b/src/main/java/fr/xephi/authme/settings/WelcomeMessageConfiguration.java
@@ -4,6 +4,7 @@ import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.initialization.DataFolder;
 import fr.xephi.authme.initialization.Reloadable;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.service.CommonService;
 import fr.xephi.authme.service.GeoIpService;
@@ -35,6 +36,8 @@ import static fr.xephi.authme.util.lazytags.TagBuilder.createTag;
  * Configuration for the welcome message (welcome.txt).
  */
 public class WelcomeMessageConfiguration implements Reloadable {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(WelcomeMessageConfiguration.class);
 
     @DataFolder
     @Inject
@@ -125,10 +128,10 @@ public class WelcomeMessageConfiguration implements Reloadable {
             try {
                 return Files.readAllLines(welcomeFile.toPath(), StandardCharsets.UTF_8);
             } catch (IOException e) {
-                ConsoleLogger.logException("Failed to read welcome.txt file:", e);
+                logger.logException("Failed to read welcome.txt file:", e);
             }
         } else {
-            ConsoleLogger.warning("Failed to copy welcome.txt from JAR");
+            logger.warning("Failed to copy welcome.txt from JAR");
         }
         return Collections.emptyList();
     }

--- a/src/main/java/fr/xephi/authme/task/purge/PurgeExecutor.java
+++ b/src/main/java/fr/xephi/authme/task/purge/PurgeExecutor.java
@@ -2,6 +2,7 @@ package fr.xephi.authme.task.purge;
 
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.permission.PermissionsManager;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.service.PluginHookService;
@@ -21,6 +22,8 @@ import static fr.xephi.authme.util.FileUtils.makePath;
  * Executes the purge operations.
  */
 public class PurgeExecutor {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(PurgeExecutor.class);
 
     @Inject
     private Settings settings;
@@ -85,7 +88,7 @@ public class PurgeExecutor {
             }
         }
 
-        ConsoleLogger.info("AutoPurge: Removed " + i + " AntiXRayData Files");
+        logger.info("AutoPurge: Removed " + i + " AntiXRayData Files");
     }
 
     /**
@@ -96,7 +99,7 @@ public class PurgeExecutor {
     synchronized void purgeFromAuthMe(Collection<String> names) {
         dataSource.purgeRecords(names);
         //TODO ljacqu 20160717: We shouldn't output namedBanned.size() but the actual total that was deleted
-        ConsoleLogger.info(ChatColor.GOLD + "Deleted " + names.size() + " user accounts");
+        logger.info(ChatColor.GOLD + "Deleted " + names.size() + " user accounts");
     }
 
     /**
@@ -141,7 +144,7 @@ public class PurgeExecutor {
                 }
             }
         }
-        ConsoleLogger.info("AutoPurge: Removed " + i + " LimitedCreative Survival, Creative and Adventure files");
+        logger.info("AutoPurge: Removed " + i + " LimitedCreative Survival, Creative and Adventure files");
     }
 
     /**
@@ -165,7 +168,7 @@ public class PurgeExecutor {
             }
         }
 
-        ConsoleLogger.info("AutoPurge: Removed " + i + " .dat Files");
+        logger.info("AutoPurge: Removed " + i + " .dat Files");
     }
 
     /**
@@ -180,7 +183,7 @@ public class PurgeExecutor {
 
         File essentialsDataFolder = pluginHookService.getEssentialsDataFolder();
         if (essentialsDataFolder == null) {
-            ConsoleLogger.info("Cannot purge Essentials: plugin is not loaded");
+            logger.info("Cannot purge Essentials: plugin is not loaded");
             return;
         }
 
@@ -197,7 +200,7 @@ public class PurgeExecutor {
             }
         }
 
-        ConsoleLogger.info("AutoPurge: Removed " + deletedFiles + " EssentialsFiles");
+        logger.info("AutoPurge: Removed " + deletedFiles + " EssentialsFiles");
     }
 
     /**
@@ -212,12 +215,12 @@ public class PurgeExecutor {
 
         for (OfflinePlayer offlinePlayer : cleared) {
             if (!permissionsManager.loadUserData(offlinePlayer)) {
-                ConsoleLogger.warning("Unable to purge the permissions of user " + offlinePlayer + "!");
+                logger.warning("Unable to purge the permissions of user " + offlinePlayer + "!");
                 continue;
             }
             permissionsManager.removeAllGroups(offlinePlayer);
         }
 
-        ConsoleLogger.info("AutoPurge: Removed permissions from " + cleared.size() + " player(s).");
+        logger.info("AutoPurge: Removed permissions from " + cleared.size() + " player(s).");
     }
 }

--- a/src/main/java/fr/xephi/authme/task/purge/PurgeService.java
+++ b/src/main/java/fr/xephi/authme/task/purge/PurgeService.java
@@ -2,6 +2,7 @@ package fr.xephi.authme.task.purge;
 
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.datasource.DataSource;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.permission.PermissionsManager;
 import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.settings.Settings;
@@ -21,6 +22,8 @@ import static fr.xephi.authme.util.Utils.logAndSendMessage;
  * Initiates purge tasks.
  */
 public class PurgeService {
+    
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(PurgeService.class);
 
     @Inject
     private BukkitService bukkitService;
@@ -51,11 +54,11 @@ public class PurgeService {
         if (!settings.getProperty(PurgeSettings.USE_AUTO_PURGE)) {
             return;
         } else if (daysBeforePurge <= 0) {
-            ConsoleLogger.warning("Did not run auto purge: configured days before purging must be positive");
+            logger.warning("Did not run auto purge: configured days before purging must be positive");
             return;
         }
 
-        ConsoleLogger.info("Automatically purging the database...");
+        logger.info("Automatically purging the database...");
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.DATE, -daysBeforePurge);
         long until = calendar.getTimeInMillis();

--- a/src/main/java/fr/xephi/authme/task/purge/PurgeTask.java
+++ b/src/main/java/fr/xephi/authme/task/purge/PurgeTask.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.task.purge;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.permission.PermissionsManager;
 import fr.xephi.authme.permission.PlayerStatePermission;
 import org.bukkit.Bukkit;
@@ -19,6 +20,7 @@ class PurgeTask extends BukkitRunnable {
     //how many players we should check for each tick
     private static final int INTERVAL_CHECK = 5;
 
+    private final ConsoleLogger logger = ConsoleLoggerFactory.get(PurgeTask.class);
     private final PurgeService purgeService;
     private final PermissionsManager permissionsManager;
     private final UUID sender;
@@ -74,7 +76,7 @@ class PurgeTask extends BukkitRunnable {
             OfflinePlayer offlinePlayer = offlinePlayers[nextPosition];
             if (offlinePlayer.getName() != null && toPurge.remove(offlinePlayer.getName().toLowerCase())) {
                 if (!permissionsManager.loadUserData(offlinePlayer)) {
-                    ConsoleLogger.warning("Unable to check if the user " + offlinePlayer.getName() + " can be purged!");
+                    logger.warning("Unable to check if the user " + offlinePlayer.getName() + " can be purged!");
                     continue;
                 }
                 if (!permissionsManager.hasPermissionOffline(offlinePlayer, PlayerStatePermission.BYPASS_PURGE)) {
@@ -85,7 +87,7 @@ class PurgeTask extends BukkitRunnable {
         }
 
         if (!toPurge.isEmpty() && playerPortion.isEmpty()) {
-            ConsoleLogger.info("Finished lookup of offlinePlayers. Begin looking purging player names only");
+            logger.info("Finished lookup of offlinePlayers. Begin looking purging player names only");
 
             //we went through all offlineplayers but there are still names remaining
             for (String name : toPurge) {
@@ -110,7 +112,7 @@ class PurgeTask extends BukkitRunnable {
         // Show a status message
         sendMessage(ChatColor.GREEN + "[AuthMe] Database has been purged successfully");
 
-        ConsoleLogger.info("Purge finished!");
+        logger.info("Purge finished!");
         purgeService.setPurging(false);
     }
 

--- a/src/main/java/fr/xephi/authme/util/FileUtils.java
+++ b/src/main/java/fr/xephi/authme/util/FileUtils.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.util;
 import com.google.common.io.Files;
 import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,6 +21,8 @@ public final class FileUtils {
     private static final DateTimeFormatter CURRENT_DATE_STRING_FORMATTER =
         DateTimeFormatter.ofPattern("yyyyMMdd_HHmm");
 
+    private static ConsoleLogger logger = ConsoleLoggerFactory.get(FileUtils.class);
+
     // Utility class
     private FileUtils() {
     }
@@ -36,20 +39,20 @@ public final class FileUtils {
         if (destinationFile.exists()) {
             return true;
         } else if (!createDirectory(destinationFile.getParentFile())) {
-            ConsoleLogger.warning("Cannot create parent directories for '" + destinationFile + "'");
+            logger.warning("Cannot create parent directories for '" + destinationFile + "'");
             return false;
         }
 
         try (InputStream is = getResourceFromJar(resourcePath)) {
             if (is == null) {
-                ConsoleLogger.warning(format("Cannot copy resource '%s' to file '%s': cannot load resource",
+                logger.warning(format("Cannot copy resource '%s' to file '%s': cannot load resource",
                     resourcePath, destinationFile.getPath()));
             } else {
                 java.nio.file.Files.copy(is, destinationFile.toPath());
                 return true;
             }
         } catch (IOException e) {
-            ConsoleLogger.logException(format("Cannot copy resource '%s' to file '%s':",
+            logger.logException(format("Cannot copy resource '%s' to file '%s':",
                 resourcePath, destinationFile.getPath()), e);
         }
         return false;
@@ -63,7 +66,7 @@ public final class FileUtils {
      */
     public static boolean createDirectory(File dir) {
         if (!dir.exists() && !dir.mkdirs()) {
-            ConsoleLogger.warning("Could not create directory '" + dir + "'");
+            logger.warning("Could not create directory '" + dir + "'");
             return false;
         }
         return dir.isDirectory();
@@ -112,7 +115,7 @@ public final class FileUtils {
         if (file != null) {
             boolean result = file.delete();
             if (!result) {
-                ConsoleLogger.warning("Could not delete file '" + file + "'");
+                logger.warning("Could not delete file '" + file + "'");
             }
         }
     }

--- a/src/main/java/fr/xephi/authme/util/Utils.java
+++ b/src/main/java/fr/xephi/authme/util/Utils.java
@@ -13,11 +13,11 @@ import java.util.regex.Pattern;
  * Utility class for various operations used in the codebase.
  */
 public final class Utils {
-    
-    private static ConsoleLogger logger = ConsoleLoggerFactory.get(Utils.class);
 
     /** Number of milliseconds in a minute. */
     public static final long MILLIS_PER_MINUTE = 60_000L;
+
+    private static ConsoleLogger logger = ConsoleLoggerFactory.get(Utils.class);
 
     // Utility class
     private Utils() {

--- a/src/main/java/fr/xephi/authme/util/Utils.java
+++ b/src/main/java/fr/xephi/authme/util/Utils.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.util;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.output.ConsoleLoggerFactory;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
@@ -12,11 +13,11 @@ import java.util.regex.Pattern;
  * Utility class for various operations used in the codebase.
  */
 public final class Utils {
+    
+    private static ConsoleLogger logger = ConsoleLoggerFactory.get(Utils.class);
 
     /** Number of milliseconds in a minute. */
     public static final long MILLIS_PER_MINUTE = 60_000L;
-    /** Number of milliseconds in an hour. */
-    public static final long MILLIS_PER_HOUR = 60 * MILLIS_PER_MINUTE;
 
     // Utility class
     private Utils() {
@@ -33,7 +34,7 @@ public final class Utils {
         try {
             return Pattern.compile(pattern);
         } catch (Exception e) {
-            ConsoleLogger.warning("Failed to compile pattern '" + pattern + "' - defaulting to allowing everything");
+            logger.warning("Failed to compile pattern '" + pattern + "' - defaulting to allowing everything");
             return Pattern.compile(".*?");
         }
     }
@@ -63,7 +64,7 @@ public final class Utils {
      * @param message the message to log and send
      */
     public static void logAndSendMessage(CommandSender sender, String message) {
-        ConsoleLogger.info(message);
+        logger.info(message);
         // Make sure sender is not console user, which will see the message from ConsoleLogger already
         if (sender != null && !(sender instanceof ConsoleCommandSender)) {
             sender.sendMessage(message);
@@ -79,7 +80,7 @@ public final class Utils {
      * @param message the warning to log and send
      */
     public static void logAndSendWarning(CommandSender sender, String message) {
-        ConsoleLogger.warning(message);
+        logger.warning(message);
         // Make sure sender is not console user, which will see the message from ConsoleLogger already
         if (sender != null && !(sender instanceof ConsoleCommandSender)) {
             sender.sendMessage(ChatColor.RED + message);

--- a/src/test/java/fr/xephi/authme/TestHelper.java
+++ b/src/test/java/fr/xephi/authme/TestHelper.java
@@ -80,7 +80,7 @@ public final class TestHelper {
      */
     public static Logger setupLogger() {
         Logger logger = Mockito.mock(Logger.class);
-        ConsoleLogger.setLogger(logger);
+        ConsoleLogger.initialize(logger, null);
         return logger;
     }
 
@@ -91,7 +91,7 @@ public final class TestHelper {
      */
     public static Logger setRealLogger() {
         Logger logger = Logger.getAnonymousLogger();
-        ConsoleLogger.setLogger(logger);
+        ConsoleLogger.initialize(logger, null);
         return logger;
     }
 

--- a/src/test/java/fr/xephi/authme/command/executable/authme/ReloadCommandTest.java
+++ b/src/test/java/fr/xephi/authme/command/executable/authme/ReloadCommandTest.java
@@ -118,9 +118,8 @@ public class ReloadCommandTest {
         verify(authMe).stopOrUnload();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    public void shouldIssueWarningForChangedDatasourceSetting() {
+    public void shouldIssueWarningForChangedDataSourceSetting() {
         // given
         CommandSender sender = mock(CommandSender.class);
         given(settings.getProperty(DatabaseSettings.BACKEND)).willReturn(DataSourceType.MYSQL);

--- a/src/test/java/fr/xephi/authme/data/limbo/LimboServiceHelperTest.java
+++ b/src/test/java/fr/xephi/authme/data/limbo/LimboServiceHelperTest.java
@@ -1,6 +1,8 @@
 package fr.xephi.authme.data.limbo;
 
+import fr.xephi.authme.TestHelper;
 import org.bukkit.Location;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -25,6 +27,11 @@ public class LimboServiceHelperTest {
 
     @InjectMocks
     private LimboServiceHelper limboServiceHelper;
+
+    @BeforeClass
+    public static void initLogger() {
+        TestHelper.setupLogger();
+    }
 
     @Test
     public void shouldMergeLimboPlayers() {

--- a/src/test/java/fr/xephi/authme/data/limbo/persistence/LimboPersistenceTest.java
+++ b/src/test/java/fr/xephi/authme/data/limbo/persistence/LimboPersistenceTest.java
@@ -16,6 +16,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import java.util.logging.Logger;
+
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -103,7 +105,7 @@ public class LimboPersistenceTest {
     public void shouldHandleExceptionWhenGettingLimbo() {
         // given
         Player player = mock(Player.class);
-        java.util.logging.Logger logger = TestHelper.setupLogger();
+        Logger logger = TestHelper.setupLogger();
         LimboPersistenceHandler handler = getHandler();
         doThrow(RuntimeException.class).when(handler).getLimboPlayer(player);
 
@@ -120,7 +122,7 @@ public class LimboPersistenceTest {
         // given
         Player player = mock(Player.class);
         LimboPlayer limbo = mock(LimboPlayer.class);
-        java.util.logging.Logger logger = TestHelper.setupLogger();
+        Logger logger = TestHelper.setupLogger();
         LimboPersistenceHandler handler = getHandler();
         doThrow(IllegalStateException.class).when(handler).saveLimboPlayer(player, limbo);
 
@@ -135,7 +137,7 @@ public class LimboPersistenceTest {
     public void shouldHandleExceptionWhenRemovingLimbo() {
         // given
         Player player = mock(Player.class);
-        java.util.logging.Logger logger = TestHelper.setupLogger();
+        Logger logger = TestHelper.setupLogger();
         LimboPersistenceHandler handler = getHandler();
         doThrow(UnsupportedOperationException.class).when(handler).removeLimboPlayer(player);
 

--- a/src/test/java/fr/xephi/authme/data/limbo/persistence/LimboPersistenceTest.java
+++ b/src/test/java/fr/xephi/authme/data/limbo/persistence/LimboPersistenceTest.java
@@ -16,8 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import java.util.logging.Logger;
-
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -105,7 +103,7 @@ public class LimboPersistenceTest {
     public void shouldHandleExceptionWhenGettingLimbo() {
         // given
         Player player = mock(Player.class);
-        Logger logger = TestHelper.setupLogger();
+        java.util.logging.Logger logger = TestHelper.setupLogger();
         LimboPersistenceHandler handler = getHandler();
         doThrow(RuntimeException.class).when(handler).getLimboPlayer(player);
 
@@ -122,7 +120,7 @@ public class LimboPersistenceTest {
         // given
         Player player = mock(Player.class);
         LimboPlayer limbo = mock(LimboPlayer.class);
-        Logger logger = TestHelper.setupLogger();
+        java.util.logging.Logger logger = TestHelper.setupLogger();
         LimboPersistenceHandler handler = getHandler();
         doThrow(IllegalStateException.class).when(handler).saveLimboPlayer(player, limbo);
 
@@ -137,7 +135,7 @@ public class LimboPersistenceTest {
     public void shouldHandleExceptionWhenRemovingLimbo() {
         // given
         Player player = mock(Player.class);
-        Logger logger = TestHelper.setupLogger();
+        java.util.logging.Logger logger = TestHelper.setupLogger();
         LimboPersistenceHandler handler = getHandler();
         doThrow(UnsupportedOperationException.class).when(handler).removeLimboPlayer(player);
 

--- a/src/test/java/fr/xephi/authme/message/MessagesIntegrationTest.java
+++ b/src/test/java/fr/xephi/authme/message/MessagesIntegrationTest.java
@@ -12,6 +12,7 @@ import fr.xephi.authme.util.FileUtils;
 import fr.xephi.authme.util.expiring.Duration;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -76,6 +77,11 @@ public class MessagesIntegrationTest {
 
         messagesFileHandler = createMessagesFileHandler();
         messages = new Messages(messagesFileHandler);
+    }
+
+    @AfterClass
+    public static void removeLoggerReferences() {
+        ConsoleLogger.initialize(null, null);
     }
 
     @Test
@@ -216,7 +222,7 @@ public class MessagesIntegrationTest {
     public void shouldLogErrorForInvalidReplacementCount() {
         // given
         Logger logger = mock(Logger.class);
-        ConsoleLogger.setLogger(logger);
+        ConsoleLogger.initialize(logger, null);
         MessageKey key = MessageKey.CAPTCHA_WRONG_ERROR;
         CommandSender sender = mock(CommandSender.class);
         given(sender.getName()).willReturn("Tester");
@@ -232,7 +238,7 @@ public class MessagesIntegrationTest {
     public void shouldSendErrorForReplacementsOnKeyWithNoTags() {
         // given
         Logger logger = mock(Logger.class);
-        ConsoleLogger.setLogger(logger);
+        ConsoleLogger.initialize(logger, null);
         MessageKey key = MessageKey.UNKNOWN_USER;
         CommandSender sender = mock(CommandSender.class);
         given(sender.getName()).willReturn("Tester");

--- a/src/test/java/fr/xephi/authme/output/ConsoleLoggerFactoryTest.java
+++ b/src/test/java/fr/xephi/authme/output/ConsoleLoggerFactoryTest.java
@@ -1,0 +1,94 @@
+package fr.xephi.authme.output;
+
+import fr.xephi.authme.AuthMe;
+import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.ReflectionTestUtils;
+import fr.xephi.authme.TestHelper;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.PluginSettings;
+import fr.xephi.authme.settings.properties.SecuritySettings;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test for {@link ConsoleLoggerFactory}.
+ */
+public class ConsoleLoggerFactoryTest {
+
+    @BeforeClass
+    public static void initLogger() {
+        removeSettingsAndClearMap();
+        TestHelper.setupLogger();
+    }
+
+    @After
+    public void resetConsoleLoggerFactoryToDefaults() {
+        removeSettingsAndClearMap();
+    }
+
+    private static void removeSettingsAndClearMap() {
+        setSettings(null);
+        getConsoleLoggerMap().clear();
+    }
+
+    @Test
+    public void shouldCreateLoggerWithProperNameAndDefaultLogLevel() {
+        // given / when
+        ConsoleLogger logger = ConsoleLoggerFactory.get(AuthMe.class);
+
+        // then
+        assertThat(logger.getName(), equalTo("fr.xephi.authme.AuthMe"));
+        assertThat(logger.getLogLevel(), equalTo(LogLevel.INFO));
+        assertThat(getConsoleLoggerMap().keySet(), contains("fr.xephi.authme.AuthMe"));
+    }
+
+    @Test
+    public void shouldReturnSameInstanceForName() {
+        // given / when
+        ConsoleLogger logger1 = ConsoleLoggerFactory.get(String.class);
+        ConsoleLogger logger2 = ConsoleLoggerFactory.get(Number.class);
+        ConsoleLogger logger3 = ConsoleLoggerFactory.get(String.class);
+
+        // then
+        assertThat(getConsoleLoggerMap().keySet(), containsInAnyOrder("java.lang.String", "java.lang.Number"));
+        assertThat(logger3, sameInstance(logger1));
+        assertThat(logger2, not(sameInstance(logger1)));
+    }
+
+    @Test
+    public void shouldInitializeAccordingToSettings() {
+        // given
+        Settings settings = mock(Settings.class);
+        given(settings.getProperty(PluginSettings.LOG_LEVEL)).willReturn(LogLevel.FINE);
+        given(settings.getProperty(SecuritySettings.USE_LOGGING)).willReturn(false);
+        ConsoleLogger existingLogger = ConsoleLoggerFactory.get(String.class);
+
+        // when
+        ConsoleLoggerFactory.reloadSettings(settings);
+        ConsoleLogger newLogger = ConsoleLoggerFactory.get(AuthMe.class);
+
+        // then
+        assertThat(existingLogger.getLogLevel(), equalTo(LogLevel.FINE));
+        assertThat(newLogger.getLogLevel(), equalTo(LogLevel.FINE));
+    }
+
+    private static void setSettings(Settings settings) {
+        ReflectionTestUtils.setField(ConsoleLoggerFactory.class, null, "settings", settings);
+    }
+
+    private static Map<String, ConsoleLogger> getConsoleLoggerMap() {
+        return ReflectionTestUtils.getFieldValue(ConsoleLoggerFactory.class, null, "consoleLoggers");
+    }
+}

--- a/src/test/java/tools/docs/hashmethods/EncryptionMethodInfoGatherer.java
+++ b/src/test/java/tools/docs/hashmethods/EncryptionMethodInfoGatherer.java
@@ -38,7 +38,7 @@ public class EncryptionMethodInfoGatherer {
     private Map<HashAlgorithm, MethodDescription> descriptions;
 
     public EncryptionMethodInfoGatherer() {
-        ConsoleLogger.setLogger(Logger.getAnonymousLogger()); // set logger because of Argon2.isLibraryLoaded()
+        ConsoleLogger.initialize(Logger.getAnonymousLogger(), null); // set logger because of Argon2.isLibraryLoaded()
         descriptions = new LinkedHashMap<>();
         constructDescriptions();
     }


### PR DESCRIPTION
- Create ConsoleLoggerFactory from which a separate logger can be created for each class
- Allows to support individual log level settings in the future

---

This doesn't change anything in behavior yet but now that each class has its own ConsoleLogger instance, we can introduce a more detailed setting for the log levels. The idea is that a user could then enable DEBUG logging just in a certain package of AuthMe, for example.

I ended up using an approach that is pretty much the same as Log4j or Slf4j use, namely to have a LoggerFactory where you pass in the class and based on that it creates a logger with that name. Initially I wanted to introduce a new annotation `@Logger` and have the injector just set those fields with a proper ConsoleLogger instance but it turned out to be more confusing than helpful. It would have required some extensive test changes to set it up in the tests as well and it could not have been used everywhere, seeing as we also have logging in enums, for example (see e.g. WalkFlySpeedRestoreType). So in any case some sort of factory-like approach would have been necessary and I didn't feel comfortable having two completely different ways of creating the logger in parallel. In the end it does require some boilerplate code, but I now understand why the other frameworks went like this, everything else seems to kind of get messy quite fast :sweat_smile: 