### PR TITLE
Use sslMode on MariaDB (remove warning)

### DIFF
--- a/src/main/java/fr/xephi/authme/datasource/MySQL.java
+++ b/src/main/java/fr/xephi/authme/datasource/MySQL.java
@@ -41,6 +41,7 @@ public class MySQL extends AbstractSqlDataSource {
     private boolean useSsl;
     private boolean serverCertificateVerification;
     private boolean allowPublicKeyRetrieval;
+    private String sslMode;
     private String host;
     private String port;
     private String username;
@@ -121,6 +122,7 @@ public class MySQL extends AbstractSqlDataSource {
         this.useSsl = settings.getProperty(DatabaseSettings.MYSQL_USE_SSL);
         this.serverCertificateVerification = settings.getProperty(DatabaseSettings.MYSQL_CHECK_SERVER_CERTIFICATE);
         this.allowPublicKeyRetrieval = settings.getProperty(DatabaseSettings.MYSQL_ALLOW_PUBLIC_KEY_RETRIEVAL);
+        this.sslMode = settings.getProperty(DatabaseSettings.SSL_MODE);
     }
 
     /**
@@ -145,7 +147,11 @@ public class MySQL extends AbstractSqlDataSource {
         ds.setDriverClassName(this.getDriverClassName());
 
         // Request mysql over SSL
-        ds.addDataSourceProperty("useSSL", String.valueOf(useSsl));
+        if (this instanceof MariaDB) {
+            ds.addDataSourceProperty("sslMode", sslMode);
+        }else {
+            ds.addDataSourceProperty("useSSL", String.valueOf(useSsl));
+        }
 
         // Disabling server certificate verification on need
         if (!serverCertificateVerification) {

--- a/src/main/java/fr/xephi/authme/datasource/MySQL.java
+++ b/src/main/java/fr/xephi/authme/datasource/MySQL.java
@@ -151,12 +151,14 @@ public class MySQL extends AbstractSqlDataSource {
             ds.addDataSourceProperty("sslMode", sslMode);
         }else {
             ds.addDataSourceProperty("useSSL", String.valueOf(useSsl));
+
+            // Disabling server certificate verification on need
+            if (!serverCertificateVerification) {
+                ds.addDataSourceProperty("verifyServerCertificate", String.valueOf(false));
+            }
         }
 
         // Disabling server certificate verification on need
-        if (!serverCertificateVerification) {
-            ds.addDataSourceProperty("verifyServerCertificate", String.valueOf(false));
-        }        // Disabling server certificate verification on need
         if (allowPublicKeyRetrieval) {
             ds.addDataSourceProperty("allowPublicKeyRetrieval", String.valueOf(true));
         }

--- a/src/main/java/fr/xephi/authme/settings/properties/DatabaseSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/DatabaseSettings.java
@@ -27,7 +27,17 @@ public final class DatabaseSettings implements SettingsHolder {
     public static final Property<String> MYSQL_PORT =
         newProperty("DataSource.mySQLPort", "3306");
 
-    @Comment("Connect to MySQL database over SSL")
+    @Comment({"Replacement of Mysql's useSsl (for MariaDB only).",
+        "- disable: No SSL",
+        "- trust: Trust blindly (no validation)",
+        "- verify_ca:  Encryption, certificates validation, BUT no hostname verification",
+        "- verify_full: Encryption, certificate validation and hostname validation",
+        "Read more: https://bit.ly/mariadb-sslmode"})
+    public static final Property<String> SSL_MODE =
+        newProperty("DataSource.sslMode", "disabled");
+
+    @Comment({"Connect to MySQL database over SSL",
+        "If you're using MariaDB, use sslMode instead"})
     public static final Property<Boolean> MYSQL_USE_SSL =
         newProperty("DataSource.mySQLUseSSL", true);
 
@@ -38,7 +48,8 @@ public final class DatabaseSettings implements SettingsHolder {
         newProperty( "DataSource.mySQLCheckServerCertificate", true );
 
     @Comment({"Authorize client to retrieve RSA server public key.",
-        "Advanced option, ignore if you don't know what it means."})
+        "Advanced option, ignore if you don't know what it means.",
+        "If you're using MariaDB, use sslMode instead"})
     public static final Property<Boolean> MYSQL_ALLOW_PUBLIC_KEY_RETRIEVAL =
         newProperty( "DataSource.mySQLAllowPublicKeyRetrieval", true );
 


### PR DESCRIPTION
Replaced '**_mySQLUseSSL_**' and '**_mySQLCheckServerCertificate_**'  with '**_sslMode_**' (modern certificate and identity verification for MariaDB).
This change effectively removes annoying messages

```
[AuthMe] [STDERR] [AuthMeMYSQLPool connection adder] WARN fr.xephi.authme.libs.org.mariadb.jdbc.Configuration - `useSsl` option is deprecated, replaced by option `sslMode`
```
```
[me.lucko.luckperms.lib.mariadb.Configuration] `useSsl` option is deprecated, replaced by option `sslMode`
```
Which in turn trigger
```
Nag author(s): '[sgdc3, games647, Hex3l, krusic22]' of 'AuthMe v5.6.0-SNAPSHOT-b2614' about their usage of System.out/err.print. Please use your plugin's logger instead (JavaPlugin#getLogger).
```