### PR TITLE
fix(premium): send authoritative premium list to proxy when disabled or empty

### DIFF
--- a/authme-core/src/main/java/fr/xephi/authme/service/ProxyLoginRequestValidator.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/ProxyLoginRequestValidator.java
@@ -8,6 +8,8 @@ import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
 import fr.xephi.authme.output.ConsoleLoggerFactory;
 import fr.xephi.authme.service.bungeecord.BungeeSender;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.PremiumSettings;
 import org.bukkit.entity.Player;
 
 import javax.inject.Inject;
@@ -43,6 +45,9 @@ public class ProxyLoginRequestValidator {
     @Inject
     private Messages messages;
 
+    @Inject
+    private Settings settings;
+
     ProxyLoginRequestValidator() {
     }
 
@@ -60,6 +65,14 @@ public class ProxyLoginRequestValidator {
         }
 
         String playerName = player.getName();
+        if (!settings.getProperty(PremiumSettings.ENABLE_PREMIUM)) {
+            // The proxy still holds this name in its premium cache; tell it to drop the entry so the
+            // player is not forced through Mojang verification again while the feature is disabled.
+            logger.info("Rejected proxy premium login for " + playerName + ": premium is disabled");
+            bungeeSender.sendPremiumUnset(playerName);
+            return false;
+        }
+
         PlayerAuth auth = playerCache.getAuth(playerName);
         if (auth == null) {
             auth = dataSource.getAuth(playerName.toLowerCase(Locale.ROOT));

--- a/authme-core/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
@@ -14,6 +14,7 @@ import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.service.ProxyLoginRequestValidator;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.HooksSettings;
+import fr.xephi.authme.settings.properties.PremiumSettings;
 import fr.xephi.authme.util.UuidUtils;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.Messenger;
@@ -42,6 +43,7 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
     private static final long MAX_AGE_MILLIS = 30_000L;
 
     private boolean isEnabled;
+    private boolean premiumEnabled;
     private String proxySharedSecret;
     private boolean channelRegistered;
 
@@ -63,6 +65,7 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
     public void reload(Settings settings) {
         this.proxySharedSecret = settings.getProperty(HooksSettings.PROXY_SHARED_SECRET);
         this.isEnabled = settings.getProperty(HooksSettings.BUNGEECORD);
+        this.premiumEnabled = settings.getProperty(PremiumSettings.ENABLE_PREMIUM);
         final Messenger messenger = plugin.getServer().getMessenger();
         if (messenger == null) {
             return;
@@ -112,22 +115,23 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
             logger.info("Proxy plugin '" + argument + "' has started and registered the authme:main channel");
             final String proxyName = argument;
             bukkitService.runTaskAsynchronously(() -> {
-                List<String> premiumNames = dataSource.getPremiumUsernames();
-                if (!premiumNames.isEmpty()) {
-                    bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(() -> {
-                        // Re-fetch a carrier at send-time: the original player may have gone offline
-                        // during the async DB query.
-                        Player freshCarrier = bukkitService.getOnlinePlayers().stream()
-                            .findFirst().orElse(null);
-                        if (freshCarrier != null) {
-                            bungeeSender.sendPremiumList(freshCarrier, premiumNames);
-                            logger.info("Sent premium list (" + premiumNames.size() + " player(s)) to proxy '" + proxyName + "'");
-                        } else {
-                            logger.warning("Cannot send premium list to proxy '" + proxyName
-                                + "': no online player available as carrier.");
-                        }
-                    });
-                }
+                // Always send the list, even when it is empty: an empty list is authoritative and
+                // lets the proxy replace a stale premium cache. With premium disabled, stored
+                // premium names must not reach the proxy, or it keeps verifying those players.
+                List<String> premiumNames = premiumEnabled ? dataSource.getPremiumUsernames() : List.of();
+                bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(() -> {
+                    // Re-fetch a carrier at send-time: the original player may have gone offline
+                    // during the async DB query.
+                    Player freshCarrier = bukkitService.getOnlinePlayers().stream()
+                        .findFirst().orElse(null);
+                    if (freshCarrier != null) {
+                        bungeeSender.sendPremiumList(freshCarrier, premiumNames);
+                        logger.info("Sent premium list (" + premiumNames.size() + " player(s)) to proxy '" + proxyName + "'");
+                    } else {
+                        logger.warning("Cannot send premium list to proxy '" + proxyName
+                            + "': no online player available as carrier.");
+                    }
+                });
             });
             return;
         }

--- a/authme-core/src/test/java/fr/xephi/authme/service/ProxyLoginRequestValidatorTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/service/ProxyLoginRequestValidatorTest.java
@@ -5,6 +5,8 @@ import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
 import fr.xephi.authme.service.bungeecord.BungeeSender;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.PremiumSettings;
 import org.bukkit.entity.Player;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Test for {@link ProxyLoginRequestValidator}.
@@ -48,6 +51,9 @@ class ProxyLoginRequestValidatorTest {
     private Messages messages;
 
     @Mock
+    private Settings settings;
+
+    @Mock
     private Player player;
 
     @Test
@@ -55,6 +61,7 @@ class ProxyLoginRequestValidatorTest {
         UUID premiumUuid = UUID.randomUUID();
         PlayerAuth auth = PlayerAuth.builder().name("bobby").premiumUuid(premiumUuid).build();
         given(player.getName()).willReturn("Bobby");
+        given(settings.getProperty(PremiumSettings.ENABLE_PREMIUM)).willReturn(true);
         given(playerCache.getAuth("Bobby")).willReturn(auth);
 
         assertTrue(validator.validate(player, premiumUuid));
@@ -67,6 +74,7 @@ class ProxyLoginRequestValidatorTest {
         UUID forwardedUuid = UUID.randomUUID();
         PlayerAuth auth = PlayerAuth.builder().name("bobby").premiumUuid(storedUuid).build();
         given(player.getName()).willReturn("Bobby");
+        given(settings.getProperty(PremiumSettings.ENABLE_PREMIUM)).willReturn(true);
         given(playerCache.getAuth("Bobby")).willReturn(auth);
 
         assertFalse(validator.validate(player, forwardedUuid));
@@ -78,6 +86,7 @@ class ProxyLoginRequestValidatorTest {
         UUID pendingUuid = UUID.randomUUID();
         PlayerAuth auth = PlayerAuth.builder().name("bobby").build();
         given(player.getName()).willReturn("Bobby");
+        given(settings.getProperty(PremiumSettings.ENABLE_PREMIUM)).willReturn(true);
         given(playerCache.getAuth("Bobby")).willReturn(auth);
         given(pendingPremiumCache.removePending("Bobby")).willReturn(pendingUuid);
 
@@ -92,6 +101,7 @@ class ProxyLoginRequestValidatorTest {
         UUID forwardedUuid = UUID.randomUUID();
         PlayerAuth auth = PlayerAuth.builder().name("bobby").build();
         given(player.getName()).willReturn("Bobby");
+        given(settings.getProperty(PremiumSettings.ENABLE_PREMIUM)).willReturn(true);
         given(playerCache.getAuth("Bobby")).willReturn(auth);
         given(pendingPremiumCache.removePending("Bobby")).willReturn(null);
 
@@ -107,6 +117,7 @@ class ProxyLoginRequestValidatorTest {
         UUID forwardedUuid = UUID.randomUUID();
         PlayerAuth auth = PlayerAuth.builder().name("bobby").build();
         given(player.getName()).willReturn("Bobby");
+        given(settings.getProperty(PremiumSettings.ENABLE_PREMIUM)).willReturn(true);
         given(playerCache.getAuth("Bobby")).willReturn(auth);
         given(pendingPremiumCache.removePending("Bobby")).willReturn(pendingUuid);
 
@@ -114,5 +125,17 @@ class ProxyLoginRequestValidatorTest {
         verify(bungeeSender).sendPremiumUnset("Bobby");
         verify(messages).send(player, MessageKey.PREMIUM_PENDING_FAIL);
         verify(premiumService, never()).finalizePendingPremium(player, forwardedUuid);
+    }
+
+    @Test
+    void shouldRejectProxyPremiumClaimAndNotifyProxyWhenPremiumIsDisabled() {
+        UUID forwardedUuid = UUID.randomUUID();
+        given(player.getName()).willReturn("Bobby");
+        given(settings.getProperty(PremiumSettings.ENABLE_PREMIUM)).willReturn(false);
+
+        assertFalse(validator.validate(player, forwardedUuid));
+        verify(bungeeSender).sendPremiumUnset("Bobby");
+        verify(messages, never()).send(player, MessageKey.PREMIUM_PENDING_FAIL);
+        verifyNoInteractions(playerCache, dataSource, pendingPremiumCache, premiumService);
     }
 }

--- a/authme-core/src/test/java/fr/xephi/authme/service/bungeecord/BungeeReceiverTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/service/bungeecord/BungeeReceiverTest.java
@@ -12,6 +12,7 @@ import fr.xephi.authme.service.BukkitService;
 import fr.xephi.authme.service.ProxyLoginRequestValidator;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.properties.HooksSettings;
+import fr.xephi.authme.settings.properties.PremiumSettings;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.Messenger;
@@ -24,10 +25,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.List;
 import java.util.UUID;
 
 import static fr.xephi.authme.service.BukkitServiceTestHelper.setBukkitServiceToRunTaskAsynchronously;
 import static fr.xephi.authme.service.BukkitServiceTestHelper.setBukkitServiceToScheduleSyncEntityTaskFromOptionallyAsyncTask;
+import static fr.xephi.authme.service.BukkitServiceTestHelper.setBukkitServiceToScheduleSyncTaskFromOptionallyAsyncTask;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -81,6 +84,7 @@ class BungeeReceiverTest {
     void setUp() {
         given(plugin.getServer()).willReturn(server);
         given(server.getMessenger()).willReturn(messenger);
+        given(settings.getProperty(PremiumSettings.ENABLE_PREMIUM)).willReturn(true);
     }
 
     @Test
@@ -286,6 +290,58 @@ class BungeeReceiverTest {
         // then
         assertThat(result, nullValue());
         verify(proxySessionManager, never()).processProxySessionMessage(any(), any());
+    }
+
+    @Test
+    void shouldSendEmptyPremiumListOnProxyStartedWhenPremiumIsDisabled() {
+        // given
+        given(settings.getProperty(HooksSettings.BUNGEECORD)).willReturn(true);
+        given(settings.getProperty(PremiumSettings.ENABLE_PREMIUM)).willReturn(false);
+        setBukkitServiceToRunTaskAsynchronously(bukkitService);
+        setBukkitServiceToScheduleSyncTaskFromOptionallyAsyncTask(bukkitService);
+
+        Player carrier = mock(Player.class);
+        given(bukkitService.getOnlinePlayers()).willReturn(List.of(carrier));
+
+        BungeeReceiver receiver =
+            new BungeeReceiver(plugin, bukkitService, proxySessionManager, management, bungeeSender, dataSource,
+                proxyLoginRequestValidator, settings);
+
+        // when
+        receiver.onPluginMessageReceived("authme:main", carrier, buildProxyStartedPayload("velocity"));
+
+        // then
+        verify(dataSource, never()).getPremiumUsernames();
+        verify(bungeeSender).sendPremiumList(carrier, List.of());
+    }
+
+    @Test
+    void shouldSendEmptyPremiumListOnProxyStartedWhenNoPremiumUsersAreStored() {
+        // given
+        given(settings.getProperty(HooksSettings.BUNGEECORD)).willReturn(true);
+        given(dataSource.getPremiumUsernames()).willReturn(List.of());
+        setBukkitServiceToRunTaskAsynchronously(bukkitService);
+        setBukkitServiceToScheduleSyncTaskFromOptionallyAsyncTask(bukkitService);
+
+        Player carrier = mock(Player.class);
+        given(bukkitService.getOnlinePlayers()).willReturn(List.of(carrier));
+
+        BungeeReceiver receiver =
+            new BungeeReceiver(plugin, bukkitService, proxySessionManager, management, bungeeSender, dataSource,
+                proxyLoginRequestValidator, settings);
+
+        // when
+        receiver.onPluginMessageReceived("authme:main", carrier, buildProxyStartedPayload("velocity"));
+
+        // then
+        verify(bungeeSender).sendPremiumList(carrier, List.of());
+    }
+
+    private static byte[] buildProxyStartedPayload(String proxyName) {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        out.writeUTF(MessageType.PROXY_STARTED.getId());
+        out.writeUTF(proxyName);
+        return out.toByteArray();
     }
 
     private static byte[] buildPerformLoginPayload(String playerName, long timestamp, String hmac) {


### PR DESCRIPTION
Fixes #3127.

Two things were wrong in how the premium list reaches the proxy.

`BungeeReceiver`'s `proxy.started` handler queried stored premium names without looking at `settings.enablePremium`, and didn't send anything at all when the list was empty. So a proxy restart re-populated the cache from stale `premiumUUID` rows even with the feature disabled, and `premium_names.cache` could never be cleared. The first commit gates the query on `enablePremium` and always sends the list — an empty one is authoritative, and both proxy bridges already handle a zero-name chunk by replacing and persisting their cache, so nothing had to change on that side.

That alone still depends on a proxy restart (the resync only fires on `proxy.started`) and on a player connection to carry the message. The second commit makes the state converge per player instead: `ProxyLoginRequestValidator.validate()` had no `enablePremium` check at all, unlike `canBypassWithPremium`, so a proxy-verified claim for a player whose row still had a `premiumUuid` was accepted while the feature was off. It now rejects the claim and answers with the existing `premium.unset`; since `validate()` sits on both the join-time path and `performLogin`, one gate covers both.

Stored `premiumUUID` values stay in the database on purpose — ignored while disabled, back when re-enabled — as described in the issue.

Three new tests, full authme-core suite is green.
