### PR TITLE
Add method to get the registration date to the API

### DIFF
--- a/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
@@ -197,6 +197,32 @@ public class AuthMeApi {
     }
 
     /**
+     * Get the registration (AuthMe) timestamp of a player.
+     *
+     * @param playerName The name of the player to process
+     *
+     * @return The timestamp of when the player was registered, or null if the player doesn't exist or is not registered
+     */
+    public Instant getRegistrationTime(String playerName) {
+        Long registrationDate = getRegistrationMillis(playerName);
+        return registrationDate == null ? null : Instant.ofEpochMilli(registrationDate);
+    }
+
+    private Long getRegistrationMillis(String playerName) {
+        if (!isRegistered(playerName.toLowerCase())) {
+            return null;
+        }
+        PlayerAuth auth = playerCache.getAuth(playerName);
+        if (auth == null) {
+            auth = dataSource.getAuth(playerName);
+        }
+        if (auth != null) {
+            return auth.getRegistrationDate();
+        }
+        return null;
+    }
+
+    /**
      * Return whether the player is registered.
      *
      * @param playerName The player name to check

--- a/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
@@ -133,6 +133,23 @@ public class AuthMeApi {
     }
 
     /**
+     * Get the registration ip address of a player.
+     *
+     * @param playerName The name of the player to process
+     * @return The registration ip address of the player
+     */
+    public String getRegistrationIp(String playerName) {
+        PlayerAuth auth = playerCache.getAuth(playerName);
+        if (auth == null) {
+            auth = dataSource.getAuth(playerName);
+        }
+        if (auth != null) {
+            return auth.getRegistrationIp();
+        }
+        return null;
+    }
+
+    /**
      * Get the last ip address of a player.
      *
      * @param playerName The name of the player to process

--- a/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
@@ -209,9 +209,6 @@ public class AuthMeApi {
     }
 
     private Long getRegistrationMillis(String playerName) {
-        if (!isRegistered(playerName.toLowerCase())) {
-            return null;
-        }
         PlayerAuth auth = playerCache.getAuth(playerName);
         if (auth == null) {
             auth = dataSource.getAuth(playerName);


### PR DESCRIPTION
No API method was written when the feature was introduced, there are some use-cases where this data is needed.