### PR TITLE
feat(premium): allow changing the default auth servers

### DIFF
--- a/authme-core/src/main/java/fr/xephi/authme/service/MojangApiService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/MojangApiService.java
@@ -3,6 +3,8 @@ package fr.xephi.authme.service;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.util.UuidUtils;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.PremiumSettings;
 
 import javax.inject.Inject;
 import java.io.BufferedReader;
@@ -21,16 +23,16 @@ import java.util.regex.Pattern;
  */
 public class MojangApiService {
 
-    private static final String PROFILE_URL = "https://api.mojang.com/users/profiles/minecraft/";
-    private static final String HAS_JOINED_URL =
-        "https://sessionserver.mojang.com/session/minecraft/hasJoined";
     private static final Pattern UUID_PATTERN =
         Pattern.compile("\"id\"\\s*:\\s*\"([0-9a-fA-F]{32})\"");
 
     private final ConsoleLogger logger = ConsoleLoggerFactory.get(MojangApiService.class);
 
+    private Settings settings;
+
     @Inject
-    MojangApiService() {
+    MojangApiService(Settings settings) {
+        this.settings = settings;
     }
 
     /**
@@ -41,7 +43,7 @@ public class MojangApiService {
      */
     public Optional<UUID> fetchUuidByName(String username) {
         try {
-            HttpURLConnection conn = openGet(PROFILE_URL + username);
+            HttpURLConnection conn = openGet(settings.getProperty(PremiumSettings.ACCOUNT_SERVER) + username);
             int code = conn.getResponseCode();
             if (code == HttpURLConnection.HTTP_NO_CONTENT || code == HttpURLConnection.HTTP_NOT_FOUND) {
                 return Optional.empty();
@@ -70,7 +72,7 @@ public class MojangApiService {
      */
     public Optional<UUID> hasJoined(String username, String serverHash) {
         try {
-            String url = HAS_JOINED_URL + "?username=" + username + "&serverId=" + serverHash;
+            String url = settings.getProperty(PremiumSettings.SESSION_SERVER) + "?username=" + username + "&serverId=" + serverHash;
             HttpURLConnection conn = openGet(url);
             int code = conn.getResponseCode();
             if (code == HttpURLConnection.HTTP_NO_CONTENT || code == HttpURLConnection.HTTP_NOT_FOUND) {

--- a/authme-core/src/main/java/fr/xephi/authme/service/MojangApiService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/MojangApiService.java
@@ -44,7 +44,7 @@ public class MojangApiService {
      */
     public Optional<UUID> fetchUuidByName(String username) {
         try {
-            HttpURLConnection conn = openGet(settings.getProperty(PremiumSettings.ACCOUNT_SERVER) + "/users/profiles/minecraft/" + username);
+            HttpURLConnection conn = openGet(settings.getProperty(PremiumSettings.ACCOUNT_SERVER) + username);
             int code = conn.getResponseCode();
             if (code == HttpURLConnection.HTTP_NO_CONTENT || code == HttpURLConnection.HTTP_NOT_FOUND) {
                 return Optional.empty();

--- a/authme-core/src/main/java/fr/xephi/authme/service/MojangApiService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/MojangApiService.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.UUID;
@@ -72,7 +73,9 @@ public class MojangApiService {
      */
     public Optional<UUID> hasJoined(String username, String serverHash) {
         try {
-            String url = settings.getProperty(PremiumSettings.SESSION_SERVER) + "?username=" + username + "&serverId=" + serverHash;
+            String url = settings.getProperty(PremiumSettings.SESSION_SERVER)
+                + "?username=" + URLEncoder.encode(username, "UTF-8")
+                + "&serverId=" + URLEncoder.encode(serverHash, "UTF-8");
             HttpURLConnection conn = openGet(url);
             int code = conn.getResponseCode();
             if (code == HttpURLConnection.HTTP_NO_CONTENT || code == HttpURLConnection.HTTP_NOT_FOUND) {

--- a/authme-core/src/main/java/fr/xephi/authme/service/MojangApiService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/MojangApiService.java
@@ -44,7 +44,7 @@ public class MojangApiService {
      */
     public Optional<UUID> fetchUuidByName(String username) {
         try {
-            HttpURLConnection conn = openGet(settings.getProperty(PremiumSettings.ACCOUNT_SERVER) + username);
+            HttpURLConnection conn = openGet(settings.getProperty(PremiumSettings.ACCOUNT_SERVER) + "/users/profiles/minecraft/" + username);
             int code = conn.getResponseCode();
             if (code == HttpURLConnection.HTTP_NO_CONTENT || code == HttpURLConnection.HTTP_NOT_FOUND) {
                 return Optional.empty();

--- a/authme-core/src/main/java/fr/xephi/authme/settings/SettingsMigrationService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/settings/SettingsMigrationService.java
@@ -15,6 +15,7 @@ import fr.xephi.authme.process.register.RegistrationType;
 import fr.xephi.authme.security.HashAlgorithm;
 import fr.xephi.authme.settings.properties.DatabaseSettings;
 import fr.xephi.authme.settings.properties.PluginSettings;
+import fr.xephi.authme.settings.properties.PremiumSettings;
 import fr.xephi.authme.settings.properties.RegistrationSettings;
 import fr.xephi.authme.settings.properties.SecuritySettings;
 import fr.xephi.authme.util.StringUtils;
@@ -93,6 +94,7 @@ public class SettingsMigrationService extends PlainMigrationService {
             | moveSaltColumnConfigWithOtherColumnConfigs(reader, configurationData)
             | migrateTimeoutToLoginAndRegisterTimeout(reader, configurationData)
             | migrateDialogSettings(reader, configurationData)
+            | migratePremiumSetting(reader, configurationData)
             || hasDeprecatedProperties(reader);
     }
 
@@ -152,6 +154,23 @@ public class SettingsMigrationService extends PlainMigrationService {
             | moveProperty(
                 newProperty("settings.registration.preJoinDialog.loginCancelKicks", true),
                 RegistrationSettings.PRE_JOIN_LOGIN_CANCEL_KICKS, reader, configData);
+    }
+
+    /**
+     * Migrates the old {@code settings.enablePremium} setting to the new
+     * {@code settings.premium.enabled} path.
+     *
+     * @param reader The property reader
+     * @param configData Configuration data
+     * @return True if the configuration has changed, false otherwise
+     */
+    private static boolean migratePremiumSetting(PropertyReader reader, ConfigurationData configData) {
+        return moveProperty(
+            newProperty("settings.enablePremium", false),
+            PremiumSettings.ENABLE_PREMIUM,
+            reader,
+            configData
+        );
     }
 
     private static boolean hasDeprecatedProperties(PropertyReader reader) {

--- a/authme-core/src/main/java/fr/xephi/authme/settings/properties/PremiumSettings.java
+++ b/authme-core/src/main/java/fr/xephi/authme/settings/properties/PremiumSettings.java
@@ -23,7 +23,7 @@ public final class PremiumSettings implements SettingsHolder {
 
     @Comment("Profile url used for premium verification.")
     public static final Property<String> ACCOUNT_SERVER =
-        newProperty("settings.premium.accountServer", "https://api.mojang.com/users/profiles/minecraft/");
+        newProperty("settings.premium.accountServer", "https://api.mojang.com");
 
     @Comment("Session server used for premium verification.")
     public static final Property<String> SESSION_SERVER =

--- a/authme-core/src/main/java/fr/xephi/authme/settings/properties/PremiumSettings.java
+++ b/authme-core/src/main/java/fr/xephi/authme/settings/properties/PremiumSettings.java
@@ -19,7 +19,15 @@ public final class PremiumSettings implements SettingsHolder {
         "Players must use /premium to opt in."
     })
     public static final Property<Boolean> ENABLE_PREMIUM =
-        newProperty("settings.enablePremium", false);
+        newProperty("settings.premium.enabled", false);
+
+    @Comment("Profile url used for premium verification.")
+    public static final Property<String> ACCOUNT_SERVER =
+        newProperty("settings.premium.accountServer", "https://api.mojang.com/users/profiles/minecraft/");
+
+    @Comment("Session server used for premium verification.")
+    public static final Property<String> SESSION_SERVER =
+        newProperty("settings.premium.sessionServer", "https://sessionserver.mojang.com");
 
     private PremiumSettings() {
     }

--- a/authme-core/src/main/java/fr/xephi/authme/settings/properties/PremiumSettings.java
+++ b/authme-core/src/main/java/fr/xephi/authme/settings/properties/PremiumSettings.java
@@ -23,7 +23,7 @@ public final class PremiumSettings implements SettingsHolder {
 
     @Comment("Profile url used for premium verification.")
     public static final Property<String> ACCOUNT_SERVER =
-        newProperty("settings.premium.accountServer", "https://api.mojang.com");
+        newProperty("settings.premium.accountServer", "https://api.mojang.com/users/profiles/minecraft/");
 
     @Comment("Session server used for premium verification.")
     public static final Property<String> SESSION_SERVER =


### PR DESCRIPTION
this would allow you to use a custom authentication server (such as https://github.com/unmojang/drasl) to authenticate premium players.