### PR TITLE
Synchronize the PlayerAuthObject to prevent bugs

### DIFF
--- a/src/main/java/fr/xephi/authme/process/register/executors/PasswordRegisterExecutor.java
+++ b/src/main/java/fr/xephi/authme/process/register/executors/PasswordRegisterExecutor.java
@@ -10,7 +10,7 @@ import static fr.xephi.authme.process.register.executors.PlayerAuthBuilderHelper
 class PasswordRegisterExecutor extends AbstractPasswordRegisterExecutor<PasswordRegisterParams> {
 
     @Override
-    public PlayerAuth createPlayerAuthObject(PasswordRegisterParams params) {
+    public synchronized PlayerAuth createPlayerAuthObject(PasswordRegisterParams params) {
         return createPlayerAuth(params.getPlayer(), params.getHashedPassword(), params.getEmail());
     }
 


### PR DESCRIPTION
When multiple players try to register at the same time, the following exception will throw:

![IMG_3568](https://github.com/AuthMe/AuthMeReloaded/assets/102713261/91d16b42-5845-4f0a-a7af-5d6db731ac1b)

Configuration is default set

How to reproduce this: Use a bot tool to make them register at same time.

Synchronize the method will resolve this, I have tested multiple times, works fine and didn't break anything.