### PR TITLE
Fix automatic antibot

### DIFF
--- a/src/main/java/fr/xephi/authme/service/AntiBotService.java
+++ b/src/main/java/fr/xephi/authme/service/AntiBotService.java
@@ -56,7 +56,7 @@ public class AntiBotService implements SettingsDependent {
         duration = settings.getProperty(ProtectionSettings.ANTIBOT_DURATION);
         int sensibility = settings.getProperty(ProtectionSettings.ANTIBOT_SENSIBILITY);
         int interval = settings.getProperty(ProtectionSettings.ANTIBOT_INTERVAL);
-        flaggedCounter = new AtomicIntervalCounter(sensibility, interval);
+        flaggedCounter = new AtomicIntervalCounter(sensibility, interval * 1000);
 
         // Stop existing protection
         stopProtection();


### PR DESCRIPTION
I was wondering why the automatic antibot never triggered no matter what settings I used.
So after doing some debugging and testing with some bots on a local server, looks like it was a pretty simple mistake.
The counter interval should be a value in miliseconds instead of seconds so it was never counting up (unless bots joined under 5 miliseconds). So it should actually work now.