### PR TITLE
Unrestricted inventories fix

### DIFF
--- a/src/main/java/fr/xephi/authme/listener/PlayerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/PlayerListener.java
@@ -475,7 +475,7 @@ public class PlayerListener implements Listener {
             return false;
         }
         Set<String> whitelist = settings.getProperty(RestrictionSettings.UNRESTRICTED_INVENTORIES);
-        return whitelist.contains(ChatColor.stripColor(inventory.getTitle()));
+        return whitelist.contains(ChatColor.stripColor(inventory.getTitle()).toLowerCase());
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)


### PR DESCRIPTION
UNRESTRICTED_INVENTORIES is a lowercase string set, so the inventory title also needs to be converted to lowercase in order to be able to match the inventory names specified in the config