### PR TITLE
Addition of /log command in the allowCommands sequence

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -136,10 +136,11 @@ settings:
         # Hide the chat log from players who are not authenticated?
         hideChat: false
         # Allowed commands for unauthenticated players
-        allowCommands: 
+        allowCommands:
         - /login
-        - /register
+        - /log
         - /l
+        - /register
         - /reg
         - /email
         - /captcha
@@ -165,7 +166,7 @@ settings:
             enabled: false
             # WorldNames where we need to force the spawn location
             # Case-sensitive!
-            worlds: 
+            worlds:
             - world
             - world_nether
             - world_the_end
@@ -268,7 +269,7 @@ settings:
         # - '123456'
         # - 'password'
         # - 'help'
-        unsafePasswords: 
+        unsafePasswords:
         - '123456'
         - password
         - qwerty
@@ -374,7 +375,7 @@ Email:
     # Delay in minute for the recall scheduler
     delayRecall: 5
     # Blacklist these domains for emails
-    emailBlacklisted: 
+    emailBlacklisted:
     - 10minutemail.com
     # Whitelist ONLY these domains for emails
     emailWhitelisted: []
@@ -410,13 +411,13 @@ Protection:
     # https://dev.maxmind.com/geoip/legacy/codes/iso3166/
     # Use "LOCALHOST" for local addresses.
     # PLEASE USE QUOTES!
-    countries: 
+    countries:
     - US
     - GB
     - LOCALHOST
     # Countries not allowed to join the server and register
     # PLEASE USE QUOTES!
-    countriesBlacklist: 
+    countriesBlacklist:
     - A1
     # Do we need to enable automatic antibot system?
     enableAntiBot: true

--- a/src/main/java/fr/xephi/authme/settings/properties/RestrictionSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/RestrictionSettings.java
@@ -27,7 +27,7 @@ public final class RestrictionSettings implements SettingsHolder {
     @Comment("Allowed commands for unauthenticated players")
     public static final Property<Set<String>> ALLOW_COMMANDS =
         newLowercaseStringSetProperty("settings.restrictions.allowCommands",
-            "/login", "/register", "/l", "/reg", "/email", "/captcha", "/2fa", "/totp");
+            "/login", "/log", "/l", "/register", "/reg", "/email", "/captcha", "/2fa", "/totp");
 
     @Comment({
         "Max number of allowed registrations per IP",


### PR DESCRIPTION
AuthMeReloaded already registers the `/log` command by default. Then this command cannot be used **after** the user logs in (which of course is good), but the same command cannot be used **before** the user logs in as well, which makes this particular command completely useless (by default of course, without modifying the config file).

My commit resolves this situation by adding the `/log` command to the default `allowCommands` sequence so that from now on this command can be used alongside the `/login` and `/l` commands.