### PR TITLE
Allow REGISTRATION_IP and LAST_IP to store IPv6 addresses

### DIFF
--- a/src/main/java/fr/xephi/authme/datasource/MySQL.java
+++ b/src/main/java/fr/xephi/authme/datasource/MySQL.java
@@ -213,7 +213,7 @@ public class MySQL extends AbstractSqlDataSource {
 
             if (isColumnMissing(md, col.LAST_IP)) {
                 st.executeUpdate("ALTER TABLE " + tableName
-                    + " ADD COLUMN " + col.LAST_IP + " VARCHAR(40) CHARACTER SET ascii COLLATE ascii_bin;");
+                    + " ADD COLUMN " + col.LAST_IP + " VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin;");
             } else {
                 MySqlMigrater.migrateLastIpColumn(st, md, tableName, col);
             }
@@ -231,7 +231,7 @@ public class MySQL extends AbstractSqlDataSource {
 
             if (isColumnMissing(md, col.REGISTRATION_IP)) {
                 st.executeUpdate("ALTER TABLE " + tableName
-                    + " ADD COLUMN " + col.REGISTRATION_IP + " VARCHAR(40) CHARACTER SET ascii COLLATE ascii_bin;");
+                    + " ADD COLUMN " + col.REGISTRATION_IP + " VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin;");
             }
 
             if (isColumnMissing(md, col.LASTLOC_X)) {


### PR DESCRIPTION
Fixing #1782 by increasing the maximum `VARCHAR` field length. You should also add a migration to update to a new length from previous versions.