### PR TITLE
Add support MariaDB driver & fix MySQL column check; 

### DIFF
--- a/src/main/java/fr/xephi/authme/datasource/AbstractSqlDataSource.java
+++ b/src/main/java/fr/xephi/authme/datasource/AbstractSqlDataSource.java
@@ -167,4 +167,6 @@ public abstract class AbstractSqlDataSource implements DataSource {
             return DataSourceValueImpl.unknownRow();
         }
     }
+
+    abstract String getJdbcUrl(String host, String port, String database);
 }

--- a/src/main/java/fr/xephi/authme/datasource/DataSourceType.java
+++ b/src/main/java/fr/xephi/authme/datasource/DataSourceType.java
@@ -7,6 +7,8 @@ public enum DataSourceType {
 
     MYSQL,
 
+    MARIADB,
+
     POSTGRESQL,
 
     SQLITE

--- a/src/main/java/fr/xephi/authme/datasource/MariaDB.java
+++ b/src/main/java/fr/xephi/authme/datasource/MariaDB.java
@@ -1,0 +1,22 @@
+package fr.xephi.authme.datasource;
+
+import fr.xephi.authme.datasource.mysqlextensions.MySqlExtensionsFactory;
+import fr.xephi.authme.settings.Settings;
+
+import java.sql.SQLException;
+
+public class MariaDB extends MySQL {
+    public MariaDB(Settings settings, MySqlExtensionsFactory extensionsFactory) throws SQLException {
+        super(settings, extensionsFactory);
+    }
+
+    @Override
+    String getJdbcUrl(String host, String port, String database) {
+        return "jdbc:mariadb://" + host + ":" + port + "/" + database;
+    }
+
+    @Override
+    public DataSourceType getType() {
+        return DataSourceType.MARIADB;
+    }
+}

--- a/src/main/java/fr/xephi/authme/datasource/MySQL.java
+++ b/src/main/java/fr/xephi/authme/datasource/MySQL.java
@@ -299,7 +299,7 @@ public class MySQL extends AbstractSqlDataSource {
     }
 
     private boolean isColumnMissing(DatabaseMetaData metaData, String columnName) throws SQLException {
-        try (ResultSet rs = metaData.getColumns(null, null, tableName, columnName)) {
+        try (ResultSet rs = metaData.getColumns(database, null, tableName, columnName)) {
             return !rs.next();
         }
     }
@@ -346,6 +346,11 @@ public class MySQL extends AbstractSqlDataSource {
             logSqlException(ex);
         }
         return false;
+    }
+
+    @Override
+    String getJdbcUrl(String host, String port, String database) {
+        return "jdbc:mysql://" + host + ":" + port + "/" + database;
     }
 
     @Override

--- a/src/main/java/fr/xephi/authme/datasource/MySQL.java
+++ b/src/main/java/fr/xephi/authme/datasource/MySQL.java
@@ -134,7 +134,7 @@ public class MySQL extends AbstractSqlDataSource {
         ds.setMaxLifetime(maxLifetime * 1000L);
 
         // Database URL
-        ds.setJdbcUrl("jdbc:mysql://" + this.host + ":" + this.port + "/" + this.database);
+        ds.setJdbcUrl(this.getJdbcUrl(this.host, this.port, this.database));
 
         // Auth
         ds.setUsername(this.username);

--- a/src/main/java/fr/xephi/authme/datasource/PostgreSqlDataSource.java
+++ b/src/main/java/fr/xephi/authme/datasource/PostgreSqlDataSource.java
@@ -119,7 +119,7 @@ public class PostgreSqlDataSource extends AbstractSqlDataSource {
 
         // Database URL
         ds.setDriverClassName("org.postgresql.Driver");
-        ds.setJdbcUrl("jdbc:postgresql://" + this.host + ":" + this.port + "/" + this.database);
+        ds.setJdbcUrl(this.getJdbcUrl(this.host, this.port, this.database));
 
         // Auth
         ds.setUsername(this.username);
@@ -304,6 +304,11 @@ public class PostgreSqlDataSource extends AbstractSqlDataSource {
             logSqlException(ex);
         }
         return false;
+    }
+
+    @Override
+    String getJdbcUrl(String host, String port, String database) {
+        return "jdbc:postgresql://" + host + ":" + port + "/" + database;
     }
 
     @Override

--- a/src/main/java/fr/xephi/authme/datasource/SQLite.java
+++ b/src/main/java/fr/xephi/authme/datasource/SQLite.java
@@ -88,7 +88,7 @@ public class SQLite extends AbstractSqlDataSource {
         }
 
         logger.debug("SQLite driver loaded");
-        this.con = DriverManager.getConnection("jdbc:sqlite:" + this.dataFolder + File.separator + database + ".db");
+        this.con = DriverManager.getConnection(this.getJdbcUrl(this.dataFolder.getAbsolutePath(), "", this.database));
         this.columnsHandler = AuthMeColumnsHandler.createForSqlite(con, settings);
     }
 
@@ -403,6 +403,11 @@ public class SQLite extends AbstractSqlDataSource {
             tableName, col.REGISTRATION_DATE, currentTimestamp));
         logger.info("Created column '" + col.REGISTRATION_DATE + "' and set the current timestamp, "
             + currentTimestamp + ", to all " + updatedRows + " rows");
