### PR TITLE
regex support for email whitelist

### DIFF
--- a/src/main/java/fr/xephi/authme/service/ValidationService.java
+++ b/src/main/java/fr/xephi/authme/service/ValidationService.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import static fr.xephi.authme.util.StringUtils.isInsideString;
 
@@ -202,13 +203,21 @@ public class ValidationService implements Reloadable {
 
     private static boolean containsIgnoreCase(Collection<String> coll, String needle) {
         for (String entry : coll) {
-            if (entry.equalsIgnoreCase(needle)) {
+            if (entry.startsWith("r:")) {
+                String pattern = entry.substring(2);
+                try {
+                    if (Pattern.compile(pattern, Pattern.CASE_INSENSITIVE).matcher(needle).matches()) {
+                        return true;
+                    }
+                } catch (PatternSyntaxException e) {
+                    //possible way to log error?
+                }
+            } else if (entry.equalsIgnoreCase(needle)) {
                 return true;
             }
         }
         return false;
     }
-
     /**
      * Loads the configured name restrictions into a Multimap by player name (all-lowercase).
      *

--- a/src/main/java/fr/xephi/authme/settings/properties/EmailSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/EmailSettings.java
@@ -63,7 +63,7 @@ public final class EmailSettings implements SettingsHolder {
     public static final Property<List<String>> DOMAIN_BLACKLIST =
         newListProperty("Email.emailBlacklisted", "10minutemail.com");
 
-    @Comment("Whitelist ONLY these domains for emails")
+    @Comment("Whitelist ONLY these domains for emails. Use 'r:' prefix for regex patterns (e.g. 'r:.*\\.gmail\\.com')")
     public static final Property<List<String>> DOMAIN_WHITELIST =
         newListProperty("Email.emailWhitelisted");
 

--- a/src/main/java/fr/xephi/authme/settings/properties/EmailSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/EmailSettings.java
@@ -63,7 +63,7 @@ public final class EmailSettings implements SettingsHolder {
     public static final Property<List<String>> DOMAIN_BLACKLIST =
         newListProperty("Email.emailBlacklisted", "10minutemail.com");
 
-    @Comment("Whitelist ONLY these domains for emails. Use 'r:' prefix for regex patterns (e.g. 'r:.*\\.gmail\\.com')")
+    @Comment("Whitelist ONLY these domains for emails. Use 'r:' prefix for regex")
     public static final Property<List<String>> DOMAIN_WHITELIST =
         newListProperty("Email.emailWhitelisted");
 


### PR DESCRIPTION
I added regex support for email whitelist while maintaining the support for old format

now a user can set it like:

 ```
 # Whitelist ONLY these domains for emails
    emailWhitelisted: [gmail.com,r:.*\.ac\.jp]
```

this pull request solves the problem in the following issue:
https://github.com/AuthMe/AuthMeReloaded/issues/2084
