### PR TITLE
If a player is not registered then we send a LOGIN plugin message on join

### DIFF
--- a/src/main/java/fr/xephi/authme/process/Management.java
+++ b/src/main/java/fr/xephi/authme/process/Management.java
@@ -57,6 +57,10 @@ public class Management {
         runTask(() -> asynchronousLogin.forceLogin(player));
     }
 
+    public void forceLogin(Player player, boolean quiet) {
+        runTask(() -> asynchronousLogin.forceLogin(player, quiet));
+    }
+
     public void performLogout(Player player) {
         runTask(() -> asynchronousLogout.logout(player));
     }

--- a/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
+++ b/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
@@ -14,6 +14,8 @@ import fr.xephi.authme.service.CommonService;
 import fr.xephi.authme.service.PluginHookService;
 import fr.xephi.authme.service.SessionService;
 import fr.xephi.authme.service.ValidationService;
+import fr.xephi.authme.service.bungeecord.BungeeSender;
+import fr.xephi.authme.service.bungeecord.MessageType;
 import fr.xephi.authme.settings.WelcomeMessageConfiguration;
 import fr.xephi.authme.settings.commandconfig.CommandManager;
 import fr.xephi.authme.settings.properties.HooksSettings;
@@ -71,6 +73,9 @@ public class AsynchronousJoin implements AsynchronousProcess {
 
     @Inject
     private SessionService sessionService;
+
+    @Inject
+    private BungeeSender bungeeSender;
 
     AsynchronousJoin() {
     }
@@ -135,6 +140,7 @@ public class AsynchronousJoin implements AsynchronousProcess {
             });
 
             // Skip if registration is optional
+            bungeeSender.sendAuthMeBungeecordMessage(MessageType.LOGIN, name);
             return;
         }
 

--- a/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
+++ b/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
@@ -149,7 +149,7 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
     private void performLogin(final String name) {
         Player player = bukkitService.getPlayerExact(name);
         if (player != null && player.isOnline()) {
-            management.forceLogin(player);
+            management.forceLogin(player, true);
             logger.info("The user " + player.getName() + " has been automatically logged in, "
                 + "as requested via plugin messaging.");
         }


### PR DESCRIPTION
Presently when AuthMeBungee is used and requireAuth is set to true a player needs to login before doing anything.

This will allow players who are not registered (have no password) to be treated as if they are logged in by broadcasting the LOGIN message.

This means that players who are registered will be required to login and will be unable to execute any command either on the server or on the proxy, and those who are not registered will still be able to play without needing to register.
