### PR TITLE
Run workflows for pull requests too to verify the test results

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,10 @@
 name: Java CI
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build_and_test:


### PR DESCRIPTION
This runs the the Maven workflow for pull requests targeting the main branch too. This can be useful to verify if the actually compiles and the test runs. 

However GitHub has bug/logic error that configurations like in this PR runs twice, because `push` and `pull_request` triggers for internal branches.

See this for reference:

https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012