### PR TITLE
#1448 Create AuthMePlayer to get player data from API with

### DIFF
--- a/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
@@ -133,20 +133,17 @@ public class AuthMeApi {
     }
 
     /**
-     * Get the registration ip address of a player.
+     * Returns the AuthMe info of the given player's name, or null if the player doesn't exist.
      *
-     * @param playerName The name of the player to process
-     * @return The registration ip address of the player
+     * @param playerName The player name to look up
+     * @return AuthMe player info, or null if not available
      */
-    public String getRegistrationIp(String playerName) {
+    public AuthMePlayer getPlayerInfo(String playerName) {
         PlayerAuth auth = playerCache.getAuth(playerName);
         if (auth == null) {
             auth = dataSource.getAuth(playerName);
         }
-        if (auth != null) {
-            return auth.getRegistrationIp();
-        }
-        return null;
+        return AuthMePlayerImpl.fromPlayerAuth(auth);
     }
 
     /**
@@ -180,7 +177,6 @@ public class AuthMeApi {
      * Get the last (AuthMe) login date of a player.
      *
      * @param playerName The name of the player to process
-     *
      * @return The date of the last login, or null if the player doesn't exist or has never logged in
      * @deprecated Use Java 8's Instant method {@link #getLastLoginTime(String)}
      */
@@ -209,29 +205,6 @@ public class AuthMeApi {
         }
         if (auth != null) {
             return auth.getLastLogin();
-        }
-        return null;
-    }
-
-    /**
-     * Get the registration (AuthMe) timestamp of a player.
-     *
-     * @param playerName The name of the player to process
-     *
-     * @return The timestamp of when the player was registered, or null if the player doesn't exist or is not registered
-     */
-    public Instant getRegistrationTime(String playerName) {
-        Long registrationDate = getRegistrationMillis(playerName);
-        return registrationDate == null ? null : Instant.ofEpochMilli(registrationDate);
-    }
-
-    private Long getRegistrationMillis(String playerName) {
-        PlayerAuth auth = playerCache.getAuth(playerName);
-        if (auth == null) {
-            auth = dataSource.getAuth(playerName);
-        }
-        if (auth != null) {
-            return auth.getRegistrationDate();
         }
         return null;
     }

--- a/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The current API of AuthMe.
@@ -133,12 +134,12 @@ public class AuthMeApi {
     }
 
     /**
-     * Returns the AuthMe info of the given player's name, or null if the player doesn't exist.
+     * Returns the AuthMe info of the given player's name, or empty optional if the player doesn't exist.
      *
      * @param playerName The player name to look up
-     * @return AuthMe player info, or null if not available
+     * @return AuthMe player info, or empty optional if the player doesn't exist
      */
