### PR TITLE
Proxy Sessions

### DIFF
--- a/src/main/java/fr/xephi/authme/data/ProxySessionManager.java
+++ b/src/main/java/fr/xephi/authme/data/ProxySessionManager.java
@@ -1,0 +1,48 @@
+package fr.xephi.authme.data;
+
+import fr.xephi.authme.initialization.HasCleanup;
+import fr.xephi.authme.util.expiring.ExpiringSet;
+
+import javax.inject.Inject;
+import java.util.concurrent.TimeUnit;
+
+public class ProxySessionManager implements HasCleanup {
+
+    private final ExpiringSet<String> activeProxySessions;
+
+    @Inject
+    public ProxySessionManager() {
+        long countTimeout = 5;
+        activeProxySessions = new ExpiringSet<>(countTimeout, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Saves the player in the set
+     * @param name the player's name
+     */
+    private void setActiveSession(String name) {
+        activeProxySessions.add(name.toLowerCase());
+    }
+
+    /**
+     * Process a proxy session message from AuthMeBungee
+     * @param name the player to process
+     */
+    public void processProxySessionMessage(String name) {
+        setActiveSession(name);
+    }
+
+    /**
+     * Returns if the player should be logged in or not
+     * @param name the name of the player to check
+     * @return true if player has to be logged in, false otherwise
+     */
+    public boolean shouldResumeSession(String name) {
+        return activeProxySessions.contains(name);
+    }
+
+    @Override
+    public void performCleanup() {
+        activeProxySessions.removeExpiredEntries();
+    }
+}

--- a/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
+++ b/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
@@ -1,6 +1,7 @@
 package fr.xephi.authme.process.join;
 
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.data.ProxySessionManager;
 import fr.xephi.authme.data.limbo.LimboService;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.ProtectInventoryEvent;
@@ -72,6 +73,9 @@ public class AsynchronousJoin implements AsynchronousProcess {
     @Inject
     private SessionService sessionService;
 
+    @Inject
+    private ProxySessionManager proxySessionManager;
+
     AsynchronousJoin() {
     }
 
@@ -127,6 +131,15 @@ public class AsynchronousJoin implements AsynchronousProcess {
                 bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(
                     () -> commandManager.runCommandsOnSessionLogin(player));
                 bukkitService.runTaskOptionallyAsync(() -> asynchronousLogin.forceLogin(player));
+                return;
+            } else if (proxySessionManager.shouldResumeSession(name)) {
+                service.send(player, MessageKey.SESSION_RECONNECTION);
+                // Run commands
+                bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(
+                    () -> commandManager.runCommandsOnSessionLogin(player));
+                bukkitService.runTaskOptionallyAsync(() -> asynchronousLogin.forceLogin(player));
+                logger.info("The user " + player.getName() + " has been automatically logged in, "
+                    + "as present in autologin queue.");
                 return;
             }
         } else if (!service.getProperty(RegistrationSettings.FORCE)) {

--- a/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
+++ b/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
@@ -4,6 +4,7 @@ import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteStreams;
 import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
+import fr.xephi.authme.data.ProxySessionManager;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.initialization.SettingsDependent;
 import fr.xephi.authme.output.ConsoleLoggerFactory;
@@ -24,16 +25,18 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
 
     private final AuthMe plugin;
     private final BukkitService bukkitService;
+    private final ProxySessionManager proxySessionManager;
     private final Management management;
     private final DataSource dataSource;
 
     private boolean isEnabled;
 
     @Inject
-    BungeeReceiver(AuthMe plugin, BukkitService bukkitService, Management management,
-                   DataSource dataSource, Settings settings) {
+    BungeeReceiver(AuthMe plugin, BukkitService bukkitService, ProxySessionManager proxySessionManager,
+                   Management management, DataSource dataSource, Settings settings) {
         this.plugin = plugin;
         this.bukkitService = bukkitService;
+        this.proxySessionManager = proxySessionManager;
         this.management = management;
         this.dataSource = dataSource;
         reload(settings);
@@ -152,6 +155,11 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
             management.forceLogin(player);
             logger.info("The user " + player.getName() + " has been automatically logged in, "
                 + "as requested via plugin messaging.");
+        } else {
+            proxySessionManager.processProxySessionMessage(name);
+            logger.info("The user " + name + " should be automatically logged in, "
+                + "as requested via plugin messaging but has not been detected, nickname has been"
+                +" added to autologin queue.");
         }
     }
 


### PR DESCRIPTION
I would like some feedback on these points:

- ~~There is an edge case that is worth considering:~~
  - ~~What if a player joins the server with the same username as the user that is switching server?~~
    1. ~~**_Player A_** starts changing server~~
    2. ~~**_Proxy_** sends the login message to mc-server~~
    3. ~~_**mc-server**_ process the message and within the next 5 seconds grants access to _Player A_ based on nickname~~
    4. ~~**_Player B_** joins, **_with the same nickname as Player A_**, the mc-server~~
    - ~~Now _Player B_ got access to _Player A_ account without even typing a command.~~
      - ~~An idea to avoid this could be to add _Player A_ remote IP to the proxy message in order to restrict the access~~
- Configurable entries expire time
- Tests (?)


This PR is an improved version of #2276 and avoids tasks
Closes #2126