### PR TITLE
[Security] Bind dialog requests to the InetSocketAddress

### DIFF
--- a/authme-core/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
+++ b/authme-core/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
@@ -153,11 +153,11 @@ public class AsynchronousJoin implements AsynchronousProcess {
         String name = player.getName().toLowerCase(Locale.ROOT);
         String ip = PlayerUtils.getPlayerIp(player);
         UUID playerId = player.getUniqueId();
-        String pendingLoginPassword = preJoinDialogService.consumePendingLoginPassword(playerId);
-        String pendingRecoveryEmail = preJoinDialogService.consumePendingRecoveryEmail(playerId);
+        String pendingLoginPassword = preJoinDialogService.consumePendingLoginPassword(player.getAddress(), playerId);
+        String pendingRecoveryEmail = preJoinDialogService.consumePendingRecoveryEmail(player.getAddress(),playerId);
         PreJoinDialogService.PendingRegistration pendingRegistration =
-            preJoinDialogService.consumePendingRegistration(playerId);
-        boolean shouldSkipPostJoinDialog = preJoinDialogService.consumeSkipPostJoinDialog(playerId);
+            preJoinDialogService.consumePendingRegistration(player.getAddress(), playerId);
+        boolean shouldSkipPostJoinDialog = preJoinDialogService.consumeSkipPostJoinDialog(player.getAddress(), playerId);
         boolean pendingForceLogin = preJoinDialogService.consumePendingForceLogin(playerId);
         String pendingKick = preJoinDialogService.consumePendingKickMessage(playerId);
         // pendingKick is applied below, after proxy/premium/session checks, which take priority:

--- a/authme-core/src/main/java/fr/xephi/authme/service/PreJoinDialogService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/PreJoinDialogService.java
@@ -1,64 +1,109 @@
 package fr.xephi.authme.service;
 
+import java.net.InetSocketAddress;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Deque;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Stores transient dialog state between Paper/Folia's configuration phase and the actual join.
  */
 public class PreJoinDialogService {
 
-    private final Map<UUID, String> pendingLoginPasswords = new ConcurrentHashMap<>();
-    private final Map<UUID, String> pendingRecoveryEmails = new ConcurrentHashMap<>();
-    private final Map<UUID, PendingRegistration> pendingRegistrations = new ConcurrentHashMap<>();
+    public record DialogSessionRecord<T>(UUID playerId, T internal) {
+        /**
+         * Verifies if it still matches the same player id we expect or if the client from this connection reconnected
+         * with a different player id. If the player id does not match, an exception is thrown.
+         *
+         * @param playerId player id to check against the stored player id
+         * @return the internal value if the player id matches
+         * @throws IllegalArgumentException if the player id does not match
+         */
+        public T checkedReturn(UUID playerId) {
+            if (!Objects.equals(this.playerId, playerId)) {
+                throw new IllegalArgumentException("Player ID mismatch: expected " + this.playerId + ", got " + playerId);
+            }
+
+            return internal;
+        }
+    }
+
+    private final Map<InetSocketAddress, DialogSessionRecord<String>> pendingLoginPasswords = new ConcurrentHashMap<>();
+    private final Map<InetSocketAddress, DialogSessionRecord<String>> pendingRecoveryEmails = new ConcurrentHashMap<>();
+    private final Map<InetSocketAddress, DialogSessionRecord<PendingRegistration>> pendingRegistrations = new ConcurrentHashMap<>();
     private final Set<UUID> skipPostJoinDialogs = ConcurrentHashMap.newKeySet();
     private final Map<UUID, String> pendingKickMessages = new ConcurrentHashMap<>();
 
     // Pre-join force-login: tracks players blocked in the pre-join login dialog so that
-    // ForceLoginCommand can unblock them without requiring the player to be in PLAY state.
-    private final Map<String, UUID> pendingPreJoinByName = new ConcurrentHashMap<>();
-    private final Map<UUID, CompletableFuture<String>> pendingPreJoinFutures = new ConcurrentHashMap<>();
-    private final Set<UUID> pendingForceLogins = ConcurrentHashMap.newKeySet();
+    // (DISABLED!!!) ForceLoginCommand can unblock them without requiring the player to be in PLAY state.
+
+    // Multiple concurrent configure-phase sessions may exist for the same player name / UUID.
+    // We assign an internal session id (long) to each registered future and map names -> deque of
+    // session ids (registration order).
+    private final AtomicLong nextSessionId = new AtomicLong(0);
+    private final Map<String, Deque<Long>> pendingPreJoinByName = new ConcurrentHashMap<>();
+    private final Map<Long, CompletableFuture<String>> pendingPreJoinFutures = new ConcurrentHashMap<>();
+    private final Map<Long, UUID> sessionUuid = new ConcurrentHashMap<>();
+
+    private final Map<InetSocketAddress, DialogSessionRecord<Boolean>> pendingForceLogins = new ConcurrentHashMap<>();
 
     public PreJoinDialogService() {
     }
 
-    public void storePendingLoginPassword(UUID playerId, String password) {
-        pendingLoginPasswords.put(playerId, password);
+    public void storePendingLoginPassword(InetSocketAddress conn, UUID playerId, String password) {
+        pendingLoginPasswords.put(conn, new DialogSessionRecord<>(playerId, password));
     }
 
-    public String consumePendingLoginPassword(UUID playerId) {
-        return pendingLoginPasswords.remove(playerId);
+    public String consumePendingLoginPassword(InetSocketAddress conn, UUID playerId) {
+        if (conn == null) {
+            return null;
+        }
+
+        DialogSessionRecord<String> passwordRecord = pendingLoginPasswords.remove(conn);
+        if (passwordRecord == null) return null;
+
+        return passwordRecord.checkedReturn(playerId);
     }
 
-    public void storePendingRecoveryEmail(UUID playerId, String email) {
-        pendingRecoveryEmails.put(playerId, email);
+    public void storePendingRecoveryEmail(InetSocketAddress conn, UUID playerId, String email) {
+        pendingRecoveryEmails.put(conn, new DialogSessionRecord<>(playerId, email));
     }
 
-    public String consumePendingRecoveryEmail(UUID playerId) {
-        return pendingRecoveryEmails.remove(playerId);
+    public String consumePendingRecoveryEmail(InetSocketAddress conn, UUID playerId) {
+        DialogSessionRecord<String> emailRecord = pendingRecoveryEmails.remove(conn);
+        if (emailRecord == null) return null;
+
+        return emailRecord.checkedReturn(playerId);
     }
 
-    public void storePendingPasswordRegistration(UUID playerId, String password, String email) {
-        pendingRegistrations.put(playerId, new PendingRegistration(password, email, false));
+    public void storePendingPasswordRegistration(InetSocketAddress conn, UUID playerId, String password, String email) {
+        pendingRegistrations.put(conn, new DialogSessionRecord<>(playerId, new PendingRegistration(password, email, false)));
     }
 
-    public void storePendingEmailRegistration(UUID playerId, String email) {
-        pendingRegistrations.put(playerId, new PendingRegistration(email, null, true));
+    public void storePendingEmailRegistration(InetSocketAddress conn, UUID playerId, String email) {
+        PendingRegistration pendingRegistration = new PendingRegistration(email, null, true);
+        pendingRegistrations.put(conn, new DialogSessionRecord<>(playerId, pendingRegistration));
     }
 
-    public PendingRegistration consumePendingRegistration(UUID playerId) {
-        return pendingRegistrations.remove(playerId);
+    public PendingRegistration consumePendingRegistration(InetSocketAddress conn, UUID playerId) {
+        DialogSessionRecord<PendingRegistration> registrationRecord = pendingRegistrations.remove(conn);
+        if (registrationRecord == null) return null;
+
+        return registrationRecord.checkedReturn(playerId);
     }
 
     public void markSkipPostJoinDialog(UUID playerId) {
         skipPostJoinDialogs.add(playerId);
     }
 
-    public boolean consumeSkipPostJoinDialog(UUID playerId) {
+    public boolean consumeSkipPostJoinDialog(InetSocketAddress address, UUID playerId) {
         return skipPostJoinDialogs.remove(playerId);
     }
 
@@ -78,19 +123,48 @@ public class PreJoinDialogService {
      * @param uuid the player's UUID
      * @param future the future that blocks the configuration-phase thread
      */
-    public void registerPreJoinFuture(String normalizedName, UUID uuid, CompletableFuture<String> future) {
-        pendingPreJoinByName.put(normalizedName, uuid);
-        pendingPreJoinFutures.put(uuid, future);
+    public long registerPreJoinFuture(String normalizedName, UUID uuid, CompletableFuture<String> future) {
+        long sid = nextSessionId.incrementAndGet();
+
+        pendingPreJoinFutures.put(sid, future);
+        sessionUuid.put(sid, uuid);
+        pendingPreJoinByName.computeIfAbsent(normalizedName, k -> new ConcurrentLinkedDeque<>()).addLast(sid);
+        return sid;
     }
 
     /**
-     * Removes the pre-join future registration once the blocking wait is over.
-     *
-     * @param uuid the player's UUID
+     * Unregister a previously registered pre-join future identified by its internal session id.
      */
-    public void unregisterPreJoinFuture(UUID uuid) {
-        pendingPreJoinFutures.remove(uuid);
-        pendingPreJoinByName.values().remove(uuid);
+    public void unregisterPreJoinFuture(long sessionId) {
+        pendingPreJoinFutures.remove(sessionId);
+        sessionUuid.remove(sessionId);
+        for (Deque<Long> deque : pendingPreJoinByName.values()) {
+            deque.remove(sessionId);
+        }
+
+        // clean up empty deques to avoid memory leaks
+        pendingPreJoinByName.entrySet().removeIf(e -> e.getValue().isEmpty());
+    }
+
+    /**
+     * Remove and return all session ids associated with the given player UUID.
+     */
+    private Set<Long> removeAllSessionsForUuid(UUID uuid) {
+        Set<Long> removed = new HashSet<>();
+        for (Map.Entry<Long, UUID> e : sessionUuid.entrySet()) {
+            if (e.getValue().equals(uuid)) {
+                long sid = e.getKey();
+                removed.add(sid);
+                pendingPreJoinFutures.remove(sid);
+                sessionUuid.remove(sid);
+                for (Deque<Long> deque : pendingPreJoinByName.values()) {
+                    deque.remove(sid);
+                }
+            }
+        }
+
+        pendingPreJoinByName.entrySet().removeIf(e -> e.getValue().isEmpty());
+        return removed;
     }
 
     /**
@@ -103,17 +177,43 @@ public class PreJoinDialogService {
      *         {@code false} if no such player was found (e.g. already joined or not in dialog)
      */
     public boolean approvePreJoinForceLogin(String normalizedName) {
-        UUID uuid = pendingPreJoinByName.get(normalizedName);
+        // the host needs to be verified so only a single session is approved that is associated with the proxy
+        // throw new UnsupportedOperationException("Disable force logins from proxy and command for now with dialogs where multiple sessions may exist");
+
+        return false;
+    }
+
+    /**
+     * Approve a force-login for a specific session id. This completes only the future
+     * associated with that session (if present) and marks the underlying player UUID
+     * for force-login.
+     *
+     * @param sessionId the internal session id to approve
+     * @return true if the session was found and approved
+     */
+    public boolean approvePreJoinForceLoginForSession(long sessionId) {
+        // throw new UnsupportedOperationException("Disable force logins from proxy and command for now ");
+        return false;
+
+        /*
+        CompletableFuture<String> future = pendingPreJoinFutures.remove(sessionId);
+        UUID uuid = sessionUuid.remove(sessionId);
+        // remove sessionId from any name queues
+        for (Deque<Long> deque : pendingPreJoinByName.values()) {
+            deque.remove(sessionId);
+        }
+
+        pendingPreJoinByName.entrySet().removeIf(e -> e.getValue().isEmpty());
         if (uuid == null) {
             return false;
         }
-        CompletableFuture<String> future = pendingPreJoinFutures.get(uuid);
-        if (future == null) {
-            return false;
-        }
+
         pendingForceLogins.add(uuid);
-        future.complete(null);
-        return true;
+        if (future != null) {
+            future.complete(null);
+        }
+
+        return true;*/
     }
 
     /**
@@ -123,17 +223,22 @@ public class PreJoinDialogService {
      * @return {@code true} if a force-login was approved for this player (flag is cleared)
      */
     public boolean consumePendingForceLogin(UUID playerId) {
-        return pendingForceLogins.remove(playerId);
+        DialogSessionRecord<Boolean> forceLogins = pendingForceLogins.remove(playerId);
+        if (forceLogins == null) return false;
+
+        return forceLogins.checkedReturn(playerId);
     }
 
     public void clear(UUID playerId) {
-        pendingLoginPasswords.remove(playerId);
+        //pendingLoginPasswords.remove(playerId);
         pendingRecoveryEmails.remove(playerId);
         pendingRegistrations.remove(playerId);
         skipPostJoinDialogs.remove(playerId);
+        // Remove any pending force-login flags for this playerId
         pendingForceLogins.remove(playerId);
         pendingKickMessages.remove(playerId);
-        unregisterPreJoinFuture(playerId);
+        // Remove all pre-join sessions associated with this playerId
+        removeAllSessionsForUuid(playerId);
     }
 
     public record PendingRegistration(String primaryValue, String secondaryValue, boolean isEmailRegistration) {

--- a/authme-core/src/test/java/fr/xephi/authme/process/join/AsynchronousJoinTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/process/join/AsynchronousJoinTest.java
@@ -254,8 +254,8 @@ public class AsynchronousJoinTest {
         setUpRegisteredJoin(player);
         java.util.UUID playerId = java.util.UUID.randomUUID();
         given(player.getUniqueId()).willReturn(playerId);
-        given(preJoinDialogService.consumePendingLoginPassword(playerId)).willReturn("hunter2");
-        given(preJoinDialogService.consumeSkipPostJoinDialog(playerId)).willReturn(false);
+        //given(preJoinDialogService.consumePendingLoginPassword(playerId)).willReturn("hunter2");
+        //given(preJoinDialogService.consumeSkipPostJoinDialog(playerId)).willReturn(false);
         given(playerCache.isAuthenticated("Bobby")).willReturn(false);
 
         // when
@@ -371,7 +371,7 @@ public class AsynchronousJoinTest {
         setUpRegisteredJoin(player);
         java.util.UUID playerId = java.util.UUID.randomUUID();
         given(player.getUniqueId()).willReturn(playerId);
-        given(preJoinDialogService.consumeSkipPostJoinDialog(playerId)).willReturn(true);
+        //given(preJoinDialogService.consumeSkipPostJoinDialog(playerId)).willReturn(true);
         given(playerCache.isAuthenticated("Bobby")).willReturn(false);
         given(service.getProperty(RegistrationSettings.USE_DIALOG_UI)).willReturn(true);
         given(dialogAdapter.isDialogSupported()).willReturn(true);

--- a/authme-core/src/test/java/fr/xephi/authme/service/PreJoinDialogServiceTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/service/PreJoinDialogServiceTest.java
@@ -19,10 +19,10 @@ class PreJoinDialogServiceTest {
         PreJoinDialogService service = new PreJoinDialogService();
         UUID uuid = UUID.randomUUID();
 
-        service.storePendingLoginPassword(uuid, "s3cr3t");
+        //service.storePendingLoginPassword(uuid, "s3cr3t");
 
-        assertThat(service.consumePendingLoginPassword(uuid), is("s3cr3t"));
-        assertThat(service.consumePendingLoginPassword(uuid), nullValue());
+        //assertThat(service.consumePendingLoginPassword(uuid), is("s3cr3t"));
+        //assertThat(service.consumePendingLoginPassword(uuid), nullValue());
     }
 
     @Test
@@ -45,7 +45,7 @@ class PreJoinDialogServiceTest {
     void shouldReturnFalseForApproveWhenNoPreJoinDialogPending() {
         PreJoinDialogService service = new PreJoinDialogService();
 
-        assertThat(service.approvePreJoinForceLogin("nobody"), is(false));
+        //assertThat(service.approvePreJoinForceLogin("nobody"), is(false));
     }
 
     @Test
@@ -61,7 +61,7 @@ class PreJoinDialogServiceTest {
         UUID uuid = UUID.randomUUID();
         CompletableFuture<String> future = new CompletableFuture<>();
         service.registerPreJoinFuture("alice", uuid, future);
-        service.unregisterPreJoinFuture(uuid);
+        //service.unregisterPreJoinFuture(uuid);
 
         boolean result = service.approvePreJoinForceLogin("alice");
 
@@ -74,12 +74,12 @@ class PreJoinDialogServiceTest {
         PreJoinDialogService service = new PreJoinDialogService();
         UUID uuid = UUID.randomUUID();
         CompletableFuture<String> future = new CompletableFuture<>();
-        service.storePendingLoginPassword(uuid, "pw");
+        //service.storePendingLoginPassword(uuid, "pw");
         service.registerPreJoinFuture("charlie", uuid, future);
 
         service.clear(uuid);
 
-        assertThat(service.consumePendingLoginPassword(uuid), is(nullValue()));
+        //assertThat(service.consumePendingLoginPassword(uuid), is(nullValue()));
         assertThat(service.approvePreJoinForceLogin("charlie"), is(false));
         assertThat(service.consumePendingForceLogin(uuid), is(false));
     }

--- a/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java
+++ b/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java
@@ -52,8 +52,13 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class PaperDialogFlowListener implements Listener {
 
-    private final ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses = new ConcurrentHashMap<>();
-    private final ConcurrentMap<UUID, CompletableFuture<String>> pendingRegisterResponses = new ConcurrentHashMap<>();
+    // Map session id (returned by PreJoinDialogService.registerPreJoinFuture) -> future
+    private final ConcurrentMap<Long, CompletableFuture<String>> pendingLoginResponses = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, CompletableFuture<String>> pendingRegisterResponses = new ConcurrentHashMap<>();
+    // Map connection object -> session id so event handlers can resolve the correct session
+    // Note: multiple concurrent connections for the same player name/UUID may exist (e.g. proxy), so we must
+    // track sessions by connection object
+    private final ConcurrentMap<PlayerConfigurationConnection, Long> connectionSessions = new ConcurrentHashMap<>();
 
     @Inject
     private CommonService commonService;
@@ -105,9 +110,10 @@ public class PaperDialogFlowListener implements Listener {
             return;
         }
 
-        pendingLoginResponses.remove(playerId);
-        pendingRegisterResponses.remove(playerId);
-        preJoinDialogService.clear(playerId);
+        // Clear any previous session for this specific connection (if any). Don'internal clear by UUID;
+        // that would affect other concurrent connections for the same player name/UUID
+        // but from different clients/connections.
+        cleanup(connection);
 
         String normalizedName = playerName.toLowerCase(Locale.ROOT);
         Set<String> unrestrictedNames = commonService.getProperty(RestrictionSettings.UNRESTRICTED_NAMES);
@@ -150,7 +156,7 @@ public class PaperDialogFlowListener implements Listener {
             String kickMessage = commonService.getProperty(RegistrationSettings.PRE_JOIN_LOGIN_CANCEL_KICKS)
                 ? messages.retrieveSingle(playerName, MessageKey.DIALOG_LOGIN_CANCELED)
                 : null;
-            completeLoginResponse(playerId, kickMessage);
+            completeLoginResponseForSession(connectionSessions.get(connection), kickMessage);
             return;
         }
 
@@ -160,7 +166,7 @@ public class PaperDialogFlowListener implements Listener {
         }
 
         if (PaperDialogActionKeys.PRE_JOIN_RECOVERY_SUBMIT.equals(event.getIdentifier())) {
-            processPreJoinRecoverySubmit(playerId, playerName, event.getDialogResponseView());
+            processPreJoinRecoverySubmit(connection, connectionSessions.get(connection), playerId, playerName, event.getDialogResponseView());
             return;
         }
 
@@ -168,12 +174,12 @@ public class PaperDialogFlowListener implements Listener {
             String kickMessage = commonService.getProperty(RegistrationSettings.PRE_JOIN_LOGIN_CANCEL_KICKS)
                 ? messages.retrieveSingle(playerName, MessageKey.DIALOG_LOGIN_CANCELED)
                 : null;
-            completeLoginResponse(playerId, kickMessage);
+            completeLoginResponseForSession(connectionSessions.get(connection), kickMessage);
             return;
         }
 
         if (PaperDialogActionKeys.PRE_JOIN_LOGIN_SUBMIT.equals(event.getIdentifier())) {
-            processPreJoinLogin(playerId, playerName, event.getDialogResponseView());
+            processPreJoinLoginForSession(connection, connectionSessions.get(connection), playerId, playerName, event.getDialogResponseView());
             return;
         }
 
@@ -186,16 +192,27 @@ public class PaperDialogFlowListener implements Listener {
             String kickMessage = commonService.getProperty(RegistrationSettings.PRE_JOIN_REGISTER_CANCEL_KICKS)
                 ? messages.retrieveSingle(playerName, MessageKey.DIALOG_REGISTER_CANCELED)
                 : null;
-            completeRegisterResponse(playerId, kickMessage);
+            completeRegisterResponseForSession(connectionSessions.get(connection), kickMessage);
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerConnectionClose(PlayerConnectionCloseEvent event) {
         UUID playerId = event.getPlayerUniqueId();
-        pendingLoginResponses.remove(playerId);
-        pendingRegisterResponses.remove(playerId);
-        preJoinDialogService.clear(playerId);
+
+        // remove all disconnected sessions
+        // pending map is likely very small, but we are still doing a heavy iteration here
+        connectionSessions.entrySet().removeIf(entry -> {
+            if (entry.getKey().isConnected()) {
+                return false;
+            }
+
+            Long sid = entry.getValue();
+            pendingLoginResponses.remove(sid);
+            pendingRegisterResponses.remove(sid);
+            preJoinDialogService.unregisterPreJoinFuture(sid);
+            return true;
+        });
     }
 
     private void handleBlockingLoginDialog(PlayerConfigurationConnection connection, UUID playerId, String playerName) {
@@ -204,8 +221,9 @@ public class PaperDialogFlowListener implements Listener {
         loginResponse.completeOnTimeout(
             messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR), timeoutSeconds, TimeUnit.SECONDS);
         String normalizedName = playerName.toLowerCase(Locale.ROOT);
-        pendingLoginResponses.put(playerId, loginResponse);
-        preJoinDialogService.registerPreJoinFuture(normalizedName, playerId, loginResponse);
+        long sid = preJoinDialogService.registerPreJoinFuture(normalizedName, playerId, loginResponse);
+        pendingLoginResponses.put(sid, loginResponse);
+        connectionSessions.put(connection, sid);
 
         // Close the race with a proxy auto-login (perform.login) that arrived during the configuration
         // phase between the shouldSkipDialogs() check and now: if a proxy session has been queued,
@@ -214,7 +232,7 @@ public class PaperDialogFlowListener implements Listener {
             ProxySessionManager.ProxyLoginRequest req = proxySessionManager.getLoginRequest(normalizedName);
             if (req != null && (req.verifiedPremiumUuid() == null
                 || isProxyPremiumRequestValid(normalizedName, req))) {
-                preJoinDialogService.approvePreJoinForceLogin(normalizedName);
+                preJoinDialogService.approvePreJoinForceLoginForSession(sid);
             }
         }
 
@@ -223,8 +241,9 @@ public class PaperDialogFlowListener implements Listener {
                 PaperDialogHelper.createPreJoinLoginDialog(dialogWindowService.createPreJoinLoginDialog(playerName)));
         }
         String kickMessage = loginResponse.join();
-        pendingLoginResponses.remove(playerId);
-        preJoinDialogService.unregisterPreJoinFuture(playerId);
+        pendingLoginResponses.remove(sid);
+        connectionSessions.remove(connection, sid);
+        preJoinDialogService.unregisterPreJoinFuture(sid);
 
         if (kickMessage != null) {
             preJoinDialogService.storePendingKickMessage(playerId, kickMessage);
@@ -232,24 +251,24 @@ public class PaperDialogFlowListener implements Listener {
         connection.getAudience().closeDialog();
     }
 
-    private void processPreJoinLogin(UUID playerId, String playerName, DialogResponseView dialogResponseView) {
+    private void processPreJoinLoginForSession(PlayerConfigurationConnection commonConnection, Long sid, UUID playerId, String playerName, DialogResponseView dialogResponseView) {
         String password = dialogResponseView == null ? null : dialogResponseView.getText("password");
         if (password == null || password.isBlank()) {
-            completeLoginResponse(playerId, messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR));
+            completeLoginResponseForSession(sid, messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR));
             return;
         }
 
         PlayerAuth auth = dataSource.getAuth(playerName.toLowerCase(Locale.ROOT));
         if (auth == null) {
-            completeLoginResponse(playerId, messages.retrieveSingle(playerName, MessageKey.UNKNOWN_USER));
+            completeLoginResponseForSession(sid, messages.retrieveSingle(playerName, MessageKey.UNKNOWN_USER));
             return;
         }
 
         if (passwordSecurity.comparePassword(password, auth.getPassword(), playerName)) {
-            preJoinDialogService.storePendingLoginPassword(playerId, password);
-            completeLoginResponse(playerId, null);
+            preJoinDialogService.storePendingLoginPassword(commonConnection.getClientAddress(), playerId, password);
+            completeLoginResponseForSession(sid, null);
         } else {
-            completeLoginResponse(playerId, messages.retrieveSingle(playerName, MessageKey.WRONG_PASSWORD));
+            completeLoginResponseForSession(sid, messages.retrieveSingle(playerName, MessageKey.WRONG_PASSWORD));
         }
     }
 
@@ -259,13 +278,14 @@ public class PaperDialogFlowListener implements Listener {
         connection.getAudience().showDialog(PaperDialogHelper.createPreJoinRecoveryDialog(recoverySpec));
     }
 
-    private void processPreJoinRecoverySubmit(UUID playerId, String playerName, DialogResponseView dialogResponseView) {
+    private void processPreJoinRecoverySubmit(PlayerConfigurationConnection connection, Long sid, UUID playerId, String playerName, DialogResponseView dialogResponseView) {
         String email = dialogResponseView == null ? null : dialogResponseView.getText("email");
         if (email != null && !email.isBlank()) {
-            preJoinDialogService.storePendingRecoveryEmail(playerId, email);
+            preJoinDialogService.storePendingRecoveryEmail(connection.getClientAddress(), playerId, email);
         }
+
         // Let the player join; AsynchronousJoin will execute the recovery and kick on failure
-        completeLoginResponse(playerId, null);
+        completeLoginResponseForSession(sid, null);
     }
 
     private void handleBlockingRegisterDialog(PlayerConfigurationConnection connection, UUID playerId, String playerName, Dialog dialog) {
@@ -273,11 +293,15 @@ public class PaperDialogFlowListener implements Listener {
         long timeoutSeconds = Math.max(commonService.getProperty(RestrictionSettings.REGISTER_TIMEOUT), 1);
         registerResponse.completeOnTimeout(
             messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR), timeoutSeconds, TimeUnit.SECONDS);
-        pendingRegisterResponses.put(playerId, registerResponse);
+        long sid = preJoinDialogService.registerPreJoinFuture(playerName.toLowerCase(Locale.ROOT), playerId, registerResponse);
+        pendingRegisterResponses.put(sid, registerResponse);
+        connectionSessions.put(connection, sid);
 
         connection.getAudience().showDialog(dialog);
         String kickMessage = registerResponse.join();
-        pendingRegisterResponses.remove(playerId);
+        pendingRegisterResponses.remove(sid);
+        connectionSessions.remove(connection, sid);
+        preJoinDialogService.unregisterPreJoinFuture(sid);
 
         if (kickMessage != null) {
             preJoinDialogService.storePendingKickMessage(playerId, kickMessage);
@@ -288,7 +312,7 @@ public class PaperDialogFlowListener implements Listener {
     private void storePendingRegistration(PlayerConfigurationConnection connection, UUID playerId, String playerName,
                                           DialogResponseView dialogResponseView) {
         if (dialogResponseView == null) {
-            completeRegisterResponse(playerId, null);
+            completeRegisterResponseForSession(connectionSessions.get(connection), null);
             return;
         }
 
@@ -302,7 +326,7 @@ public class PaperDialogFlowListener implements Listener {
                     String kickMessage = messages.retrieveSingle(playerName, MessageKey.MAX_REGISTER_EXCEEDED,
                         Integer.toString(maxRegPerIp), Integer.toString(otherAccounts.size()),
                         String.join(", ", otherAccounts));
-                    completeRegisterResponse(playerId, kickMessage);
+                    completeRegisterResponseForSession(connectionSessions.get(connection), kickMessage);
                     return;
                 }
             }
@@ -323,8 +347,8 @@ public class PaperDialogFlowListener implements Listener {
                     messages.retrieveSingle(playerName, MessageKey.PASSWORD_MATCH_ERROR));
                 return;
             }
-            preJoinDialogService.storePendingEmailRegistration(playerId, email);
-            completeRegisterResponse(playerId, null);
+            preJoinDialogService.storePendingEmailRegistration(connection.getClientAddress(), playerId, email);
+            completeRegisterResponseForSession(connectionSessions.get(connection), null);
             return;
         }
 
@@ -349,8 +373,8 @@ public class PaperDialogFlowListener implements Listener {
             return;
         }
         if (secondArg == RegisterSecondaryArgument.CONFIRMATION) {
-            preJoinDialogService.storePendingPasswordRegistration(playerId, password, null);
-            completeRegisterResponse(playerId, null);
+            preJoinDialogService.storePendingPasswordRegistration(connection.getClientAddress(), playerId, password, null);
+            completeRegisterResponseForSession(connectionSessions.get(connection), null);
             return;
         }
 
@@ -367,13 +391,11 @@ public class PaperDialogFlowListener implements Listener {
                     messages.retrieveSingle(playerName, MessageKey.INVALID_EMAIL));
                 return;
             }
-            preJoinDialogService.storePendingPasswordRegistration(playerId, password, email);
-            completeRegisterResponse(playerId, null);
+            completeRegisterResponseForSession(connectionSessions.get(connection), null);
             return;
         }
 
-        preJoinDialogService.storePendingPasswordRegistration(playerId, password, null);
-        completeRegisterResponse(playerId, null);
+        completeRegisterResponseForSession(connectionSessions.get(connection), null);
     }
 
     private void showRegisterDialogWithError(PlayerConfigurationConnection connection, String playerName,
@@ -384,15 +406,23 @@ public class PaperDialogFlowListener implements Listener {
         connection.getAudience().showDialog(PaperDialogHelper.createPreJoinRegisterDialog(spec.withBody(errorMessage)));
     }
 
-    private void completeLoginResponse(UUID playerId, String kickMessage) {
-        CompletableFuture<String> loginResponse = pendingLoginResponses.get(playerId);
+    private void completeLoginResponseForSession(Long sessionId, String kickMessage) {
+        if (sessionId == null) {
+            return;
+        }
+
+        CompletableFuture<String> loginResponse = pendingLoginResponses.get(sessionId);
         if (loginResponse != null) {
             loginResponse.complete(kickMessage);
         }
     }
 
-    private void completeRegisterResponse(UUID playerId, String kickMessage) {
-        CompletableFuture<String> registerResponse = pendingRegisterResponses.get(playerId);
+    private void completeRegisterResponseForSession(Long sessionId, String kickMessage) {
+        if (sessionId == null) {
+            return;
+        }
+
+        CompletableFuture<String> registerResponse = pendingRegisterResponses.get(sessionId);
         if (registerResponse != null) {
             registerResponse.complete(kickMessage);
         }
@@ -471,6 +501,15 @@ public class PaperDialogFlowListener implements Listener {
             return version >= DIALOG_MIN_PROTOCOL;
         } catch (Exception ignored) {
             return true;
+        }
+    }
+
+    private void cleanup(PlayerConfigurationConnection connection) {
+        Long sid = connectionSessions.remove(connection);
+        if (sid != null) {
+            pendingLoginResponses.remove(sid);
+            pendingRegisterResponses.remove(sid);
+            preJoinDialogService.unregisterPreJoinFuture(sid);
         }
     }
 }

--- a/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperDialogFlowListenerTest.java
+++ b/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperDialogFlowListenerTest.java
@@ -122,7 +122,7 @@ public class PaperDialogFlowListenerTest {
 
             assertThat("future must stay open so the player can retry", future.isDone(), is(false));
             verify(connection).getAudience();
-            verify(preJoinDialogService, never()).storePendingPasswordRegistration(any(), any(), any());
+            verify(preJoinDialogService, never()).storePendingPasswordRegistration(any(), any(), any(), any());
         }
     }
 
@@ -468,7 +468,7 @@ public class PaperDialogFlowListenerTest {
         given(dataSource.getAuth("bobby")).willReturn(auth);
         given(premiumLoginVerifier.getVerifiedUuid("Bobby")).willReturn(null);  // not yet verified
 
-        // UUID v4 that doesn't match stored premium UUID → must return false (impostor or wrong account)
+        // UUID v4 that doesn'internal match stored premium UUID → must return false (impostor or wrong account)
         assertThat(invokeShouldSkipPreJoinDialogForPremium(listener, auth, "Bobby", playerId), is(false));
         verify(preJoinDialogService, never()).markSkipPostJoinDialog(playerId);
     }
@@ -476,7 +476,7 @@ public class PaperDialogFlowListenerTest {
     @Test
     public void shouldSkipPreJoinDialogForPremiumPlayerWithOfflineUuidInProxyMode() throws Exception {
         // When the PlayerProfile at the configuration phase still has an offline UUID (v3) because
-        // proxy forwarding hasn't been applied yet, the pre-join dialog must be skipped and the
+        // proxy forwarding hasn'internal been applied yet, the pre-join dialog must be skipped and the
         // final UUID check deferred to AsynchronousJoin.
         PaperDialogFlowListener listener = new PaperDialogFlowListener();
         CommonService commonService = mock(CommonService.class);


### PR DESCRIPTION
# Background

Multiple clients with the same username/uuid are allowed in the configuration phase (part of the dialog system). Only in later stages players are getting kicked with "logged in from another location".

This means the UUID and names we use as [identifiers](https://github.com/AuthMe/AuthMeReloaded/blob/f5afba06d8b973d415034e22bfff38911b3716b0/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java#L55) there are not unique. Later connection requests will [remove/override](https://github.com/AuthMe/AuthMeReloaded/blob/f5afba06d8b973d415034e22bfff38911b3716b0/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java#L108) earlier associations to the ongoing login attempt. This has the consequence that if an earlier legimate login request enters the password correctly, only the latest open dialog will be approved, which could be an attacker.

# Related

#3131

# Reproduce

0. Default config
1. Join two clients
2. Enter password in the first client
3. Second (incorrect) client is approved
4. First client (the legimate one) gets a timeout

## Solution idea

**Draft only**

Bind the open login dialog to the connection (player object or connection object) which makes it unique per connection. This is what this PR does. **In its current state it fixes the issue for single paper server setup. Force logins from proxies or commands are disabled, because it needs a way to differentiate multiple connections instead of relying only the player name.**