### PR TITLE
Fix unregistered players teleport to spawn with unforced registration

### DIFF
--- a/src/main/java/fr/xephi/authme/service/TeleportationService.java
+++ b/src/main/java/fr/xephi/authme/service/TeleportationService.java
@@ -13,6 +13,7 @@ import fr.xephi.authme.initialization.Reloadable;
 import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.SpawnLoader;
+import fr.xephi.authme.settings.properties.RegistrationSettings;
 import fr.xephi.authme.settings.properties.RestrictionSettings;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -65,6 +66,12 @@ public class TeleportationService implements Reloadable {
      * @param player the player to process
      */
     public void teleportOnJoin(final Player player) {
+    	if (!settings.getProperty(RegistrationSettings.FORCE) 
+    			&& !dataSource.isAuthAvailable(player.getName())) {
+    		logger.debug("`{0}` is not registered, thus he will not get teleported on join.", player.getName());
+    		return;
+    	}
+    	
         if (!settings.getProperty(RestrictionSettings.NO_TELEPORT)
             && settings.getProperty(TELEPORT_UNAUTHED_TO_SPAWN)) {
             logger.debug("Teleport on join for player `{0}`", player.getName());
@@ -80,6 +87,12 @@ public class TeleportationService implements Reloadable {
      * @return the custom spawn location, null if the player should spawn at the original location
      */
     public Location prepareOnJoinSpawnLocation(final Player player) {
+    	if (!settings.getProperty(RegistrationSettings.FORCE) 
+    			&& !dataSource.isAuthAvailable(player.getName())) {
+    		logger.debug("`{0}` is not registered, thus he will not get teleported on join.", player.getName());
+    		return null;
+    	}
+    	
         if (!settings.getProperty(RestrictionSettings.NO_TELEPORT)
             && settings.getProperty(TELEPORT_UNAUTHED_TO_SPAWN)) {
             final Location location = spawnLoader.getSpawnLocation(player);

--- a/src/test/java/fr/xephi/authme/service/TeleportationServiceTest.java
+++ b/src/test/java/fr/xephi/authme/service/TeleportationServiceTest.java
@@ -7,6 +7,7 @@ import fr.xephi.authme.events.FirstSpawnTeleportEvent;
 import fr.xephi.authme.events.SpawnTeleportEvent;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.SpawnLoader;
+import fr.xephi.authme.settings.properties.RegistrationSettings;
 import fr.xephi.authme.settings.properties.RestrictionSettings;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -71,6 +72,8 @@ public class TeleportationServiceTest {
     public void shouldNotTeleportPlayerOnJoin() {
         // given
         given(settings.getProperty(RestrictionSettings.NO_TELEPORT)).willReturn(true);
+        given(settings.getProperty(RegistrationSettings.FORCE)).willReturn(true);
+        
         Player player = mock(Player.class);
 
         // when
@@ -105,6 +108,8 @@ public class TeleportationServiceTest {
     public void shouldTeleportPlayerToSpawn() {
         // given
         given(settings.getProperty(RestrictionSettings.TELEPORT_UNAUTHED_TO_SPAWN)).willReturn(true);
+        given(settings.getProperty(RegistrationSettings.FORCE)).willReturn(true);
+        
         Player player = mock(Player.class);
         given(player.isOnline()).willReturn(true);
         Location spawn = mockLocation();
@@ -172,6 +177,8 @@ public class TeleportationServiceTest {
         Location spawn = mockLocation();
         given(spawnLoader.getSpawnLocation(player)).willReturn(spawn);
         given(settings.getProperty(RestrictionSettings.TELEPORT_UNAUTHED_TO_SPAWN)).willReturn(true);
+        given(settings.getProperty(RegistrationSettings.FORCE)).willReturn(true);
+        
         doAnswer(invocation -> {
             SpawnTeleportEvent event = (SpawnTeleportEvent) invocation.getArguments()[0];
             assertThat(event.getPlayer(), equalTo(player));
@@ -195,6 +202,8 @@ public class TeleportationServiceTest {
         Location spawn = mockLocation();
         given(spawnLoader.getSpawnLocation(player)).willReturn(spawn);
         given(settings.getProperty(RestrictionSettings.TELEPORT_UNAUTHED_TO_SPAWN)).willReturn(true);
+        given(settings.getProperty(RegistrationSettings.FORCE)).willReturn(true);
+        
         doAnswer(invocation -> {
             SpawnTeleportEvent event = (SpawnTeleportEvent) invocation.getArguments()[0];
             assertThat(event.getPlayer(), equalTo(player));


### PR DESCRIPTION
Considering that I posted the same bug 4 years back (which was fixed on an old version), you should really consider that there are some servers, which do not force registration for players... since the whole test class is written only with forced registration in mind.

If you set teleportUnAuthToSpawn to true and also forceRegistration to false, unregistered players always end up at spawn, while they should not be altered by AuthMe and login like vanilla. Once you register that player it works perfectly fine.