### PR TITLE
Execute simple check before enable BungeeCord hook.

### DIFF
--- a/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
+++ b/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
@@ -20,7 +20,7 @@ import javax.inject.Inject;
 import java.util.Optional;
 
 public class BungeeReceiver implements PluginMessageListener, SettingsDependent {
-    
+
     private final ConsoleLogger logger = ConsoleLoggerFactory.get(BungeeReceiver.class);
 
     private final AuthMe plugin;
@@ -45,7 +45,9 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
     @Override
     public void reload(final Settings settings) {
         this.isEnabled = settings.getProperty(HooksSettings.BUNGEECORD);
-
+        if (this.isEnabled) {
+            this.isEnabled = bukkitService.isBungeeCordConfiguredForSpigot().orElse(false);
+        }
         if (this.isEnabled) {
             final Messenger messenger = plugin.getServer().getMessenger();
             if (!messenger.isIncomingChannelRegistered(plugin, "BungeeCord")) {
@@ -159,7 +161,7 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
             proxySessionManager.processProxySessionMessage(name);
             logger.info("The user " + name + " should be automatically logged in, "
                 + "as requested via plugin messaging but has not been detected, nickname has been"
-                +" added to autologin queue.");
+                + " added to autologin queue.");
         }
     }
 

--- a/src/main/java/fr/xephi/authme/settings/SettingsWarner.java
+++ b/src/main/java/fr/xephi/authme/settings/SettingsWarner.java
@@ -67,6 +67,14 @@ public class SettingsWarner {
                 + " AuthMeBungee add-on to work properly you have to enable this option!");
         }
 
+        if (!isTrue(bukkitService.isBungeeCordConfiguredForSpigot())
+            && settings.getProperty(HooksSettings.BUNGEECORD)) {
+            logger.warning("Note: Hooks.bungeecord is set to true but your server appears to be running in"
+                + " non-bungeecord mode (see your spigot.yml). In order to prevent untrusted payload attack, "
+                + "BungeeCord hook will be automatically disabled!");
+        }
+
+
         // Check if argon2 library is present and can be loaded
         if (settings.getProperty(SecuritySettings.PASSWORD_HASH).equals(HashAlgorithm.ARGON2)
             && !Argon2.isLibraryLoaded()) {


### PR DESCRIPTION
This PR added a simple check that check spigot.yml -> settings.bungeecord status by using AuthMe built-in method bukkitService.isBungeeCordConfiguredForSpigot() and disable hook if it enabled and not behind an BungeeCord proxy.

Register plugin message channel without BungeeCord proxy will allow attacker send fake login payload to treat AuthMe login with Plugin Message for him and bypass the user login.

Fixed:
https://github.com/AuthMe/AuthMeReloaded/issues/2571
https://github.com/AuthMe/AuthMeReloaded/issues/2559