### PR TITLE
Add test for AuthMeApi.getLastLoginMillis

### DIFF
--- a/src/test/java/fr/xephi/authme/api/v3/AuthMeApiTest.java
+++ b/src/test/java/fr/xephi/authme/api/v3/AuthMeApiTest.java
@@ -242,6 +242,12 @@ public class AuthMeApiTest {
     }
 
     @Test
+    public void testGetLastLoginMillis() {
+        AuthMeApi result = AuthMeApi.getInstance();
+        assertThat(result.getLastLoginTime("notAPlayer"), nullValue());
+    }
+
+    @Test
     public void shouldHandleNullLastLoginTime() {
         // given
         String name = "John";


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `result.getLastLoginTime("notAPlayer")` is null when `getLastLoginTime` is called with the parameter `playerName = "notAPlayer"`.
This tests the method [`AuthMeApi.getLastLoginMillis`](https://github.com/AuthMe/AuthMeReloaded/blob/3892bb692354d4591aac023f5eb05f68466c8353/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java#L202).
This test is based on the test [`shouldReturnInstanceOrNull`](https://github.com/AuthMe/AuthMeReloaded/blob/3892bb692354d4591aac023f5eb05f68466c8353/src/test/java/fr/xephi/authme/api/v3/AuthMeApiTest.java#L75).

Curious to hear what you think!

Also, is the description I provided of the test is helping you to answer to this pull request? Why (not)?

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))