### PR TITLE
When performing a login we will try for up to 30s in case the player is not yet fully logged in

### DIFF
--- a/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
+++ b/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
@@ -147,10 +147,14 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
         }
     }
 
+    /**
+     * Attempt to log in player for up to 30s
+     *
+     * @param name username of player
+     */
     private void performLogin(final String name) {
-        // Attempt the login for up to 30s in case a slow player login causes this to fail
         bukkitService.runTaskTimerAsynchronously(new BukkitRunnable() {
-            int count=0;
+            private int count = 0;
 
             @Override
             public void run() {


### PR DESCRIPTION
Sometimes when switching between bungee servers the player is not yet fully connected before the backend server receives the PERFORM_LOGIN packet. This means the player is null and they will require another login attempt.

We schedule a task that will try every second for 30 seconds to attempt the login, delaying the first attempt by 5 ticks. This should fix this issue.

Closes #2126