### PR TITLE
[Discussion] Raise BCrypt default cost factor for current computing power

### DIFF
--- a/src/main/java/fr/xephi/authme/settings/properties/HooksSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/HooksSettings.java
@@ -44,7 +44,7 @@ public final class HooksSettings implements SettingsHolder {
 
     @Comment("How much log2 rounds needed in BCrypt (do not change if you do not know what it does)")
     public static final Property<Integer> BCRYPT_LOG2_ROUND =
-        newProperty("ExternalBoardOptions.bCryptLog2Round", 10);
+        newProperty("ExternalBoardOptions.bCryptLog2Round", 12);
 
     @Comment("phpBB table prefix defined during the phpBB installation process")
     public static final Property<String> PHPBB_TABLE_PREFIX =


### PR DESCRIPTION
Based on the discussion #2356, there was the suggestion to raise the default BCrypt cost factor. This is necessary to accommodate todays increased computing power with the goal to slow down brute force attempts against leaked databases.

Notes:
* BCrypt is insecure against massively parallel GPU hashing, ASICS and FPGA (low memory requirements)
* Cost factor is a user configurable setting
* BCrypt is not our default algorithm
* Default in other software:
  * PHP: 10
  * Some Rust crates: 12
  * Ruby: 12
  * Golang: 10

Benchmark (JMH) from our BCrypt library with i7700k:
https://github.com/patrickfav/bcrypt#performance

|              | cost 6   | cost   8  | cost 10  | cost 12   | cost 14   |
|--------------|----------|-----------|----------|-----------|-----------|
| jBcrypt      |  3.43 ms |  13.75 ms | 54.76 ms | 218.62 ms | 883.55 ms |
* [Sources](https://security.stackexchange.com/questions/17207/recommended-of-rounds-for-bcrypt) imply that the common recommendation is to target 250ms

Advantages:
* Better protection against brute force attacks so it slows down the attacker

Disadvantages:
* Lower performance with weaker hardware low budget systems
* Impact for DOS impacts
* Maybe not so important for Minecraft, I guess?

Opinion:
I think we can implement the changes. DOS attacks should be implemented with other means. 