-    public AuthMePlayer getPlayerInfo(String playerName) {
+    public Optional<AuthMePlayer> getPlayerInfo(String playerName) {
         PlayerAuth auth = playerCache.getAuth(playerName);
         if (auth == null) {
             auth = dataSource.getAuth(playerName);

--- a/src/main/java/fr/xephi/authme/api/v3/AuthMePlayer.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMePlayer.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.api.v3;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -17,19 +18,19 @@ public interface AuthMePlayer {
 
     /**
      * Returns the UUID of the player as given by the server (may be offline UUID or not).
-     * The UUID is null if AuthMe is configured not to store the UUID or if the data is not
+     * The UUID is not present if AuthMe is configured not to store the UUID or if the data is not
      * present (e.g. older record).
      *
-     * @return player uuid, or null if not available
+     * @return player uuid, or empty optional if not available
      */
-    UUID getUuid();
+    Optional<UUID> getUuid();
 
     /**
-     * Returns the email address associated with this player, or null if not available.
+     * Returns the email address associated with this player, or an empty optional if not available.
      *
-     * @return player's email or null
+     * @return player's email or empty optional
      */
-    String getEmail();
+    Optional<String> getEmail();
 
     /**
      * @return the registration date of the player's account - never null
@@ -37,26 +38,26 @@ public interface AuthMePlayer {
     Instant getRegistrationDate();
 
     /**
-     * Returns the IP address with which the player's account was registered. May be null
+     * Returns the IP address with which the player's account was registered. Returns an empty optional
      * for older accounts, or if the account was registered by someone else (e.g. by an admin).
      *
-     * @return the ip address used during the registration of the account, or null
+     * @return the ip address used during the registration of the account, or empty optional
      */
-    String getRegistrationIpAddress();
+    Optional<String> getRegistrationIpAddress();
 
     /**
-     * Returns the last login date of the player. May be null if the player never logged in.
+     * Returns the last login date of the player. An empty optional is returned if the player never logged in.
      *
-     * @return date the player last logged in successfully, or null if not applicable
+     * @return date the player last logged in successfully, or empty optional if not applicable
      */
-    Instant getLastLoginDate();
+    Optional<Instant> getLastLoginDate();
 
     /**
-     * Returns the IP address the player last logged in with successfully. May be null if the
+     * Returns the IP address the player last logged in with successfully. Returns an empty optional if the
      * player never logged in.
      *
-     * @return ip address the player last logged in with successfully, or null if not applicable
+     * @return ip address the player last logged in with successfully, or empty optional if not applicable
      */
-    String getLastLoginIpAddress();
+    Optional<String> getLastLoginIpAddress();
 
 }

--- a/src/main/java/fr/xephi/authme/api/v3/AuthMePlayer.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMePlayer.java
@@ -5,7 +5,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- * Read-only player info exposed in the AuthMe API.
+ * Read-only player info exposed in the AuthMe API. The data in this object is copied from the
+ * database and not updated afterwards. As such, it may become outdated if the player data changes
+ * in AuthMe.
  *
  * @see AuthMeApi#getPlayerInfo
  */

--- a/src/main/java/fr/xephi/authme/api/v3/AuthMePlayer.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMePlayer.java
@@ -1,0 +1,62 @@
+package fr.xephi.authme.api.v3;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Read-only player info exposed in the AuthMe API.
+ *
+ * @see AuthMeApi#getPlayerInfo
+ */
+public interface AuthMePlayer {
+
+    /**
+     * @return the case-sensitive name of the player, e.g. "thePlayer3030" - never null
+     */
+    String getName();
+
+    /**
+     * Returns the UUID of the player as given by the server (may be offline UUID or not).
+     * The UUID is null if AuthMe is configured not to store the UUID or if the data is not
+     * present (e.g. older record).
+     *
+     * @return player uuid, or null if not available
+     */
+    UUID getUuid();
+
+    /**
+     * Returns the email address associated with this player, or null if not available.
+     *
+     * @return player's email or null
+     */
+    String getEmail();
+
+    /**
+     * @return the registration date of the player's account - never null
+     */
+    Instant getRegistrationDate();
+
+    /**
+     * Returns the IP address with which the player's account was registered. May be null
+     * for older accounts, or if the account was registered by someone else (e.g. by an admin).
+     *
+     * @return the ip address used during the registration of the account, or null
+     */
+    String getRegistrationIpAddress();
+
+    /**
+     * Returns the last login date of the player. May be null if the player never logged in.
+     *
+     * @return date the player last logged in successfully, or null if not applicable
+     */
+    Instant getLastLoginDate();
+
+    /**
+     * Returns the IP address the player last logged in with successfully. May be null if the
+     * player never logged in.
+     *
+     * @return ip address the player last logged in with successfully, or null if not applicable
+     */
+    String getLastLoginIpAddress();
+
+}

--- a/src/main/java/fr/xephi/authme/api/v3/AuthMePlayerImpl.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMePlayerImpl.java
@@ -1,0 +1,81 @@
+package fr.xephi.authme.api.v3;
+
+import fr.xephi.authme.data.auth.PlayerAuth;
+
+import java.time.Instant;
+import java.util.UUID;
+
+class AuthMePlayerImpl implements AuthMePlayer {
+
+    private String name;
+    private UUID uuid;
+    private String email;
+
+    private Instant registrationDate;
+    private String registrationIpAddress;
+
+    private Instant lastLoginDate;
+    private String lastLoginIpAddress;
+
+    AuthMePlayerImpl() {
+    }
+
+    static AuthMePlayer fromPlayerAuth(PlayerAuth playerAuth) {
+        if (playerAuth == null) {
+            return null;
+        }
+
+        AuthMePlayerImpl authMeUser = new AuthMePlayerImpl();
+        authMeUser.name = playerAuth.getRealName();
+        authMeUser.uuid = playerAuth.getUuid();
+        authMeUser.email = nullIfDefault(playerAuth.getEmail(), PlayerAuth.DB_EMAIL_DEFAULT);
+        Long lastLoginMillis = nullIfDefault(playerAuth.getLastLogin(), PlayerAuth.DB_LAST_LOGIN_DEFAULT);
+        authMeUser.registrationDate = toInstant(playerAuth.getRegistrationDate());
+        authMeUser.registrationIpAddress = playerAuth.getRegistrationIp();
+        authMeUser.lastLoginDate = toInstant(lastLoginMillis);
+        authMeUser.lastLoginIpAddress = nullIfDefault(playerAuth.getLastIp(), PlayerAuth.DB_LAST_IP_DEFAULT);
+        return authMeUser;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public Instant getRegistrationDate() {
+        return registrationDate;
+    }
+
+    @Override
+    public String getRegistrationIpAddress() {
+        return registrationIpAddress;
+    }
+
+    @Override
+    public Instant getLastLoginDate() {
+        return lastLoginDate;
+    }
+
+    @Override
+    public String getLastLoginIpAddress() {
+        return lastLoginIpAddress;
+    }
+
+    private static Instant toInstant(Long epochMillis) {
+        return epochMillis == null ? null : Instant.ofEpochMilli(epochMillis);
+    }
+
+    private static <T> T nullIfDefault(T value, T defaultValue) {
+        return defaultValue.equals(value) ? null : value;
+    }
+}

--- a/src/main/java/fr/xephi/authme/api/v3/AuthMePlayerImpl.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMePlayerImpl.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.api.v3;
 import fr.xephi.authme.data.auth.PlayerAuth;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -25,15 +26,15 @@ class AuthMePlayerImpl implements AuthMePlayer {
     }
 
     /**
-     * Maps the given player auth to an AuthMePlayer instance. Returns null if
+     * Maps the given player auth to an AuthMePlayer instance. Returns an empty optional if
      * the player auth is null.
      *
      * @param playerAuth the player auth or null
-     * @return the mapped player auth, or null if the argument was null
+     * @return the mapped player auth, or empty optional if the argument was null
      */
-    static AuthMePlayer fromPlayerAuth(PlayerAuth playerAuth) {
+    static Optional<AuthMePlayer> fromPlayerAuth(PlayerAuth playerAuth) {
         if (playerAuth == null) {
-            return null;
+            return Optional.empty();
         }
 
         AuthMePlayerImpl authMeUser = new AuthMePlayerImpl();
@@ -45,7 +46,7 @@ class AuthMePlayerImpl implements AuthMePlayer {
         authMeUser.registrationIpAddress = playerAuth.getRegistrationIp();
         authMeUser.lastLoginDate = toInstant(lastLoginMillis);
         authMeUser.lastLoginIpAddress = nullIfDefault(playerAuth.getLastIp(), PlayerAuth.DB_LAST_IP_DEFAULT);
-        return authMeUser;
+        return Optional.of(authMeUser);
     }
 
     @Override
@@ -53,13 +54,13 @@ class AuthMePlayerImpl implements AuthMePlayer {
         return name;
     }
 
-    public UUID getUuid() {
-        return uuid;
+    public Optional<UUID> getUuid() {
+        return Optional.ofNullable(uuid);
     }
 
     @Override
-    public String getEmail() {
-        return email;
+    public Optional<String> getEmail() {
+        return Optional.ofNullable(email);
     }
 
     @Override
@@ -68,18 +69,18 @@ class AuthMePlayerImpl implements AuthMePlayer {
     }
 
     @Override
-    public String getRegistrationIpAddress() {
-        return registrationIpAddress;
+    public Optional<String> getRegistrationIpAddress() {
+        return Optional.ofNullable(registrationIpAddress);
     }
 
     @Override
-    public Instant getLastLoginDate() {
-        return lastLoginDate;
+    public Optional<Instant> getLastLoginDate() {
+        return Optional.ofNullable( lastLoginDate);
     }
 
     @Override
-    public String getLastLoginIpAddress() {
-        return lastLoginIpAddress;
+    public Optional<String> getLastLoginIpAddress() {
+        return Optional.ofNullable(lastLoginIpAddress);
     }
 
     private static Instant toInstant(Long epochMillis) {

--- a/src/main/java/fr/xephi/authme/api/v3/AuthMePlayerImpl.java
+++ b/src/main/java/fr/xephi/authme/api/v3/AuthMePlayerImpl.java
@@ -5,6 +5,10 @@ import fr.xephi.authme.data.auth.PlayerAuth;
 import java.time.Instant;
 import java.util.UUID;
 
+/**
+ * Implementation of {@link AuthMePlayer}. This implementation is not part of the API and
+ * may have breaking changes in subsequent releases.
+ */
 class AuthMePlayerImpl implements AuthMePlayer {
 
     private String name;
@@ -20,6 +24,13 @@ class AuthMePlayerImpl implements AuthMePlayer {
     AuthMePlayerImpl() {
     }
 
+    /**
+     * Maps the given player auth to an AuthMePlayer instance. Returns null if
+     * the player auth is null.
+     *
+     * @param playerAuth the player auth or null
+     * @return the mapped player auth, or null if the argument was null
+     */
     static AuthMePlayer fromPlayerAuth(PlayerAuth playerAuth) {
         if (playerAuth == null) {
             return null;

--- a/src/test/java/fr/xephi/authme/api/v3/AuthMeApiTest.java
+++ b/src/test/java/fr/xephi/authme/api/v3/AuthMeApiTest.java
@@ -31,12 +31,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static fr.xephi.authme.IsEqualByReflectionMatcher.hasEqualValuesOnAllFields;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -510,6 +510,35 @@ public class AuthMeApiTest {
         // then
         assertThat(countryCode, equalTo("XA"));
         assertThat(countryName, equalTo("Syldavia"));
+    }
+
+    @Test
+    public void shouldReturnAuthMePlayerInfo() {
+        // given
+        PlayerAuth auth = PlayerAuth.builder()
+            .name("bobb")
+            .realName("Bobb")
+            .registrationDate(1433166082000L)
+            .build();
+        given(dataSource.getAuth("bobb")).willReturn(auth);
+
+        // when
+        AuthMePlayer playerInfo = api.getPlayerInfo("bobb");
+
+        // then
+        assertThat(playerInfo.getName(), equalTo("Bobb"));
+        assertThat(playerInfo.getRegistrationDate(), equalTo(Instant.ofEpochMilli(1433166082000L)));
+    }
+
+    @Test
+    public void shouldReturnNullForNonExistentAuth() {
+        // given / when
+        AuthMePlayer result = api.getPlayerInfo("doesNotExist");
+
+        // then
+        assertThat(result, nullValue());
+        verify(playerCache).getAuth("doesNotExist");
+        verify(dataSource).getAuth("doesNotExist");
     }
 
     private static Player mockPlayerWithName(String name) {

--- a/src/test/java/fr/xephi/authme/api/v3/AuthMeApiTest.java
+++ b/src/test/java/fr/xephi/authme/api/v3/AuthMeApiTest.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static fr.xephi.authme.IsEqualByReflectionMatcher.hasEqualValuesOnAllFields;
@@ -523,9 +524,10 @@ public class AuthMeApiTest {
         given(dataSource.getAuth("bobb")).willReturn(auth);
 
         // when
-        AuthMePlayer playerInfo = api.getPlayerInfo("bobb");
+        Optional<AuthMePlayer> result = api.getPlayerInfo("bobb");
 
         // then
+        AuthMePlayer playerInfo = result.get();
         assertThat(playerInfo.getName(), equalTo("Bobb"));
         assertThat(playerInfo.getRegistrationDate(), equalTo(Instant.ofEpochMilli(1433166082000L)));
     }
@@ -533,10 +535,10 @@ public class AuthMeApiTest {
     @Test
     public void shouldReturnNullForNonExistentAuth() {
         // given / when
-        AuthMePlayer result = api.getPlayerInfo("doesNotExist");
+        Optional<AuthMePlayer> result = api.getPlayerInfo("doesNotExist");
 
         // then
-        assertThat(result, nullValue());
+        assertThat(result.isPresent(), equalTo(false));
         verify(playerCache).getAuth("doesNotExist");
         verify(dataSource).getAuth("doesNotExist");
     }

--- a/src/test/java/fr/xephi/authme/api/v3/AuthMePlayerImplTest.java
+++ b/src/test/java/fr/xephi/authme/api/v3/AuthMePlayerImplTest.java
@@ -1,9 +1,13 @@
 package fr.xephi.authme.api.v3;
 
 import fr.xephi.authme.data.auth.PlayerAuth;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -18,7 +22,7 @@ public class AuthMePlayerImplTest {
     @Test
     public void shouldMapNullWithoutError() {
         // given / when / then
-        assertThat(AuthMePlayerImpl.fromPlayerAuth(null), nullValue());
+        assertThat(AuthMePlayerImpl.fromPlayerAuth(null), emptyOptional());
     }
 
     @Test
@@ -36,16 +40,17 @@ public class AuthMePlayerImplTest {
             .build();
 
         // when
-        AuthMePlayer result = AuthMePlayerImpl.fromPlayerAuth(auth);
+        Optional<AuthMePlayer> result = AuthMePlayerImpl.fromPlayerAuth(auth);
 
         // then
-        assertThat(result.getName(), equalTo("Victor"));
-        assertThat(result.getUuid(), equalTo(auth.getUuid()));
-        assertThat(result.getEmail(), equalTo(auth.getEmail()));
-        assertThat(result.getRegistrationDate(), equalTo(Instant.ofEpochMilli(auth.getRegistrationDate())));
-        assertThat(result.getRegistrationIpAddress(), equalTo(auth.getRegistrationIp()));
-        assertThat(result.getLastLoginDate(), equalTo(Instant.ofEpochMilli(auth.getLastLogin())));
-        assertThat(result.getLastLoginIpAddress(), equalTo(auth.getLastIp()));
+        AuthMePlayer playerInfo = result.get();
+        assertThat(playerInfo.getName(), equalTo("Victor"));
+        assertThat(playerInfo.getUuid().get(), equalTo(auth.getUuid()));
+        assertThat(playerInfo.getEmail().get(), equalTo(auth.getEmail()));
+        assertThat(playerInfo.getRegistrationDate(), equalTo(Instant.ofEpochMilli(auth.getRegistrationDate())));
+        assertThat(playerInfo.getRegistrationIpAddress().get(), equalTo(auth.getRegistrationIp()));
+        assertThat(playerInfo.getLastLoginDate().get(), equalTo(Instant.ofEpochMilli(auth.getLastLogin())));
+        assertThat(playerInfo.getLastLoginIpAddress().get(), equalTo(auth.getLastIp()));
     }
 
     @Test
@@ -61,15 +66,31 @@ public class AuthMePlayerImplTest {
             .build();
 
         // when
-        AuthMePlayer result = AuthMePlayerImpl.fromPlayerAuth(auth);
+        Optional<AuthMePlayer> result = AuthMePlayerImpl.fromPlayerAuth(auth);
 
         // then
-        assertThat(result.getName(), equalTo("Victor"));
-        assertThat(result.getUuid(), nullValue());
-        assertThat(result.getEmail(), nullValue());
-        assertThat(result.getRegistrationDate(), equalTo(Instant.ofEpochMilli(auth.getRegistrationDate())));
-        assertThat(result.getRegistrationIpAddress(), nullValue());
-        assertThat(result.getLastLoginDate(), nullValue());
-        assertThat(result.getLastLoginIpAddress(), nullValue());
+        AuthMePlayer playerInfo = result.get();
+        assertThat(playerInfo.getName(), equalTo("Victor"));
+        assertThat(playerInfo.getUuid(), emptyOptional());
+        assertThat(playerInfo.getEmail(), emptyOptional());
+        assertThat(playerInfo.getRegistrationDate(), equalTo(Instant.ofEpochMilli(auth.getRegistrationDate())));
+        assertThat(playerInfo.getRegistrationIpAddress(), emptyOptional());
+        assertThat(playerInfo.getLastLoginDate(), emptyOptional());
+        assertThat(playerInfo.getLastLoginIpAddress(), emptyOptional());
+    }
+
+    private static <T> Matcher<Optional<T>> emptyOptional() {
+        return new TypeSafeMatcher<Optional<T>>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("an empty optional");
+            }
+
+            @Override
+            protected boolean matchesSafely(Optional<T> item) {
+                return !item.isPresent();
+            }
+        };
     }
 }

--- a/src/test/java/fr/xephi/authme/api/v3/AuthMePlayerImplTest.java
+++ b/src/test/java/fr/xephi/authme/api/v3/AuthMePlayerImplTest.java
@@ -1,0 +1,75 @@
+package fr.xephi.authme.api.v3;
+
+import fr.xephi.authme.data.auth.PlayerAuth;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Test for {@link AuthMePlayerImpl}.
+ */
+public class AuthMePlayerImplTest {
+
+    @Test
+    public void shouldMapNullWithoutError() {
+        // given / when / then
+        assertThat(AuthMePlayerImpl.fromPlayerAuth(null), nullValue());
+    }
+
+    @Test
+    public void shouldMapFromPlayerAuth() {
+        // given
+        PlayerAuth auth = PlayerAuth.builder()
+            .name("victor")
+            .realName("Victor")
+            .email("vic@example.com")
+            .registrationDate(1480075661000L)
+            .registrationIp("124.125.126.127")
+            .lastLogin(1542675632000L)
+            .lastIp("62.63.64.65")
+            .uuid(UUID.fromString("deadbeef-2417-4653-9026-feedbabeface"))
+            .build();
+
+        // when
+        AuthMePlayer result = AuthMePlayerImpl.fromPlayerAuth(auth);
+
+        // then
+        assertThat(result.getName(), equalTo("Victor"));
+        assertThat(result.getUuid(), equalTo(auth.getUuid()));
+        assertThat(result.getEmail(), equalTo(auth.getEmail()));
+        assertThat(result.getRegistrationDate(), equalTo(Instant.ofEpochMilli(auth.getRegistrationDate())));
+        assertThat(result.getRegistrationIpAddress(), equalTo(auth.getRegistrationIp()));
+        assertThat(result.getLastLoginDate(), equalTo(Instant.ofEpochMilli(auth.getLastLogin())));
+        assertThat(result.getLastLoginIpAddress(), equalTo(auth.getLastIp()));
+    }
+
+    @Test
+    public void shouldHandleNullAndDefaultValues() {
+        // given
+        PlayerAuth auth = PlayerAuth.builder()
+            .name("victor")
+            .realName("Victor")
+            .email("your@email.com") // DB default
+            .registrationDate(1480075661000L)
+            .lastLogin(0L) // DB default
+            .lastIp("127.0.0.1") // DB default
+            .build();
+
+        // when
+        AuthMePlayer result = AuthMePlayerImpl.fromPlayerAuth(auth);
+
+        // then
+        assertThat(result.getName(), equalTo("Victor"));
+        assertThat(result.getUuid(), nullValue());
+        assertThat(result.getEmail(), nullValue());
+        assertThat(result.getRegistrationDate(), equalTo(Instant.ofEpochMilli(auth.getRegistrationDate())));
+        assertThat(result.getRegistrationIpAddress(), nullValue());
+        assertThat(result.getLastLoginDate(), nullValue());
+        assertThat(result.getLastLoginIpAddress(), nullValue());
+    }
+}

--- a/src/test/java/fr/xephi/authme/api/v3/AuthMePlayerImplTest.java
+++ b/src/test/java/fr/xephi/authme/api/v3/AuthMePlayerImplTest.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Test for {@link AuthMePlayerImpl}.


### PR DESCRIPTION
Introduces an API method to get a lot of player info with one load from the database. Unit tests will still follow but I open this PR early to get some feedback on the naming (and anything else). Ideally we won't have to remove or rename anything in the future since this is an API so it's really worth looking at our API methods carefully.

For the naming of _AuthMePlayer_: "ApiPlayer" would make sense for us in _our_ codebase but not for anyone that is integrating our API. I also chose "Player" over "User" as I guess that's really the more used terminology in Minecraft (you have _players_ on the server; it's _players_ who register themselves in AuthMe).

cc: @RikoDEV @YellowZaki