### PR TITLE
Fix y = 0 teleportUnAuthedToSpawn bug

### DIFF
--- a/src/main/java/fr/xephi/authme/process/login/ProcessSyncPlayerLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/ProcessSyncPlayerLogin.java
@@ -90,6 +90,11 @@ public class ProcessSyncPlayerLogin implements SynchronousProcess {
         }
 
         final PlayerAuth auth = playerCache.getAuth(name);
+
+        if (isFirstLogin) { // Save quit location before login teleport
+            auth.setQuitLocation(player.getLocation());
+        }
+
         teleportationService.teleportOnLogin(player, auth, limbo);
 
         // We can now display the join message (if delayed)

--- a/src/main/java/fr/xephi/authme/service/TeleportationService.java
+++ b/src/main/java/fr/xephi/authme/service/TeleportationService.java
@@ -140,7 +140,7 @@ public class TeleportationService implements Reloadable {
             logger.debug("Teleporting `{0}` to spawn because of 'force-spawn after login'", player.getName());
             teleportToSpawn(player, true);
         } else if (settings.getProperty(TELEPORT_UNAUTHED_TO_SPAWN)) {
-            if (settings.getProperty(RestrictionSettings.SAVE_QUIT_LOCATION) && auth.getQuitLocY() != 0) {
+            if (settings.getProperty(RestrictionSettings.SAVE_QUIT_LOCATION)) {
                 Location location = buildLocationFromAuth(player, auth);
                 logger.debug("Teleporting `{0}` after login, based on the player auth", player.getName());
                 teleportBackFromSpawn(player, location);

--- a/src/test/java/fr/xephi/authme/service/TeleportationServiceTest.java
+++ b/src/test/java/fr/xephi/authme/service/TeleportationServiceTest.java
@@ -22,10 +22,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Arrays;
 
 import static fr.xephi.authme.service.BukkitServiceTestHelper.setBukkitServiceToScheduleSyncTaskFromOptionallyAsyncTask;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -326,30 +325,6 @@ public class TeleportationServiceTest {
         ArgumentCaptor<Location> locationCaptor = ArgumentCaptor.forClass(Location.class);
         verify(player).teleport(locationCaptor.capture());
         assertCorrectLocation(locationCaptor.getValue(), auth, world);
-    }
-
-    @Test
-    public void shouldTeleportWithLimboPlayerIfAuthYCoordIsNotSet() {
-        // given
-        given(settings.getProperty(RestrictionSettings.TELEPORT_UNAUTHED_TO_SPAWN)).willReturn(true);
-        given(settings.getProperty(RestrictionSettings.SAVE_QUIT_LOCATION)).willReturn(true);
-
-        PlayerAuth auth = createAuthWithLocation();
-        auth.setQuitLocY(0.0);
-        auth.setWorld("authWorld");
-        Player player = mock(Player.class);
-        given(player.isOnline()).willReturn(true);
-        LimboPlayer limbo = mock(LimboPlayer.class);
-        Location location = mockLocation();
-        given(limbo.getLocation()).willReturn(location);
-        setBukkitServiceToScheduleSyncTaskFromOptionallyAsyncTask(bukkitService);
-
-        // when
-        teleportationService.teleportOnLogin(player, auth, limbo);
-
-        // then
-        verify(player).teleport(location);
-        verify(bukkitService, never()).getWorld(anyString());
     }
 
     @Test


### PR DESCRIPTION
This pull request resolves #2723.

#### Changes:
- Save a quit location before first login teleport
- Removed y = 0 check in TeleportationService
- Removed y coordinate validation test, since y coordinate is always set

This fix works fine in my own fork and no bugs found(currently)