### PR TITLE
Fix: Teleporting Players to Spawn on Login with teleportUnAuthedToSpawn=true

### DIFF
--- a/src/main/java/fr/xephi/authme/service/TeleportationService.java
+++ b/src/main/java/fr/xephi/authme/service/TeleportationService.java
@@ -146,7 +146,12 @@ public class TeleportationService implements Reloadable {
                 teleportBackFromSpawn(player, location);
             } else if (limbo != null && limbo.getLocation() != null) {
                 logger.debug("Teleporting `{0}` after login, based on the limbo player", player.getName());
-                teleportBackFromSpawn(player, limbo.getLocation());
+                //check for essential's quit location exists
+                Location location = spawnLoader.getEssentialsQuitLocation(player);
+                if(location != null)
+                    teleportBackFromSpawn(player, location);
+                else
+                    teleportBackFromSpawn(player, limbo.getLocation());
             }
         }
     }

--- a/src/main/java/fr/xephi/authme/settings/SpawnLoader.java
+++ b/src/main/java/fr/xephi/authme/settings/SpawnLoader.java
@@ -146,16 +146,13 @@ public class SpawnLoader implements Reloadable {
 
         String path = "userdata/" + player.getUniqueId() + ".yml";
         File essentialsUserdataFile = new File(essentialsFolder, path);
-        logger.info(essentialsUserdataFile.getAbsolutePath());
         if (essentialsUserdataFile.exists()) {
-            logger.info("Found location!");
 
             YamlConfiguration config = YamlConfiguration.loadConfiguration(essentialsUserdataFile);
             if (config.contains("logoutlocation")) {
                 String worldName = config.getString("logoutlocation.world-name");
                 World world = Bukkit.getWorld(worldName);
                 if (world == null) {
-                    logger.warning("World not found: " + worldName);
                     return null;
                 }
                 double x = config.getDouble("logoutlocation.x");
@@ -165,14 +162,13 @@ public class SpawnLoader implements Reloadable {
                 float pitch = (float) config.getDouble("logoutlocation.pitch");
 
                 Location location = new Location(world, x, y, z, yaw, pitch);
-                logger.info(location.toString());
                 return location;
             } else {
-                logger.info("logoutlocation not found in file: " + essentialsUserdataFile.getAbsolutePath());
+                logger.debug("logoutlocation not found in userdata file: " + essentialsUserdataFile.getAbsolutePath());
                 return null;
             }
         } else {
-            logger.info("Essentials userdata file not found: '" + essentialsUserdataFile.getAbsolutePath() + "'");
+            logger.debug("Essentials userdata file not found: '" + essentialsUserdataFile.getAbsolutePath() + "'");
             return null;
         }
     }

--- a/src/main/java/fr/xephi/authme/settings/SpawnLoader.java
+++ b/src/main/java/fr/xephi/authme/settings/SpawnLoader.java
@@ -129,6 +129,56 @@ public class SpawnLoader implements Reloadable {
     }
 
     /**
+     * Retrieves the last logout location of a player from their Essentials data file.
+     *
+     * This function fetches the player's data file from the Essentials data folder,
+     * reads the 'logoutlocation' section, and constructs a Location object from it.
+     * If the file or the location data is not found, it returns null.
+     *
+     * @param player The player whose logout location is to be retrieved.
+     * @return The last known logout location of the player, or null if not found.
+     */
+    public Location getEssentialsQuitLocation(Player player) {
+        File essentialsFolder = pluginHookService.getEssentialsDataFolder();
+        if (essentialsFolder == null) {
+            return null;
+        }
+
+        String path = "userdata/" + player.getUniqueId() + ".yml";
+        File essentialsUserdataFile = new File(essentialsFolder, path);
+        logger.info(essentialsUserdataFile.getAbsolutePath());
+        if (essentialsUserdataFile.exists()) {
+            logger.info("Found location!");
+
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(essentialsUserdataFile);
+            if (config.contains("logoutlocation")) {
+                String worldName = config.getString("logoutlocation.world-name");
+                World world = Bukkit.getWorld(worldName);
+                if (world == null) {
+                    logger.warning("World not found: " + worldName);
+                    return null;
+                }
+                double x = config.getDouble("logoutlocation.x");
+                double y = config.getDouble("logoutlocation.y");
+                double z = config.getDouble("logoutlocation.z");
+                float yaw = (float) config.getDouble("logoutlocation.yaw");
+                float pitch = (float) config.getDouble("logoutlocation.pitch");
+
+                Location location = new Location(world, x, y, z, yaw, pitch);
+                logger.info(location.toString());
+                return location;
+            } else {
+                logger.info("logoutlocation not found in file: " + essentialsUserdataFile.getAbsolutePath());
+                return null;
+            }
+        } else {
+            logger.info("Essentials userdata file not found: '" + essentialsUserdataFile.getAbsolutePath() + "'");
+            return null;
+        }
+    }
+
+
+    /**
      * Unset the spawn point defined in EssentialsSpawn.
      */
     public void unloadEssentialsSpawn() {


### PR DESCRIPTION
Issue: When changing the config option teleportUnAuthedToSpawn=true during midgame, players were teleported to spawn on their next login. It only happens once after the update.

Patch: AuthMe now checks the player's last logout location from Essentials if it is not found in the AuthMe database. This ensures players are teleported to their last known location instead of the spawn point when the configuration is changed mid-game.