### PR TITLE
Fix #2018. using player's health value instead of isDead (unreliable)

### DIFF
--- a/src/main/java/fr/xephi/authme/settings/SpawnLoader.java
+++ b/src/main/java/fr/xephi/authme/settings/SpawnLoader.java
@@ -273,7 +273,7 @@ public class SpawnLoader implements Reloadable {
      * @return location of the given player if alive, spawn location if dead.
      */
     public Location getPlayerLocationOrSpawn(Player player) {
-        if (player.isOnline() && player.isDead()) {
+        if (player.getHealth() <= 0.0) {
             return getSpawnLocation(player);
         }
         return player.getLocation();


### PR DESCRIPTION
Technical information available in the last comments of the issue,  here's a recap:

When Spigot (in my case Tuinity) calls the PlayerQuitEvent, it returns a Player instance which is flagged as both dead and offline. When AuthMeReloaded saves the quit location it checks for those two values, which return garbage data. A quick and easy way to check if the Player was dead at the moment of the quit is to check it's health, which is exactly what I did. The health value is fortunately reliable and shows 0.0 if the player was dead on exit

The exploit that could take place before this fix:
If you selected "Go to title screen" upon death and rejoined the server you could "bypass" your respawn location and directly spawn on the location of your death. I've tested my fix and it works!