+    }
+
+    @Override
+    String getJdbcUrl(String dataPath, String ignored, String database) {
+        return "jdbc:sqlite:" + dataPath + File.separator + database + ".db";
     }
 
     private static void close(Connection con) {

--- a/src/main/java/fr/xephi/authme/initialization/DataSourceProvider.java
+++ b/src/main/java/fr/xephi/authme/initialization/DataSourceProvider.java
@@ -5,6 +5,7 @@ import fr.xephi.authme.data.auth.PlayerCache;
 import fr.xephi.authme.datasource.CacheDataSource;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.datasource.DataSourceType;
+import fr.xephi.authme.datasource.MariaDB;
 import fr.xephi.authme.datasource.MySQL;
 import fr.xephi.authme.datasource.PostgreSqlDataSource;
 import fr.xephi.authme.datasource.SQLite;
@@ -65,6 +66,9 @@ public class DataSourceProvider implements Provider<DataSource> {
         switch (dataSourceType) {
             case MYSQL:
                 dataSource = new MySQL(settings, mySqlExtensionsFactory);
+                break;
+            case MARIADB:
+                dataSource = new MariaDB(settings, mySqlExtensionsFactory);
                 break;
             case POSTGRESQL:
                 dataSource = new PostgreSqlDataSource(settings, mySqlExtensionsFactory);


### PR DESCRIPTION
Trying to use this plugin with MariaDB, I got exceptions related to `MySQL.isColumnMissing` (error report below), 
I do not have MySQL for the test, but https://github.com/AuthMe/AuthMeReloaded/issues/2543 shows the same error on MySQL
This PR fixes it
```
[12:01:12 WARN]: [AuthMe] Can't initialize the MySQL database: [SQLSyntaxErrorException]: Unknown column 'x' in 'authme'
[12:01:12 WARN]: [AuthMe] Please check your database settings in the config.yml file!
[12:01:12 WARN]: [AuthMe] Could not create data source: [SQLSyntaxErrorException]: Unknown column 'x' in 'authme'
[12:01:12 WARN]: [AuthMe] Aborting initialization of AuthMe: [IllegalStateException]: Error during initialization of data source
[12:01:12 WARN]: java.lang.IllegalStateException: Error during initialization of data source
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.initialization.DataSourceProvider.get(DataSourceProvider.java:53)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.initialization.DataSourceProvider.get(DataSourceProvider.java:26)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.ch.jalu.injector.handlers.instantiation.ProviderHandler$InstantiationByProviderClass.instantiateWith(ProviderHandler.java:129)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.ch.jalu.injector.InjectorImpl.resolveContext(InjectorImpl.java:164)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.ch.jalu.injector.InjectorImpl.resolve(InjectorImpl.java:133)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.ch.jalu.injector.InjectorImpl.getSingleton(InjectorImpl.java:72)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.AuthMe.instantiateServices(AuthMe.java:245)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.AuthMe.initialize(AuthMe.java:221)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.AuthMe.onEnable(AuthMe.java:145)
[12:01:12 WARN]:        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:264)
[12:01:12 WARN]:        at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:370)
[12:01:12 WARN]:        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:542)
[12:01:12 WARN]:        at org.bukkit.craftbukkit.v1_19_R1.CraftServer.enablePlugin(CraftServer.java:563)
[12:01:12 WARN]:        at org.bukkit.craftbukkit.v1_19_R1.CraftServer.enablePlugins(CraftServer.java:477)
[12:01:12 WARN]:        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:634)
[12:01:12 WARN]:        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:420)
[12:01:12 WARN]:        at net.minecraft.server.dedicated.DedicatedServer.e(DedicatedServer.java:306)
[12:01:12 WARN]:        at net.minecraft.server.MinecraftServer.v(MinecraftServer.java:1122)
[12:01:12 WARN]:        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:303)
[12:01:12 WARN]:        at java.base/java.lang.Thread.run(Thread.java:833)
[12:01:12 WARN]: Caused by: java.sql.SQLSyntaxErrorException: Unknown column 'x' in 'authme'
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.com.mysql.cj.jdbc.StatementImpl.executeUpdateInternal(StatementImpl.java:1337)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.com.mysql.cj.jdbc.StatementImpl.executeLargeUpdate(StatementImpl.java:2112)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.com.mysql.cj.jdbc.StatementImpl.executeUpdate(StatementImpl.java:1247)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.com.zaxxer.hikari.pool.ProxyStatement.executeUpdate(ProxyStatement.java:119)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.libs.com.zaxxer.hikari.pool.HikariProxyStatement.executeUpdate(HikariProxyStatement.java)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.datasource.MySQL.checkTablesAndColumns(MySQL.java:253)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.datasource.MySQL.<init>(MySQL.java:80)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.initialization.DataSourceProvider.createDataSource(DataSourceProvider.java:68)
[12:01:12 WARN]:        at AuthMe-5.6.0-SNAPSHOT.jar//fr.xephi.authme.initialization.DataSourceProvider.get(DataSourceProvider.java:50)
[12:01:12 WARN]:        ... 19 more
[12:01:12 WARN]: [AuthMe] THE SERVER IS GOING TO SHUT DOWN AS DEFINED IN THE CONFIGURATION!
```

Also fixed the use of MariaDB driver and created a class to override MySQL methods.