### PR TITLE
fix a flaky test 

### DIFF
--- a/src/test/java/fr/xephi/authme/listener/PlayerListenerTest.java
+++ b/src/test/java/fr/xephi/authme/listener/PlayerListenerTest.java
@@ -65,7 +65,7 @@ import java.util.UUID;
 import static com.google.common.collect.Sets.newHashSet;
 import static fr.xephi.authme.listener.EventCancelVerifier.withServiceMock;
 import static fr.xephi.authme.service.BukkitServiceTestHelper.setBukkitServiceToScheduleSyncDelayedTaskWithDelay;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -345,7 +345,7 @@ public class PlayerListenerTest {
         // message sender + 3 recipients = 4
         verify(listenerService, times(4)).shouldCancelEvent(any(Player.class));
         verify(event, never()).setCancelled(anyBoolean());
-        assertThat(event.getRecipients(), contains(recipients.get(1), recipients.get(2)));
+        assertThat(event.getRecipients(), containsInAnyOrder(recipients.get(1), recipients.get(2)));
     }
 
     @Test


### PR DESCRIPTION
A flaky test is found in this project and this PR proposes to fix it.

1. How to reproduce the flaky test
- The project is built and tested under `javaJDK8`.
- The tool used for the flaky test detection is [NonDex](https://github.com/TestingResearchIllinois/NonDex).
- I ran `mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=fr.xephi.authme.listener.PlayerListenerTest#shouldHideChatFromUnauthed`, which produces
`PlayerListenerTest.shouldHideChatFromUnauthed:348 
Expected: iterable containing [<Mock for Player, hashCode: 775174220>, <Mock for Player, hashCode: 810672306>]
but: item 0: was <Mock for Player, hashCode: 810672306>`.

2. Why the test failed
- The method `org.bukkit.event.player.AsyncPlayerChatEvent.getRecipients()` called in the test  `fr.xephi.authme.listener.PlayerListenerTest.shouldHideChatFromUnauthed` returns a set, which does not guarantee the order of the elements in it.

3. The changes made
- The `contains` in `shouldHideChatFromUnauthed` is changed to `containsInAnyOrder`, and the function `org.hamcrest.Matchers.containsInAnyOrder` is imported instead of `org.hamcrest.Matchers.contains`.