### PR TITLE
Fix SQLite file not found issue

### DIFF
--- a/src/main/java/fr/xephi/authme/datasource/SQLite.java
+++ b/src/main/java/fr/xephi/authme/datasource/SQLite.java
@@ -88,7 +88,7 @@ public class SQLite extends AbstractSqlDataSource {
         }
 
         logger.debug("SQLite driver loaded");
-        this.con = DriverManager.getConnection("jdbc:sqlite:plugins/AuthMe/" + database + ".db");
+        this.con = DriverManager.getConnection("jdbc:sqlite:" + this.dataFolder + File.separator + database + ".db");
         this.columnsHandler = AuthMeColumnsHandler.createForSqlite(con, settings);
     }
 


### PR DESCRIPTION
When OP customize bukkit/spigot plugins directory location, SQLite file will still on default directory.
It will cause directory not found exception. Also let SQLite file not correct in the plugin directory.

for example, my server use following script to execute server
```sh
SERVER_DIR="$(dirname "$PWD")"
PLUGIN_DIR="${SERVER_DIR}/plugins"
CONFIG_DIR="${SERVER_DIR}/configs"
WORLD_DIR="${SERVER_DIR}/worlds"

cd "${CONFIG_DIR}/vanilla"

java \
    -Dlog4j.configurationFile="${CONFIG_DIR}/log4j2.xml" \
    -server \
    -jar "${SERVER_DIR}/server.jar" \
    --plugins $PLUGIN_DIR \
    --world-dir $WORLD_DIR \
    --bukkit-settings "${CONFIG_DIR}/spigot/bukkit.yml" \
    --spigot-settings "${CONFIG_DIR}/spigot/spigot.yml" \
    --commands-settings "${CONFIG_DIR}/spigot/commands.yml" \
    --nogui
```

Our directory structure is as following:
```
server
  configs
    vanilla
    spigot
  plugins
  worlds
  server.jar
```

In current version, `authme.db` will create at `server/configs/vanilla/plugins/authme/authme.db`, and if directory is no exist, it will raise exception and stop server. 

Other plugin config files (e.g. `config.yml` will locate on `server/plugins/authme/`. The db file and config file not on the same directory. It not out expectation.

The pull request wanna solve this issue. I found the path of db file is hardcode, so I edit to use variable `this.dataFolder` and use `File.separator` to concat the path.