### PR TITLE
fix(proxy): route authentication to the originating player

### DIFF
--- a/authme-bungee/src/main/java/fr/xephi/authme/bungee/BungeeAuthenticationStore.java
+++ b/authme-bungee/src/main/java/fr/xephi/authme/bungee/BungeeAuthenticationStore.java
@@ -2,35 +2,26 @@ package fr.xephi.authme.bungee;
 
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
-import java.util.Locale;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 final class BungeeAuthenticationStore {
 
-    private final Set<String> authenticatedPlayers = ConcurrentHashMap.newKeySet();
+    private final Map<ProxiedPlayer, String> authenticatedPlayers = new IdentityHashMap<>();
 
-    void markAuthenticated(String playerName) {
-        authenticatedPlayers.add(normalizeName(playerName));
+    synchronized void markAuthenticated(ProxiedPlayer player) {
+        authenticatedPlayers.put(player, player.getName());
     }
 
-    void markLoggedOut(String playerName) {
-        authenticatedPlayers.remove(normalizeName(playerName));
+    synchronized void markLoggedOut(ProxiedPlayer player) {
+        authenticatedPlayers.remove(player);
     }
 
-    boolean isAuthenticated(ProxiedPlayer player) {
-        return isAuthenticated(player.getName());
-    }
-
-    boolean isAuthenticated(String playerName) {
-        return authenticatedPlayers.contains(normalizeName(playerName));
+    synchronized boolean isAuthenticated(ProxiedPlayer player) {
+        return authenticatedPlayers.containsKey(player);
     }
 
     void clear(ProxiedPlayer player) {
-        markLoggedOut(player.getName());
-    }
-
-    private static String normalizeName(String playerName) {
-        return playerName.toLowerCase(Locale.ROOT);
+        markLoggedOut(player);
     }
 }

--- a/authme-bungee/src/main/java/fr/xephi/authme/bungee/BungeeProxyBridge.java
+++ b/authme-bungee/src/main/java/fr/xephi/authme/bungee/BungeeProxyBridge.java
@@ -30,7 +30,9 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -64,7 +66,8 @@ public final class BungeeProxyBridge implements Listener {
     private final Logger logger;
     private BungeeProxyConfiguration configuration;
     private final BungeeAuthenticationStore authenticationStore;
-    private final Map<String, AtomicInteger> pendingAutoLogins = new ConcurrentHashMap<>();
+    private final Map<ProxiedPlayer, AtomicInteger> pendingAutoLogins =
+        Collections.synchronizedMap(new IdentityHashMap<>());
     private final Set<String> notifiedAuthServers = ConcurrentHashMap.newKeySet();
     private volatile Set<String> premiumUsernames = ConcurrentHashMap.newKeySet();
     private List<String> premiumListBuffer = new ArrayList<>();
@@ -234,7 +237,8 @@ public final class BungeeProxyBridge implements Listener {
         if (event.isCancelled() || !AUTHME_CHANNEL.equals(event.getTag())) {
             return;
         }
-        if (!(event.getSender() instanceof Server server)) {
+        if (!(event.getSender() instanceof Server server)
+            || !(event.getReceiver() instanceof ProxiedPlayer player)) {
             event.setCancelled(true);
             return;
         }
@@ -243,27 +247,33 @@ public final class BungeeProxyBridge implements Listener {
         if (parsedMessage.typeId() == null || parsedMessage.playerName() == null) {
             return;
         }
+        if (isPlayerSessionMessage(parsedMessage.typeId())
+            && !parsedMessage.playerName().equalsIgnoreCase(player.getName())) {
+            logger.warning("Ignoring AuthMe message for '" + parsedMessage.playerName()
+                + "' carried by player '" + player.getName() + "'");
+            return;
+        }
 
         if (LOGIN_MESSAGE.equals(parsedMessage.typeId())) {
             if (configuration.isAuthServer(server.getInfo())) {
                 logger.info("Player " + parsedMessage.playerName() + " authenticated on auth server '"
                     + server.getInfo().getName() + "'");
-                authenticationStore.markAuthenticated(parsedMessage.playerName());
-                sendAutoLoginIfAlreadySwitched(parsedMessage.playerName(), server.getInfo());
-                redirectToLoginServer(parsedMessage.playerName());
-            } else if (pendingAutoLogins.containsKey(parsedMessage.playerName())) {
+                authenticationStore.markAuthenticated(player);
+                sendAutoLoginIfAlreadySwitched(player, server.getInfo());
+                redirectToLoginServer(player);
+            } else if (pendingAutoLogins.containsKey(player)) {
                 // Implicit ACK: login from non-auth server confirms perform.login was processed
                 logger.info("Auto-login confirmed for " + parsedMessage.playerName()
                     + " via login from server '" + server.getInfo().getName() + "'");
-                cancelPendingLogin(parsedMessage.playerName());
+                cancelPendingLogin(player);
             }
         } else if (LOGOUT_MESSAGE.equals(parsedMessage.typeId())) {
-            authenticationStore.markLoggedOut(parsedMessage.playerName());
-            redirectLoggedOutPlayer(parsedMessage.playerName());
+            authenticationStore.markLoggedOut(player);
+            redirectLoggedOutPlayer(player);
         } else if (PERFORM_LOGIN_ACK_MESSAGE.equals(parsedMessage.typeId())) {
             logger.info("Auto-login ACK received for " + parsedMessage.playerName()
                 + " from server '" + server.getInfo().getName() + "'");
-            cancelPendingLogin(parsedMessage.playerName());
+            cancelPendingLogin(player);
         } else if (PREMIUM_SET_MESSAGE.equals(parsedMessage.typeId())) {
             premiumUsernames.add(parsedMessage.playerName());
             pendingPremiumUsernames.remove(parsedMessage.playerName());
@@ -353,9 +363,8 @@ public final class BungeeProxyBridge implements Listener {
 
         String serverName = currentServer.getInfo().getName();
         logger.info("Sending auto-login request to server '" + serverName + "' for player " + normalizedName);
-        currentServer.getInfo().sendData(
-            AUTHME_CHANNEL, createPerformLoginMessage(normalizedName, verifiedPremiumUuid), false);
-        initiatePendingLogin(normalizedName);
+        currentServer.sendData(AUTHME_CHANNEL, createPerformLoginMessage(normalizedName, verifiedPremiumUuid));
+        initiatePendingLogin(player);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -417,10 +426,10 @@ public final class BungeeProxyBridge implements Listener {
     @EventHandler
     public void onPlayerDisconnect(PlayerDisconnectEvent event) {
         String normalizedName = normalizeName(event.getPlayer().getName());
-        if (pendingAutoLogins.containsKey(normalizedName)) {
+        if (pendingAutoLogins.containsKey(event.getPlayer())) {
             logger.fine("Cancelling pending auto-login for " + normalizedName + " (player disconnected)");
         }
-        cancelPendingLogin(normalizedName);
+        cancelPendingLogin(event.getPlayer());
         authenticationStore.clear(event.getPlayer());
         premiumVerificationManager.clearVerifiedPremium(normalizedName);
     }
@@ -431,14 +440,11 @@ public final class BungeeProxyBridge implements Listener {
         retryScheduler.shutdownNow();
     }
 
-    private void sendAutoLoginIfAlreadySwitched(String normalizedName, ServerInfo authServer) {
+    private void sendAutoLoginIfAlreadySwitched(ProxiedPlayer player, ServerInfo authServer) {
         if (!configuration.autoLoginEnabled()) {
             return;
         }
-        ProxiedPlayer player = proxyServer.getPlayer(normalizedName);
-        if (player == null) {
-            return;
-        }
+        String normalizedName = normalizeName(player.getName());
         Server currentConn = player.getServer();
         if (currentConn == null) {
             return;
@@ -451,9 +457,8 @@ public final class BungeeProxyBridge implements Listener {
         logger.info("Player " + normalizedName + " already on server '" + currentServerName
             + "' when login message arrived — sending auto-login immediately");
         UUID verifiedPremiumUuid = premiumVerificationManager.getVerifiedPremiumUuid(normalizedName);
-        currentConn.getInfo().sendData(
-            AUTHME_CHANNEL, createPerformLoginMessage(normalizedName, verifiedPremiumUuid), false);
-        initiatePendingLogin(normalizedName);
+        currentConn.sendData(AUTHME_CHANNEL, createPerformLoginMessage(normalizedName, verifiedPremiumUuid));
+        initiatePendingLogin(player);
     }
 
     private void sendProxyStartedHandshakeIfPending(ServerInfo server) {
@@ -474,37 +479,37 @@ public final class BungeeProxyBridge implements Listener {
         }
     }
 
-    private void initiatePendingLogin(String normalizedName) {
-        pendingAutoLogins.put(normalizedName, new AtomicInteger(0));
-        scheduleRetry(normalizedName);
+    private void initiatePendingLogin(ProxiedPlayer player) {
+        pendingAutoLogins.put(player, new AtomicInteger(0));
+        scheduleRetry(player);
     }
 
-    private void cancelPendingLogin(String normalizedName) {
-        pendingAutoLogins.remove(normalizedName);
+    private void cancelPendingLogin(ProxiedPlayer player) {
+        pendingAutoLogins.remove(player);
     }
 
-    private void scheduleRetry(String normalizedName) {
+    private void scheduleRetry(ProxiedPlayer player) {
         retryScheduler.schedule(() -> {
-            AtomicInteger attempts = pendingAutoLogins.get(normalizedName);
+            AtomicInteger attempts = pendingAutoLogins.get(player);
             if (attempts == null) {
                 return;
             }
+            String normalizedName = normalizeName(player.getName());
             int current = attempts.getAndIncrement();
             if (current >= MAX_RETRIES) {
-                pendingAutoLogins.remove(normalizedName);
+                pendingAutoLogins.remove(player);
                 logger.warning("No auto-login ACK received for " + normalizedName
                     + " after " + MAX_RETRIES + " retries; giving up");
                 return;
             }
-            ProxiedPlayer player = proxyServer.getPlayer(normalizedName);
-            if (player == null) {
-                pendingAutoLogins.remove(normalizedName);
+            if (!player.isConnected()) {
+                pendingAutoLogins.remove(player);
                 logger.fine("Auto-login retry cancelled for " + normalizedName + " (player no longer online)");
                 return;
             }
             Server server = player.getServer();
             if (server == null) {
-                pendingAutoLogins.remove(normalizedName);
+                pendingAutoLogins.remove(player);
                 logger.fine("Auto-login retry cancelled for " + normalizedName + " (player has no active server)");
                 return;
             }
@@ -512,9 +517,8 @@ public final class BungeeProxyBridge implements Listener {
             logger.fine("Retrying auto-login for " + normalizedName + " on server '" + serverName
                 + "' (attempt " + (current + 1) + "/" + MAX_RETRIES + ")");
             UUID verifiedPremiumUuid = premiumVerificationManager.getVerifiedPremiumUuid(normalizedName);
-            server.getInfo().sendData(
-                AUTHME_CHANNEL, createPerformLoginMessage(normalizedName, verifiedPremiumUuid), false);
-            scheduleRetry(normalizedName);
+            server.sendData(AUTHME_CHANNEL, createPerformLoginMessage(normalizedName, verifiedPremiumUuid));
+            scheduleRetry(player);
         }, 1, TimeUnit.SECONDS);
     }
 
@@ -542,12 +546,17 @@ public final class BungeeProxyBridge implements Listener {
         }
     }
 
-    private void redirectToLoginServer(String normalizedPlayerName) {
+    private static boolean isPlayerSessionMessage(String typeId) {
+        return LOGIN_MESSAGE.equals(typeId) || LOGOUT_MESSAGE.equals(typeId)
+            || PERFORM_LOGIN_ACK_MESSAGE.equals(typeId);
+    }
+
+    private void redirectToLoginServer(ProxiedPlayer player) {
+        String normalizedPlayerName = normalizeName(player.getName());
         if (configuration.loginServer().isEmpty()) {
             return;
         }
-        ProxiedPlayer player = proxyServer.getPlayer(normalizedPlayerName);
-        if (player == null) {
+        if (!player.isConnected()) {
             logger.fine("Cannot redirect " + normalizedPlayerName + " to loginServer: player no longer on proxy");
             return;
         }
@@ -562,7 +571,8 @@ public final class BungeeProxyBridge implements Listener {
         player.connect(targetServer);
     }
 
-    private void redirectLoggedOutPlayer(String normalizedPlayerName) {
+    private void redirectLoggedOutPlayer(ProxiedPlayer player) {
+        String normalizedPlayerName = normalizeName(player.getName());
         if (!configuration.sendOnLogoutEnabled()) {
             return;
         }
@@ -572,8 +582,7 @@ public final class BungeeProxyBridge implements Listener {
             return;
         }
 
-        ProxiedPlayer player = proxyServer.getPlayer(normalizedPlayerName);
-        if (player == null) {
+        if (!player.isConnected()) {
             return;
         }
 

--- a/authme-bungee/src/test/java/fr/xephi/authme/bungee/BungeeProxyBridgeTest.java
+++ b/authme-bungee/src/test/java/fr/xephi/authme/bungee/BungeeProxyBridgeTest.java
@@ -14,6 +14,7 @@ import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.event.ServerSwitchEvent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -29,6 +30,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -88,6 +90,11 @@ class BungeeProxyBridgeTest {
     @Captor
     private ArgumentCaptor<byte[]> payloadCaptor;
 
+    @BeforeEach
+    void setPluginMessageReceiver() {
+        org.mockito.Mockito.lenient().when(pluginMessageEvent.getReceiver()).thenReturn(player);
+    }
+
     @Test
     void shouldTrackAuthenticatedPlayerAndForwardPerformLoginOnServerSwitch() {
         given(pluginMessageEvent.isCancelled()).willReturn(false);
@@ -105,8 +112,50 @@ class BungeeProxyBridgeTest {
         bridge.onPluginMessage(pluginMessageEvent);
         bridge.onServerSwitch(serverSwitchEvent);
 
-        verify(authServerInfo).sendData(eq(BungeeProxyBridge.AUTHME_CHANNEL), payloadCaptor.capture(), eq(false));
+        verify(currentServer).sendData(eq(BungeeProxyBridge.AUTHME_CHANNEL), payloadCaptor.capture());
         assertPerformLoginPayload(payloadCaptor.getValue(), "alice", "test-secret");
+    }
+
+    @Test
+    void shouldAuthenticateThePlayerCarryingTheLoginMessage() {
+        ProxiedPlayer olderPlayer = org.mockito.Mockito.mock(ProxiedPlayer.class);
+        given(olderPlayer.getName()).willReturn("Example");
+        given(player.getName()).willReturn("example");
+        given(pluginMessageEvent.isCancelled()).willReturn(false);
+        given(pluginMessageEvent.getTag()).willReturn(BungeeProxyBridge.AUTHME_CHANNEL);
+        given(pluginMessageEvent.getSender()).willReturn(sourceServer);
+        given(pluginMessageEvent.getReceiver()).willReturn(player);
+        given(pluginMessageEvent.getData()).willReturn(createAuthMePayload("login", "Example"));
+        given(sourceServer.getInfo()).willReturn(authServerInfo);
+        given(authServerInfo.getName()).willReturn("lobby");
+
+        BungeeAuthenticationStore store = new BungeeAuthenticationStore();
+        BungeeProxyBridge bridge = new BungeeProxyBridge(proxyServer, logger, createConfiguration(), store, null);
+        bridge.onPluginMessage(pluginMessageEvent);
+
+        assertFalse(store.isAuthenticated(olderPlayer));
+        assertTrue(store.isAuthenticated(player));
+        verify(proxyServer, never()).getPlayer(any(String.class));
+    }
+
+    @Test
+    void shouldRejectLoginForANameDifferentFromTheMessageReceiver() {
+        given(player.getName()).willReturn("Alice");
+        given(pluginMessageEvent.isCancelled()).willReturn(false);
+        given(pluginMessageEvent.getTag()).willReturn(BungeeProxyBridge.AUTHME_CHANNEL);
+        given(pluginMessageEvent.getSender()).willReturn(sourceServer);
+        given(pluginMessageEvent.getReceiver()).willReturn(player);
+        given(pluginMessageEvent.getData()).willReturn(createAuthMePayload("login", "Bob"));
+        given(sourceServer.getInfo()).willReturn(authServerInfo);
+        given(authServerInfo.getName()).willReturn("lobby");
+
+        BungeeAuthenticationStore store = new BungeeAuthenticationStore();
+        BungeeProxyBridge bridge = new BungeeProxyBridge(proxyServer, logger, createConfiguration(), store, null);
+        bridge.onPluginMessage(pluginMessageEvent);
+
+        assertFalse(store.isAuthenticated(player));
+        verify(player, never()).connect(any(ServerInfo.class));
+        verify(proxyServer, never()).getPlayer(any(String.class));
     }
 
     @Test
@@ -157,7 +206,10 @@ class BungeeProxyBridgeTest {
         given(pluginMessageEvent.getTag()).willReturn(BungeeProxyBridge.AUTHME_CHANNEL);
         given(pluginMessageEvent.getSender()).willReturn(sourceServer);
         given(pluginMessageEvent.getData()).willReturn(createAuthMePayload("logout", "Alice"));
-        given(proxyServer.getPlayer("alice")).willReturn(player);
+        given(sourceServer.getInfo()).willReturn(nonAuthServerInfo);
+        given(nonAuthServerInfo.getName()).willReturn("survival");
+        given(player.getName()).willReturn("Alice");
+        given(player.isConnected()).willReturn(true);
         given(proxyServer.getServerInfo("limbo")).willReturn(nonAuthServerInfo);
 
         BungeeProxyBridge bridge = new BungeeProxyBridge(
@@ -204,8 +256,7 @@ class BungeeProxyBridgeTest {
         given(pluginMessageEvent.getData()).willReturn(createAuthMePayload("perform.login.ack", "Alice"));
         bridge.onPluginMessage(pluginMessageEvent);
 
-        // getPlayer called exactly once by sendAutoLoginIfAlreadySwitched (on login), not by any retry
-        verify(proxyServer, org.mockito.Mockito.times(1)).getPlayer("alice");
+        verify(proxyServer, never()).getPlayer(any(String.class));
     }
 
     @Test
@@ -233,8 +284,7 @@ class BungeeProxyBridgeTest {
         given(sourceServer.getInfo()).willReturn(nonAuthServerInfo);
         bridge.onPluginMessage(pluginMessageEvent);
 
-        // getPlayer called exactly once by sendAutoLoginIfAlreadySwitched (on login from auth server), not by retries
-        verify(proxyServer, org.mockito.Mockito.times(1)).getPlayer("alice");
+        verify(proxyServer, never()).getPlayer(any(String.class));
     }
 
     @Test
@@ -370,7 +420,7 @@ class BungeeProxyBridgeTest {
         given(sourceServer.getInfo()).willReturn(authServerInfo);
         given(serverSwitchEvent.getPlayer()).willReturn(player);
         given(player.getName()).willReturn("Alice");
-        given(player.getServer()).willReturn(currentServer);
+        given(player.getServer()).willReturn(sourceServer, currentServer);
         given(currentServer.getInfo()).willReturn(nonAuthServerInfo);
         given(nonAuthServerInfo.getName()).willReturn("survival");
         given(serverSwitchEvent.getFrom()).willReturn(authServerInfo);
@@ -380,7 +430,7 @@ class BungeeProxyBridgeTest {
         bridge.onPluginMessage(pluginMessageEvent);
         bridge.onServerSwitch(serverSwitchEvent);
 
-        verify(nonAuthServerInfo).sendData(eq(BungeeProxyBridge.AUTHME_CHANNEL), payloadCaptor.capture(), eq(false));
+        verify(currentServer).sendData(eq(BungeeProxyBridge.AUTHME_CHANNEL), payloadCaptor.capture());
         assertPerformLoginPayload(payloadCaptor.getValue(), "alice", "test-secret");
     }
 
@@ -434,7 +484,7 @@ class BungeeProxyBridgeTest {
         given(sourceServer.getInfo()).willReturn(authServerInfo);
         given(authServerInfo.getName()).willReturn("lobby");
         // Player is already on a non-auth server when the login message arrives
-        given(proxyServer.getPlayer("alice")).willReturn(player);
+        given(player.getName()).willReturn("Alice");
         given(player.getServer()).willReturn(currentServer);
         given(currentServer.getInfo()).willReturn(nonAuthServerInfo);
         given(nonAuthServerInfo.getName()).willReturn("survival");
@@ -442,7 +492,7 @@ class BungeeProxyBridgeTest {
         BungeeProxyBridge bridge = new BungeeProxyBridge(proxyServer, logger, createConfiguration(), new BungeeAuthenticationStore(), null);
         bridge.onPluginMessage(pluginMessageEvent);
 
-        verify(nonAuthServerInfo).sendData(eq(BungeeProxyBridge.AUTHME_CHANNEL), payloadCaptor.capture(), eq(false));
+        verify(currentServer).sendData(eq(BungeeProxyBridge.AUTHME_CHANNEL), payloadCaptor.capture());
         assertPerformLoginPayload(payloadCaptor.getValue(), "alice", "test-secret");
     }
 

--- a/authme-core/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
+++ b/authme-core/src/main/java/fr/xephi/authme/api/v3/AuthMeApi.java
@@ -96,7 +96,7 @@ public class AuthMeApi {
      * @return true if the player is authenticated
      */
     public boolean isAuthenticated(Player player) {
-        return playerCache.isAuthenticated(player.getName());
+        return playerCache.isAuthenticated(player);
     }
 
     /**
@@ -128,7 +128,7 @@ public class AuthMeApi {
      * @return The location of the player
      */
     public Location getLastLocation(Player player) {
-        PlayerAuth auth = playerCache.getAuth(player.getName());
+        PlayerAuth auth = playerCache.getAuth(player);
         if (auth != null) {
             return new Location(Bukkit.getWorld(auth.getWorld()),
                 auth.getQuitLocX(), auth.getQuitLocY(), auth.getQuitLocZ(), auth.getYaw(), auth.getPitch());

--- a/authme-core/src/main/java/fr/xephi/authme/command/executable/captcha/CaptchaCommand.java
+++ b/authme-core/src/main/java/fr/xephi/authme/command/executable/captcha/CaptchaCommand.java
@@ -41,7 +41,7 @@ public class CaptchaCommand extends PlayerCommand {
     public void runCommand(Player player, List<String> arguments) {
         final String name = player.getName();
 
-        if (playerCache.isAuthenticated(name)) {
+        if (playerCache.isAuthenticated(player)) {
             // No captcha is relevant if the player is logged in
             commonService.send(player, MessageKey.ALREADY_LOGGED_IN_ERROR);
             return;

--- a/authme-core/src/main/java/fr/xephi/authme/command/executable/changepassword/ChangePasswordCommand.java
+++ b/authme-core/src/main/java/fr/xephi/authme/command/executable/changepassword/ChangePasswordCommand.java
@@ -38,7 +38,7 @@ public class ChangePasswordCommand extends PlayerCommand {
     public void runCommand(Player player, List<String> arguments) {
         String name = player.getName().toLowerCase(Locale.ROOT);
 
-        if (!playerCache.isAuthenticated(name)) {
+        if (!playerCache.isAuthenticated(player)) {
             commonService.send(player, MessageKey.NOT_LOGGED_IN);
             return;
         }

--- a/authme-core/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
+++ b/authme-core/src/main/java/fr/xephi/authme/command/executable/email/ShowEmailCommand.java
@@ -25,7 +25,7 @@ public class ShowEmailCommand extends PlayerCommand {
 
     @Override
     public void runCommand(Player player, List<String> arguments) {
-        PlayerAuth auth = playerCache.getAuth(player.getName());
+        PlayerAuth auth = playerCache.getAuth(player);
         if (auth != null && !Utils.isEmailEmpty(auth.getEmail())) {
             if (commonService.getProperty(SecuritySettings.USE_EMAIL_MASKING)){
                 commonService.send(player, MessageKey.EMAIL_SHOW, emailMask(auth.getEmail()));

--- a/authme-core/src/main/java/fr/xephi/authme/command/executable/totp/AddTotpCommand.java
+++ b/authme-core/src/main/java/fr/xephi/authme/command/executable/totp/AddTotpCommand.java
@@ -28,7 +28,7 @@ public class AddTotpCommand extends PlayerCommand {
 
     @Override
     protected void runCommand(Player player, List<String> arguments) {
-        PlayerAuth auth = playerCache.getAuth(player.getName());
+        PlayerAuth auth = playerCache.getAuth(player);
         if (auth == null) {
             messages.send(player, MessageKey.NOT_LOGGED_IN);
         } else if (auth.getTotpKey() == null) {

--- a/authme-core/src/main/java/fr/xephi/authme/command/executable/totp/ConfirmTotpCommand.java
+++ b/authme-core/src/main/java/fr/xephi/authme/command/executable/totp/ConfirmTotpCommand.java
@@ -36,7 +36,7 @@ public class ConfirmTotpCommand extends PlayerCommand {
 
     @Override
     protected void runCommand(Player player, List<String> arguments) {
-        PlayerAuth auth = playerCache.getAuth(player.getName());
+        PlayerAuth auth = playerCache.getAuth(player);
         if (auth == null) {
             messages.send(player, MessageKey.NOT_LOGGED_IN);
         } else if (auth.getTotpKey() != null) {

--- a/authme-core/src/main/java/fr/xephi/authme/command/executable/totp/RemoveTotpCommand.java
+++ b/authme-core/src/main/java/fr/xephi/authme/command/executable/totp/RemoveTotpCommand.java
@@ -35,7 +35,7 @@ public class RemoveTotpCommand extends PlayerCommand {
 
     @Override
     protected void runCommand(Player player, List<String> arguments) {
-        PlayerAuth auth = playerCache.getAuth(player.getName());
+        PlayerAuth auth = playerCache.getAuth(player);
         if (auth == null) {
             messages.send(player, MessageKey.NOT_LOGGED_IN);
         } else if (auth.getTotpKey() == null) {

--- a/authme-core/src/main/java/fr/xephi/authme/command/executable/totp/TotpCodeCommand.java
+++ b/authme-core/src/main/java/fr/xephi/authme/command/executable/totp/TotpCodeCommand.java
@@ -45,7 +45,7 @@ public class TotpCodeCommand extends PlayerCommand {
 
     @Override
     protected void runCommand(Player player, List<String> arguments) {
-        if (playerCache.isAuthenticated(player.getName())) {
+        if (playerCache.isAuthenticated(player)) {
             messages.send(player, MessageKey.ALREADY_LOGGED_IN_ERROR);
             return;
         }

--- a/authme-core/src/main/java/fr/xephi/authme/command/executable/unregister/UnregisterCommand.java
+++ b/authme-core/src/main/java/fr/xephi/authme/command/executable/unregister/UnregisterCommand.java
@@ -34,7 +34,7 @@ public class UnregisterCommand extends PlayerCommand {
         String playerName = player.getName();
 
         // Make sure the player is authenticated
-        if (!playerCache.isAuthenticated(playerName)) {
+        if (!playerCache.isAuthenticated(player)) {
             commonService.send(player, MessageKey.NOT_LOGGED_IN);
             return;
         }

--- a/authme-core/src/main/java/fr/xephi/authme/data/auth/PlayerCache.java
+++ b/authme-core/src/main/java/fr/xephi/authme/data/auth/PlayerCache.java
@@ -1,6 +1,9 @@
 package fr.xephi.authme.data.auth;
 
+import org.bukkit.entity.Player;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,6 +14,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PlayerCache {
 
     private final Map<String, PlayerAuth> cache = new ConcurrentHashMap<>();
+    private final Map<Player, PlayerAuth> playerCache = Collections.synchronizedMap(new IdentityHashMap<>());
+    private final Map<String, Player> owners = new ConcurrentHashMap<>();
 
     PlayerCache() {
     }
@@ -20,8 +25,19 @@ public class PlayerCache {
      *
      * @param auth the player auth object to save
      */
-    public void updatePlayer(PlayerAuth auth) {
-        cache.put(auth.getNickname().toLowerCase(Locale.ROOT), auth);
+    public synchronized void updatePlayer(PlayerAuth auth) {
+        String normalizedName = auth.getNickname().toLowerCase(Locale.ROOT);
+        cache.put(normalizedName, auth);
+        synchronized (playerCache) {
+            playerCache.replaceAll((player, current) -> player.getName().equalsIgnoreCase(normalizedName) ? auth : current);
+        }
+    }
+
+    public synchronized void updatePlayer(Player player, PlayerAuth auth) {
+        String normalizedName = auth.getNickname().toLowerCase(Locale.ROOT);
+        cache.put(normalizedName, auth);
+        owners.put(normalizedName, player);
+        playerCache.put(player, auth);
     }
 
     /**
@@ -29,8 +45,24 @@ public class PlayerCache {
      *
      * @param user name of the player to remove
      */
-    public void removePlayer(String user) {
-        cache.remove(user.toLowerCase(Locale.ROOT));
+    public synchronized void removePlayer(String user) {
+        String normalizedName = user.toLowerCase(Locale.ROOT);
+        cache.remove(normalizedName);
+        owners.remove(normalizedName);
+        synchronized (playerCache) {
+            playerCache.keySet().removeIf(player -> player.getName().equalsIgnoreCase(normalizedName));
+        }
+    }
+
+    public synchronized void removePlayer(Player player) {
+        PlayerAuth removed = playerCache.remove(player);
+        if (removed != null) {
+            String normalizedName = removed.getNickname().toLowerCase(Locale.ROOT);
+            if (owners.get(normalizedName) == player) {
+                owners.remove(normalizedName);
+                cache.remove(normalizedName);
+            }
+        }
     }
 
     /**
@@ -44,6 +76,11 @@ public class PlayerCache {
         return cache.containsKey(user.toLowerCase(Locale.ROOT));
     }
 
+    public synchronized boolean isAuthenticated(Player player) {
+        PlayerAuth auth = playerCache.get(player);
+        return auth != null && owners.get(auth.getNickname().toLowerCase(Locale.ROOT)) == player;
+    }
+
     /**
      * Returns the PlayerAuth associated with the given user, if available.
      *
@@ -53,6 +90,10 @@ public class PlayerCache {
      */
     public PlayerAuth getAuth(String user) {
         return cache.get(user.toLowerCase(Locale.ROOT));
+    }
+
+    public synchronized PlayerAuth getAuth(Player player) {
+        return isAuthenticated(player) ? playerCache.get(player) : null;
     }
 
     /**

--- a/authme-core/src/main/java/fr/xephi/authme/listener/ListenerService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/listener/ListenerService.java
@@ -77,7 +77,7 @@ public class ListenerService implements SettingsDependent {
      * @return true if the associated event should be canceled, false otherwise
      */
     public boolean shouldCancelEvent(Player player) {
-        return player != null && !checkAuth(player.getName()) && !PlayerUtils.isNpc(player);
+        return player != null && !checkAuth(player) && !PlayerUtils.isNpc(player);
     }
 
     @Override
@@ -92,8 +92,9 @@ public class ListenerService implements SettingsDependent {
      * @param name the name of the player to verify
      * @return true if the player may play, false otherwise
      */
-    private boolean checkAuth(String name) {
-        if (validationService.isUnrestricted(name) || playerCache.isAuthenticated(name)) {
+    private boolean checkAuth(Player player) {
+        String name = player.getName();
+        if (validationService.isUnrestricted(name) || playerCache.isAuthenticated(player)) {
             return true;
         }
         if (!isRegistrationForced && !dataSource.isAuthAvailable(name)) {

--- a/authme-core/src/main/java/fr/xephi/authme/listener/packetevents/InventoryPacketListener.java
+++ b/authme-core/src/main/java/fr/xephi/authme/listener/packetevents/InventoryPacketListener.java
@@ -45,7 +45,7 @@ public class InventoryPacketListener extends PacketListenerAbstract {
 
     private void cancelIfShouldHide(PacketSendEvent event) {
         Player player = event.getPlayer();
-        if (player != null && !playerCache.isAuthenticated(player.getName())
+        if (player != null && !playerCache.isAuthenticated(player)
                 && dataSource.isAuthAvailable(player.getName())) {
             event.setCancelled(true);
         }

--- a/authme-core/src/main/java/fr/xephi/authme/listener/packetevents/PacketEventsService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/listener/packetevents/PacketEventsService.java
@@ -82,7 +82,7 @@ public class PacketEventsService implements SettingsDependent {
                 inventoryProtectionRegistered = true;
                 // Send blank packets to online unauthenticated players (reload scenario)
                 for (Player player : bukkitService.getOnlinePlayers()) {
-                    if (!playerCache.isAuthenticated(player.getName())
+                    if (!playerCache.isAuthenticated(player)
                             && dataSource.isAuthAvailable(player.getName())) {
                         packetInterceptionAdapter.sendBlankInventoryPacket(player);
                     }
@@ -158,7 +158,7 @@ public class PacketEventsService implements SettingsDependent {
             packetInterceptionAdapter.unregisterInventoryProtection();
             inventoryProtectionRegistered = false;
             for (Player onlinePlayer : bukkitService.getOnlinePlayers()) {
-                if (!playerCache.isAuthenticated(onlinePlayer.getName())) {
+                if (!playerCache.isAuthenticated(onlinePlayer)) {
                     onlinePlayer.updateInventory();
                 }
             }

--- a/authme-core/src/main/java/fr/xephi/authme/listener/packetevents/TabCompletePacketListener.java
+++ b/authme-core/src/main/java/fr/xephi/authme/listener/packetevents/TabCompletePacketListener.java
@@ -18,7 +18,7 @@ public class TabCompletePacketListener extends PacketListenerAbstract {
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.TAB_COMPLETE) {
             Player player = event.getPlayer();
-            if (player != null && !playerCache.isAuthenticated(player.getName())) {
+            if (player != null && !playerCache.isAuthenticated(player)) {
                 event.setCancelled(true);
             }
         }

--- a/authme-core/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
+++ b/authme-core/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
@@ -215,7 +215,7 @@ public class AsynchronousJoin implements AsynchronousProcess {
                 ProxySessionManager.ProxyLoginRequest proxyLoginRequest = proxySessionManager.consumeLoginRequest(name);
                 if (proxyLoginRequest != null) {
                     if (proxyLoginRequestValidator.validate(player, proxyLoginRequest.verifiedPremiumUuid())) {
-                        if (playerCache.isAuthenticated(name)) {
+                        if (playerCache.isAuthenticated(player)) {
                             return;
                         }
                         service.send(player, MessageKey.SESSION_RECONNECTION);
@@ -262,7 +262,7 @@ public class AsynchronousJoin implements AsynchronousProcess {
         // Guard: a proxy-initiated forceLoginFromProxy() may have already authenticated the player
         // (if the perform.login message arrived and was processed before this async task completes).
         // Scheduling a limbo in that case would freeze the player permanently.
-        if (playerCache.isAuthenticated(name)) {
+        if (playerCache.isAuthenticated(player)) {
             return;
         }
 
@@ -302,7 +302,7 @@ public class AsynchronousJoin implements AsynchronousProcess {
 
         bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(player, () -> {
             // Guard: proxy login may have completed between when this task was scheduled and now
-            if (playerCache.isAuthenticated(player.getName())) {
+            if (playerCache.isAuthenticated(player)) {
                 return;
             }
             limboService.createLimboPlayer(player, isAuthAvailable);
@@ -334,7 +334,7 @@ public class AsynchronousJoin implements AsynchronousProcess {
                 return;
             }
             if (!shouldSkipPostJoinDialog
-                && !playerCache.isAuthenticated(player.getName())
+                && !playerCache.isAuthenticated(player)
                 && service.getProperty(RegistrationSettings.USE_DIALOG_UI)
                 && dialogAdapter.isDialogSupported()) {
                 bukkitService.runTaskLater(player, () -> showPostJoinDialogIfNecessary(player, isAuthAvailable), 1L);
@@ -344,7 +344,7 @@ public class AsynchronousJoin implements AsynchronousProcess {
 
     private void showPostJoinDialogIfNecessary(Player player, boolean isAuthAvailable) {
         if (!player.isOnline()
-            || playerCache.isAuthenticated(player.getName())
+            || playerCache.isAuthenticated(player)
             || !service.getProperty(RegistrationSettings.USE_DIALOG_UI)
             || !dialogAdapter.isDialogSupported()) {
             return;

--- a/authme-core/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
+++ b/authme-core/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
@@ -170,7 +170,7 @@ public class AsynchronousLogin implements AsynchronousProcess {
      */
     private PlayerAuth getPlayerAuth(Player player, boolean quiet) {
         String name = player.getName().toLowerCase(Locale.ROOT);
-        if (playerCache.isAuthenticated(name)) {
+        if (playerCache.isAuthenticated(player)) {
             if (!quiet) {
                 service.send(player, MessageKey.ALREADY_LOGGED_IN_ERROR);
             }
@@ -282,7 +282,7 @@ public class AsynchronousLogin implements AsynchronousProcess {
         }
 
         bukkitService.runTaskLater(player, () -> {
-            if (!player.isOnline() || playerCache.isAuthenticated(player.getName())) {
+            if (!player.isOnline() || playerCache.isAuthenticated(player)) {
                 return;
             }
             dialogAdapter.showTotpDialog(player, dialogWindowService.createTotpDialog(player));
@@ -343,7 +343,7 @@ public class AsynchronousLogin implements AsynchronousProcess {
             logger.fine(player.getName() + " logged in " + ip);
 
             // makes player loggedin
-            playerCache.updatePlayer(auth);
+            playerCache.updatePlayer(player, auth);
             dataSource.setLogged(name);
             sessionService.grantSession(name);
 

--- a/authme-core/src/main/java/fr/xephi/authme/process/login/ProcessSyncPlayerLogin.java
+++ b/authme-core/src/main/java/fr/xephi/authme/process/login/ProcessSyncPlayerLogin.java
@@ -123,7 +123,7 @@ public class ProcessSyncPlayerLogin implements SynchronousProcess {
             restoreInventory(player);
         }
 
-        final PlayerAuth auth = playerCache.getAuth(name);
+        final PlayerAuth auth = playerCache.getAuth(player);
 
         if (isFirstLogin) { // Save quit location before login teleport
             auth.setQuitLocation(player.getLocation());

--- a/authme-core/src/main/java/fr/xephi/authme/process/logout/AsynchronousLogout.java
+++ b/authme-core/src/main/java/fr/xephi/authme/process/logout/AsynchronousLogout.java
@@ -55,12 +55,12 @@ public class AsynchronousLogout implements AsynchronousProcess {
      */
     public void logout(Player player, Location quitLocation) {
         String name = player.getName().toLowerCase(Locale.ROOT);
-        if (!playerCache.isAuthenticated(name)) {
+        if (!playerCache.isAuthenticated(player)) {
             service.send(player, MessageKey.NOT_LOGGED_IN);
             return;
         }
 
-        PlayerAuth auth = playerCache.getAuth(name);
+        PlayerAuth auth = playerCache.getAuth(player);
         database.updateSession(auth);
         // TODO: send an update when a messaging service will be implemented (SESSION)
         if (service.getProperty(RestrictionSettings.SAVE_QUIT_LOCATION)) {
@@ -69,7 +69,7 @@ public class AsynchronousLogout implements AsynchronousProcess {
             // TODO: send an update when a messaging service will be implemented (QUITLOC)
         }
 
-        playerCache.removePlayer(name);
+        playerCache.removePlayer(player);
         codeManager.unverify(name);
         database.setUnlogged(name);
         sessionService.revokeSession(name);

--- a/authme-core/src/main/java/fr/xephi/authme/process/quit/AsynchronousQuit.java
+++ b/authme-core/src/main/java/fr/xephi/authme/process/quit/AsynchronousQuit.java
@@ -75,7 +75,7 @@ public class AsynchronousQuit implements AsynchronousProcess {
         String name = player.getName().toLowerCase(Locale.ROOT);
         teleportationService.clearOriginalJoinLocation(name);
         dialogStateService.clearDialogOpen(player);
-        boolean wasLoggedIn = playerCache.isAuthenticated(name);
+        boolean wasLoggedIn = playerCache.isAuthenticated(player);
 
         if (wasLoggedIn) {
             if (service.getProperty(RestrictionSettings.SAVE_QUIT_LOCATION)) {
@@ -99,7 +99,7 @@ public class AsynchronousQuit implements AsynchronousProcess {
         }
 
         //always unauthenticate the player - use session only for auto logins on the same ip
-        playerCache.removePlayer(name);
+        playerCache.removePlayer(player);
         codeManager.unverify(name);
 
         //always update the database when the player quit the game (if sessions are disabled)

--- a/authme-core/src/main/java/fr/xephi/authme/process/unregister/AsynchronousUnregister.java
+++ b/authme-core/src/main/java/fr/xephi/authme/process/unregister/AsynchronousUnregister.java
@@ -69,7 +69,7 @@ public class AsynchronousUnregister implements AsynchronousProcess {
      */
     public void unregister(Player player, String password) {
         String name = player.getName();
-        PlayerAuth cachedAuth = playerCache.getAuth(name);
+        PlayerAuth cachedAuth = playerCache.getAuth(player);
         if (passwordSecurity.comparePassword(password, cachedAuth.getPassword(), name)) {
             if (dataSource.removeAuth(name)) {
                 performPostUnregisterActions(name, player);
@@ -115,11 +115,15 @@ public class AsynchronousUnregister implements AsynchronousProcess {
      * @param player the according Player object (nullable)
      */
     private void performPostUnregisterActions(String name, Player player) {
-        if (player != null && playerCache.isAuthenticated(name)) {
+        if (player != null && playerCache.isAuthenticated(player)) {
             bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(player,
                 () -> bungeeSender.sendAuthMeBungeecordMessage(player, MessageType.LOGOUT));
         }
-        playerCache.removePlayer(name);
+        if (player == null) {
+            playerCache.removePlayer(name);
+        } else {
+            playerCache.removePlayer(player);
+        }
 
         // TODO: send an update when a messaging service will be implemented (UNREGISTER)
 

--- a/authme-core/src/main/java/fr/xephi/authme/service/PremiumService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/PremiumService.java
@@ -66,7 +66,7 @@ public class PremiumService implements HasCleanup {
             return;
         }
 
-        PlayerAuth auth = playerCache.getAuth(player.getName());
+        PlayerAuth auth = playerCache.getAuth(player);
         if (auth == null) {
             messages.send(player, MessageKey.NOT_LOGGED_IN);
             return;
@@ -115,7 +115,7 @@ public class PremiumService implements HasCleanup {
             return;
         }
 
-        PlayerAuth auth = playerCache.getAuth(player.getName());
+        PlayerAuth auth = playerCache.getAuth(player);
         if (auth == null) {
             messages.send(player, MessageKey.NOT_LOGGED_IN);
             return;

--- a/authme-core/src/main/java/fr/xephi/authme/service/TeleportationService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/TeleportationService.java
@@ -78,7 +78,7 @@ public class TeleportationService implements Reloadable {
             && settings.getProperty(TELEPORT_UNAUTHED_TO_SPAWN)
             && !isUnregisteredWithOptionalAuth(player.getName())) {
             logger.debug("Teleport on join for player `{0}`", player.getName());
-            teleportToSpawn(player, playerCache.isAuthenticated(player.getName()));
+            teleportToSpawn(player, playerCache.isAuthenticated(player));
         }
     }
 
@@ -106,7 +106,7 @@ public class TeleportationService implements Reloadable {
             final Location location = spawnLoader.getSpawnLocation(player);
 
             SpawnTeleportEvent event = new SpawnTeleportEvent(player, location,
-                playerCache.isAuthenticated(player.getName()));
+                playerCache.isAuthenticated(player));
             bukkitService.callEvent(event);
             if (!isEventValid(event)) {
                 return null;

--- a/authme-core/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
@@ -137,7 +137,12 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
             if (verified == null) {
                 return;
             }
-            performLogin(verified.name, verified.verifiedPremiumUuid);
+            if (!verified.name.equalsIgnoreCase(player.getName())) {
+                logger.warning("Rejected perform.login for " + verified.name
+                    + ": message was carried by " + player.getName());
+                return;
+            }
+            performLogin(player, verified.verifiedPremiumUuid);
         }
     }
 
@@ -235,16 +240,16 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
         return playerName + ":" + timestamp + ":" + (verifiedPremiumUuid == null ? "" : verifiedPremiumUuid);
     }
 
-    private void performLogin(String name, UUID verifiedPremiumUuid) {
+    private void performLogin(Player player, UUID verifiedPremiumUuid) {
+        String name = player.getName();
         logger.debug("Received perform.login request for {0}", name);
         // Always queue in the proxy session manager so processJoin can consume it even when
         // the player is already online (PlayerJoinEvent fires before ServerSwitchEvent on the
         // proxy, so processJoin may run before perform.login arrives at this backend).
         proxySessionManager.processProxySessionMessage(name, verifiedPremiumUuid);
-        Player player = bukkitService.getPlayerExact(name);
         logger.info("performLogin: " + name + " verifiedPremiumUuid=" + verifiedPremiumUuid
-            + " playerOnline=" + (player != null && player.isOnline()));
-        if (player != null && player.isOnline()) {
+            + " playerOnline=" + player.isOnline());
+        if (player.isOnline()) {
             if (verifiedPremiumUuid == null) {
                 completeProxyLogin(player);
             } else {

--- a/authme-core/src/main/java/fr/xephi/authme/task/TimeoutTask.java
+++ b/authme-core/src/main/java/fr/xephi/authme/task/TimeoutTask.java
@@ -27,7 +27,7 @@ public class TimeoutTask implements Runnable {
 
     @Override
     public void run() {
-        if (!playerCache.isAuthenticated(player.getName())) {
+        if (!playerCache.isAuthenticated(player)) {
             player.kickPlayer(message);
         }
     }

--- a/authme-core/src/test/java/fr/xephi/authme/api/v3/AuthMeApiTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/api/v3/AuthMeApiTest.java
@@ -85,14 +85,14 @@ class AuthMeApiTest {
     void shouldReturnIfPlayerIsAuthenticated() {
         // given
         String name = "Bobby";
-        Player player = mockPlayerWithName(name);
-        given(playerCache.isAuthenticated(name)).willReturn(true);
+        Player player = mock(Player.class);
+        given(playerCache.isAuthenticated(player)).willReturn(true);
 
         // when
         boolean result = api.isAuthenticated(player);
 
         // then
-        verify(playerCache).isAuthenticated(name);
+        verify(playerCache).isAuthenticated(player);
         assertThat(result, equalTo(true));
     }
 
@@ -129,7 +129,7 @@ class AuthMeApiTest {
     void shouldGetLastLocation() {
         // given
         String name = "Gary";
-        Player player = mockPlayerWithName(name);
+        Player player = mock(Player.class);
         PlayerAuth auth = PlayerAuth.builder().name(name)
             .locWorld("world")
             .locX(12.4)
@@ -138,7 +138,7 @@ class AuthMeApiTest {
             .locYaw(3.41f)
             .locPitch(0.29f)
             .build();
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         Server server = mock(Server.class);
         ReflectionTestUtils.setField(Bukkit.class, null, "server", server);
         World world = mock(World.class);
@@ -272,8 +272,8 @@ class AuthMeApiTest {
     void shouldReturnNullForUnavailablePlayer() {
         // given
         String name = "Numan";
-        Player player = mockPlayerWithName(name);
-        given(playerCache.getAuth(name)).willReturn(null);
+        Player player = mock(Player.class);
+        given(playerCache.getAuth(player)).willReturn(null);
 
         // when
         Location result = api.getLastLocation(player);

--- a/authme-core/src/test/java/fr/xephi/authme/command/executable/captcha/CaptchaCommandTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/command/executable/captcha/CaptchaCommandTest.java
@@ -57,7 +57,7 @@ public class CaptchaCommandTest {
         // given
         String name = "creeper011";
         Player player = mockPlayerWithName(name);
-        given(playerCache.isAuthenticated(name)).willReturn(true);
+        given(playerCache.isAuthenticated(player)).willReturn(true);
 
         // when
         command.executeCommand(player, Collections.singletonList("123"));
@@ -71,7 +71,7 @@ public class CaptchaCommandTest {
         // given
         String name = "bobby";
         Player player = mockPlayerWithName(name);
-        given(playerCache.isAuthenticated(name)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         given(loginCaptchaManager.isCaptchaRequired(name)).willReturn(false);
         given(dataSource.isAuthAvailable(name)).willReturn(true);
 
@@ -89,7 +89,7 @@ public class CaptchaCommandTest {
         // given
         String name = "smith";
         Player player = mockPlayerWithName(name);
-        given(playerCache.isAuthenticated(name)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         given(loginCaptchaManager.isCaptchaRequired(name)).willReturn(true);
         String captchaCode = "3991";
         given(loginCaptchaManager.checkCode(player, captchaCode)).willReturn(true);
@@ -112,7 +112,7 @@ public class CaptchaCommandTest {
         // given
         String name = "smith";
         Player player = mockPlayerWithName(name);
-        given(playerCache.isAuthenticated(name)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         given(loginCaptchaManager.isCaptchaRequired(name)).willReturn(true);
         String captchaCode = "2468";
         given(loginCaptchaManager.checkCode(player, captchaCode)).willReturn(false);
@@ -191,5 +191,4 @@ public class CaptchaCommandTest {
         return player;
     }
 }
-
 

--- a/authme-core/src/test/java/fr/xephi/authme/command/executable/changepassword/ChangePasswordCommandTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/command/executable/changepassword/ChangePasswordCommandTest.java
@@ -131,9 +131,8 @@ public class ChangePasswordCommandTest {
     private Player initPlayerWithName(String name, boolean loggedIn) {
         Player player = mock(Player.class);
         when(player.getName()).thenReturn(name);
-        when(playerCache.isAuthenticated(name)).thenReturn(loggedIn);
+        when(playerCache.isAuthenticated(player)).thenReturn(loggedIn);
         return player;
     }
 }
-
 

--- a/authme-core/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/command/executable/email/ShowEmailCommandTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import java.util.Collections;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -44,7 +45,7 @@ public class ShowEmailCommandTest {
         // given
         Player sender = mock(Player.class);
         given(sender.getName()).willReturn(USERNAME);
-        given(playerCache.getAuth(USERNAME)).willReturn(newAuthWithEmail(CURRENT_EMAIL));
+        given(playerCache.getAuth(any(Player.class))).willReturn(newAuthWithEmail(CURRENT_EMAIL));
         given(commonService.getProperty(SecuritySettings.USE_EMAIL_MASKING)).willReturn(false);
 
         // when
@@ -59,7 +60,7 @@ public class ShowEmailCommandTest {
         // given
         Player sender = mock(Player.class);
         given(sender.getName()).willReturn(USERNAME);
-        given(playerCache.getAuth(USERNAME)).willReturn(newAuthWithEmail(CURRENT_EMAIL));
+        given(playerCache.getAuth(any(Player.class))).willReturn(newAuthWithEmail(CURRENT_EMAIL));
         given(commonService.getProperty(SecuritySettings.USE_EMAIL_MASKING)).willReturn(true);
 
         // when
@@ -74,7 +75,7 @@ public class ShowEmailCommandTest {
         // given
         Player sender = mock(Player.class);
         given(sender.getName()).willReturn(USERNAME);
-        given(playerCache.getAuth(USERNAME)).willReturn(newAuthWithNoEmail());
+        given(playerCache.getAuth(any(Player.class))).willReturn(newAuthWithNoEmail());
 
         // when
         command.executeCommand(sender, Collections.emptyList());
@@ -96,5 +97,3 @@ public class ShowEmailCommandTest {
             .build();
     }
 }
-
-

--- a/authme-core/src/test/java/fr/xephi/authme/command/executable/totp/AddTotpCommandTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/command/executable/totp/AddTotpCommandTest.java
@@ -43,7 +43,7 @@ public class AddTotpCommandTest {
     public void shouldHandleNonLoggedInUser() {
         // given
         Player player = mockPlayerWithName("bob");
-        given(playerCache.getAuth("bob")).willReturn(null);
+        given(playerCache.getAuth(player)).willReturn(null);
 
         // when
         addTotpCommand.runCommand(player, Collections.emptyList());
@@ -59,7 +59,7 @@ public class AddTotpCommandTest {
         Player player = mockPlayerWithName("arend");
         PlayerAuth auth = PlayerAuth.builder().name("arend")
             .totpKey("TOTP2345").build();
-        given(playerCache.getAuth("arend")).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
 
         // when
         addTotpCommand.runCommand(player, Collections.emptyList());
@@ -74,7 +74,7 @@ public class AddTotpCommandTest {
         // given
         Player player = mockPlayerWithName("charles");
         PlayerAuth auth = PlayerAuth.builder().name("charles").build();
-        given(playerCache.getAuth("charles")).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
 
         TotpGenerationResult generationResult = new TotpGenerationResult(
             "777Key214", "http://example.org/qr-code/link");
@@ -94,5 +94,4 @@ public class AddTotpCommandTest {
         return player;
     }
 }
-
 

--- a/authme-core/src/test/java/fr/xephi/authme/command/executable/totp/ConfirmTotpCommandTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/command/executable/totp/ConfirmTotpCommandTest.java
@@ -62,7 +62,7 @@ public class ConfirmTotpCommandTest {
         String playerName = "George";
         given(player.getName()).willReturn(playerName);
         PlayerAuth auth = PlayerAuth.builder().name(playerName).build();
-        given(playerCache.getAuth(playerName)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         String generatedTotpKey = "totp-key";
         given(generateTotpService.getGeneratedTotpKey(player)).willReturn(new TotpGenerationResult(generatedTotpKey, "url-not-relevant"));
         String totpCode = "954321";
@@ -88,7 +88,7 @@ public class ConfirmTotpCommandTest {
         String playerName = "George";
         given(player.getName()).willReturn(playerName);
         PlayerAuth auth = PlayerAuth.builder().name(playerName).build();
-        given(playerCache.getAuth(playerName)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         given(generateTotpService.getGeneratedTotpKey(player)).willReturn(new TotpGenerationResult("totp-key", "url-not-relevant"));
         String totpCode = "754321";
         given(generateTotpService.isTotpCodeCorrectForGeneratedTotpKey(player, totpCode)).willReturn(false);
@@ -99,7 +99,7 @@ public class ConfirmTotpCommandTest {
         // then
         verify(generateTotpService).isTotpCodeCorrectForGeneratedTotpKey(player, totpCode);
         verify(generateTotpService, never()).removeGenerateTotpKey(any(Player.class));
-        verify(playerCache, only()).getAuth(playerName);
+        verify(playerCache, only()).getAuth(player);
         verify(messages).send(player, MessageKey.TWO_FACTOR_ENABLE_ERROR_WRONG_CODE);
         verifyNoInteractions(dataSource);
     }
@@ -111,7 +111,7 @@ public class ConfirmTotpCommandTest {
         String playerName = "George";
         given(player.getName()).willReturn(playerName);
         PlayerAuth auth = PlayerAuth.builder().name(playerName).build();
-        given(playerCache.getAuth(playerName)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         given(generateTotpService.getGeneratedTotpKey(player)).willReturn(null);
 
         // when
@@ -119,7 +119,7 @@ public class ConfirmTotpCommandTest {
 
         // then
         verify(generateTotpService, only()).getGeneratedTotpKey(player);
-        verify(playerCache, only()).getAuth(playerName);
+        verify(playerCache, only()).getAuth(player);
         verify(messages).send(player, MessageKey.TWO_FACTOR_ENABLE_ERROR_NO_CODE);
         verifyNoInteractions(dataSource);
     }
@@ -131,13 +131,13 @@ public class ConfirmTotpCommandTest {
         String playerName = "George";
         given(player.getName()).willReturn(playerName);
         PlayerAuth auth = PlayerAuth.builder().name(playerName).totpKey("A987234").build();
-        given(playerCache.getAuth(playerName)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
 
         // when
         command.runCommand(player, Collections.singletonList("871634"));
 
         // then
-        verify(playerCache, only()).getAuth(playerName);
+        verify(playerCache, only()).getAuth(player);
         verifyNoInteractions(generateTotpService, dataSource);
         verify(messages).send(player, MessageKey.TWO_FACTOR_ALREADY_ENABLED);
     }
@@ -148,16 +148,14 @@ public class ConfirmTotpCommandTest {
         Player player = mock(Player.class);
         String playerName = "George";
         given(player.getName()).willReturn(playerName);
-        given(playerCache.getAuth(playerName)).willReturn(null);
+        given(playerCache.getAuth(player)).willReturn(null);
 
         // when
         command.runCommand(player, Collections.singletonList("984685"));
 
         // then
-        verify(playerCache, only()).getAuth(playerName);
+        verify(playerCache, only()).getAuth(player);
         verifyNoInteractions(generateTotpService, dataSource);
         verify(messages).send(player, MessageKey.NOT_LOGGED_IN);
     }
 }
-
-

--- a/authme-core/src/test/java/fr/xephi/authme/command/executable/totp/RemoveTotpCommandTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/command/executable/totp/RemoveTotpCommandTest.java
@@ -21,6 +21,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -55,7 +56,7 @@ public class RemoveTotpCommandTest {
         // given
         String name = "aws";
         PlayerAuth auth = PlayerAuth.builder().name(name).totpKey("some-totp-key").build();
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(any(Player.class))).willReturn(auth);
         String inputCode = "93847";
         given(totpAuthenticator.checkCode(auth, inputCode)).willReturn(true);
         given(dataSource.removeTotpKey(name)).willReturn(true);
@@ -77,7 +78,7 @@ public class RemoveTotpCommandTest {
         // given
         String name = "aws";
         PlayerAuth auth = PlayerAuth.builder().name(name).totpKey("some-totp-key").build();
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(any(Player.class))).willReturn(auth);
         String inputCode = "93847";
         given(totpAuthenticator.checkCode(auth, inputCode)).willReturn(true);
         given(dataSource.removeTotpKey(name)).willReturn(false);
@@ -90,7 +91,7 @@ public class RemoveTotpCommandTest {
         // then
         verify(dataSource).removeTotpKey(name);
         verify(messages, only()).send(player, MessageKey.ERROR);
-        verify(playerCache, only()).getAuth(name);
+        verify(playerCache, only()).getAuth(player);
     }
 
     @Test
@@ -98,7 +99,7 @@ public class RemoveTotpCommandTest {
         // given
         String name = "cesar";
         PlayerAuth auth = PlayerAuth.builder().name(name).totpKey("some-totp-key").build();
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(any(Player.class))).willReturn(auth);
         String inputCode = "93847";
         given(totpAuthenticator.checkCode(auth, inputCode)).willReturn(false);
         Player player = mock(Player.class);
@@ -110,7 +111,7 @@ public class RemoveTotpCommandTest {
         // then
         verifyNoInteractions(dataSource);
         verify(messages, only()).send(player, MessageKey.TWO_FACTOR_INVALID_CODE);
-        verify(playerCache, only()).getAuth(name);
+        verify(playerCache, only()).getAuth(player);
     }
 
     @Test
@@ -118,7 +119,7 @@ public class RemoveTotpCommandTest {
         // given
         String name = "cesar";
         PlayerAuth auth = PlayerAuth.builder().name(name).build();
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(any(Player.class))).willReturn(auth);
         String inputCode = "654684";
         Player player = mock(Player.class);
         given(player.getName()).willReturn(name);
@@ -129,14 +130,14 @@ public class RemoveTotpCommandTest {
         // then
         verifyNoInteractions(dataSource, totpAuthenticator);
         verify(messages, only()).send(player, MessageKey.TWO_FACTOR_NOT_ENABLED_ERROR);
-        verify(playerCache, only()).getAuth(name);
+        verify(playerCache, only()).getAuth(player);
     }
 
     @Test
     public void shouldHandleNonLoggedInUser() {
         // given
         String name = "cesar";
-        given(playerCache.getAuth(name)).willReturn(null);
+        given(playerCache.getAuth(any(Player.class))).willReturn(null);
         String inputCode = "654684";
         Player player = mock(Player.class);
         given(player.getName()).willReturn(name);
@@ -147,8 +148,6 @@ public class RemoveTotpCommandTest {
         // then
         verifyNoInteractions(dataSource, totpAuthenticator);
         verify(messages, only()).send(player, MessageKey.NOT_LOGGED_IN);
-        verify(playerCache, only()).getAuth(name);
+        verify(playerCache, only()).getAuth(player);
     }
 }
-
-

--- a/authme-core/src/test/java/fr/xephi/authme/command/executable/unregister/UnregisterCommandTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/command/executable/unregister/UnregisterCommandTest.java
@@ -59,13 +59,13 @@ public class UnregisterCommandTest {
         String name = "player77";
         Player player = mock(Player.class);
         given(player.getName()).willReturn(name);
-        given(playerCache.isAuthenticated(name)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
 
         // when
         command.executeCommand(player, Collections.singletonList(password));
 
         // then
-        verify(playerCache).isAuthenticated(name);
+        verify(playerCache).isAuthenticated(player);
         verify(commonService).send(player, MessageKey.NOT_LOGGED_IN);
         verifyNoInteractions(management);
     }
@@ -76,14 +76,14 @@ public class UnregisterCommandTest {
         String name = "asldjf";
         Player player = mock(Player.class);
         given(player.getName()).willReturn(name);
-        given(playerCache.isAuthenticated(name)).willReturn(true);
+        given(playerCache.isAuthenticated(player)).willReturn(true);
         given(codeManager.isVerificationRequired(player)).willReturn(true);
 
         // when
         command.executeCommand(player, Collections.singletonList("blergh"));
 
         // then
-        verify(playerCache).isAuthenticated(name);
+        verify(playerCache).isAuthenticated(player);
         verify(codeManager).codeExistOrGenerateNew(name);
         verify(commonService).send(player, MessageKey.VERIFICATION_CODE_REQUIRED);
         verifyNoInteractions(management);
@@ -96,14 +96,14 @@ public class UnregisterCommandTest {
         String name = "jas0n_";
         Player player = mock(Player.class);
         given(player.getName()).willReturn(name);
-        given(playerCache.isAuthenticated(name)).willReturn(true);
+        given(playerCache.isAuthenticated(player)).willReturn(true);
         given(codeManager.isVerificationRequired(player)).willReturn(false);
 
         // when
         command.executeCommand(player, Collections.singletonList(password));
 
         // then
-        verify(playerCache).isAuthenticated(name);
+        verify(playerCache).isAuthenticated(player);
         verify(management).performUnregister(player, password);
         verify(codeManager).isVerificationRequired(player);
     }
@@ -127,5 +127,3 @@ public class UnregisterCommandTest {
         assertThat(command.getArgumentsMismatchMessage(), equalTo(MessageKey.USAGE_UNREGISTER));
     }
 }
-
-

--- a/authme-core/src/test/java/fr/xephi/authme/data/auth/PlayerCacheTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/data/auth/PlayerCacheTest.java
@@ -1,0 +1,33 @@
+package fr.xephi.authme.data.auth;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class PlayerCacheTest {
+
+    @Test
+    void shouldKeepAuthenticationWithTheCurrentPlayerConnection() {
+        Player first = mock(Player.class);
+        Player second = mock(Player.class);
+        given(first.getName()).willReturn("Example");
+        given(second.getName()).willReturn("example");
+        PlayerAuth firstAuth = PlayerAuth.builder().name("Example").build();
+        PlayerAuth secondAuth = PlayerAuth.builder().name("Example").build();
+        PlayerCache cache = new PlayerCache();
+
+        cache.updatePlayer(first, firstAuth);
+        cache.updatePlayer(second, secondAuth);
+        cache.removePlayer(first);
+
+        assertFalse(cache.isAuthenticated(first));
+        assertTrue(cache.isAuthenticated(second));
+        assertSame(secondAuth, cache.getAuth(second));
+        assertSame(secondAuth, cache.getAuth("Example"));
+    }
+}

--- a/authme-core/src/test/java/fr/xephi/authme/listener/ListenerServiceTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/listener/ListenerServiceTest.java
@@ -80,7 +80,7 @@ class ListenerServiceTest {
         // given
         String playerName = "Bobby";
         Player player = mockPlayerWithName(playerName);
-        given(playerCache.isAuthenticated(playerName)).willReturn(true);
+        given(playerCache.isAuthenticated(player)).willReturn(true);
         EntityEvent event = mock(EntityEvent.class);
         given(event.getEntity()).willReturn(player);
 
@@ -89,7 +89,7 @@ class ListenerServiceTest {
 
         // then
         assertThat(result, equalTo(false));
-        verify(playerCache).isAuthenticated(playerName);
+        verify(playerCache).isAuthenticated(player);
         verifyNoInteractions(dataSource);
     }
 
@@ -98,7 +98,7 @@ class ListenerServiceTest {
         // given
         String playerName = "Tester";
         Player player = mockPlayerWithName(playerName);
-        given(playerCache.isAuthenticated(playerName)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         EntityEvent event = mock(EntityEvent.class);
         given(event.getEntity()).willReturn(player);
 
@@ -107,7 +107,7 @@ class ListenerServiceTest {
 
         // then
         assertThat(result, equalTo(true));
-        verify(playerCache).isAuthenticated(playerName);
+        verify(playerCache).isAuthenticated(player);
         // makes sure the setting is checked first = avoid unnecessary DB operation
         verifyNoInteractions(dataSource);
     }
@@ -117,7 +117,7 @@ class ListenerServiceTest {
         // given
         String playerName = "myPlayer1";
         Player player = mockPlayerWithName(playerName);
-        given(playerCache.isAuthenticated(playerName)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         given(settings.getProperty(RegistrationSettings.FORCE)).willReturn(false);
         EntityEvent event = mock(EntityEvent.class);
         given(event.getEntity()).willReturn(player);
@@ -128,7 +128,7 @@ class ListenerServiceTest {
 
         // then
         assertThat(result, equalTo(false));
-        verify(playerCache).isAuthenticated(playerName);
+        verify(playerCache).isAuthenticated(player);
         verify(dataSource).isAuthAvailable(playerName);
     }
 
@@ -173,14 +173,14 @@ class ListenerServiceTest {
         String playerName = "example";
         Player player = mockPlayerWithName(playerName);
         PlayerEvent event = new TestPlayerEvent(player);
-        given(playerCache.isAuthenticated(playerName)).willReturn(true);
+        given(playerCache.isAuthenticated(player)).willReturn(true);
 
         // when
         boolean result = listenerService.shouldCancelEvent(event);
 
         // then
         assertThat(result, equalTo(false));
-        verify(playerCache).isAuthenticated(playerName);
+        verify(playerCache).isAuthenticated(player);
         verifyNoInteractions(dataSource);
     }
 
@@ -208,7 +208,7 @@ class ListenerServiceTest {
 
         // then
         assertThat(result, equalTo(true));
-        verify(playerCache).isAuthenticated(playerName);
+        verify(playerCache).isAuthenticated(player);
         verifyNoInteractions(dataSource);
     }
 

--- a/authme-core/src/test/java/fr/xephi/authme/process/join/AsynchronousJoinTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/process/join/AsynchronousJoinTest.java
@@ -125,7 +125,7 @@ public class AsynchronousJoinTest {
         // given
         Player player = mockPlayer("Bobby");
         setUpRegisteredJoin(player);
-        given(playerCache.isAuthenticated("Bobby")).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         given(service.getProperty(RegistrationSettings.USE_DIALOG_UI)).willReturn(true);
         given(dialogAdapter.isDialogSupported()).willReturn(true);
         given(dialogWindowService.createLoginDialog(player)).willReturn(createDialogSpec("Login", "Login"));
@@ -144,7 +144,7 @@ public class AsynchronousJoinTest {
         // given — player is already authenticated when the sync limbo task fires
         Player player = mockPlayer("Bobby");
         setUpRegisteredJoin(player);
-        given(playerCache.isAuthenticated("Bobby")).willReturn(true);
+        given(playerCache.isAuthenticated(player)).willReturn(true);
 
         // when
         asynchronousJoin.processJoin(player);
@@ -165,7 +165,7 @@ public class AsynchronousJoinTest {
         Player player = mockPlayer("Bobby");
         setUpRegisteredJoin(player);
         given(player.isOnline()).willReturn(true);
-        given(playerCache.isAuthenticated("Bobby")).willReturn(false, false, true);
+        given(playerCache.isAuthenticated(player)).willReturn(false, false, false, true);
         given(service.getProperty(RegistrationSettings.USE_DIALOG_UI)).willReturn(true);
         given(dialogAdapter.isDialogSupported()).willReturn(true);
         given(dialogWindowService.createLoginDialog(player)).willReturn(createDialogSpec("Login", "Login"));
@@ -256,7 +256,7 @@ public class AsynchronousJoinTest {
         given(player.getUniqueId()).willReturn(playerId);
         given(preJoinDialogService.consumePendingLoginPassword(playerId)).willReturn("hunter2");
         given(preJoinDialogService.consumeSkipPostJoinDialog(playerId)).willReturn(false);
-        given(playerCache.isAuthenticated("Bobby")).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
 
         // when
         asynchronousJoin.processJoin(player);
@@ -372,7 +372,7 @@ public class AsynchronousJoinTest {
         java.util.UUID playerId = java.util.UUID.randomUUID();
         given(player.getUniqueId()).willReturn(playerId);
         given(preJoinDialogService.consumeSkipPostJoinDialog(playerId)).willReturn(true);
-        given(playerCache.isAuthenticated("Bobby")).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         given(service.getProperty(RegistrationSettings.USE_DIALOG_UI)).willReturn(true);
         given(dialogAdapter.isDialogSupported()).willReturn(true);
 

--- a/authme-core/src/test/java/fr/xephi/authme/process/login/AsynchronousLoginTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/process/login/AsynchronousLoginTest.java
@@ -103,13 +103,13 @@ class AsynchronousLoginTest {
         // given
         String name = "bobby";
         Player player = mockPlayer(name);
-        given(playerCache.isAuthenticated(name)).willReturn(true);
+        given(playerCache.isAuthenticated(player)).willReturn(true);
 
         // when
         asynchronousLogin.forceLogin(player);
 
         // then
-        verify(playerCache, only()).isAuthenticated(name);
+        verify(playerCache, only()).isAuthenticated(player);
         verify(commonService).send(player, MessageKey.ALREADY_LOGGED_IN_ERROR);
         verifyNoInteractions(dataSource);
     }
@@ -119,14 +119,14 @@ class AsynchronousLoginTest {
         // given
         String name = "oscar";
         Player player = mockPlayer(name);
-        given(playerCache.isAuthenticated(name)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         given(dataSource.getAuth(name)).willReturn(null);
 
         // when
         asynchronousLogin.forceLogin(player);
 
         // then
-        verify(playerCache, only()).isAuthenticated(name);
+        verify(playerCache, only()).isAuthenticated(player);
         verify(commonService).send(player, MessageKey.UNKNOWN_USER);
         verify(dataSource, only()).getAuth(name);
     }
@@ -136,7 +136,7 @@ class AsynchronousLoginTest {
         // given
         String name = "oscar";
         Player player = mockPlayer(name);
-        given(playerCache.isAuthenticated(name)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         int groupId = 13;
         PlayerAuth auth = PlayerAuth.builder().name(name).groupId(groupId).build();
         given(dataSource.getAuth(name)).willReturn(auth);
@@ -147,7 +147,7 @@ class AsynchronousLoginTest {
         asynchronousLogin.forceLogin(player);
 
         // then
-        verify(playerCache, only()).isAuthenticated(name);
+        verify(playerCache, only()).isAuthenticated(player);
         verify(commonService).send(player, MessageKey.ACCOUNT_NOT_ACTIVATED);
         verify(dataSource, only()).getAuth(name);
     }
@@ -159,7 +159,7 @@ class AsynchronousLoginTest {
         String ip = "1.1.1.245";
         Player player = mockPlayer(name);
         TestHelper.mockIpAddressToPlayer(player, ip);
-        given(playerCache.isAuthenticated(name)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         PlayerAuth auth = PlayerAuth.builder().name(name).build();
         given(dataSource.getAuth(name)).willReturn(auth);
         given(commonService.getProperty(DatabaseSettings.MYSQL_COL_GROUP)).willReturn("");
@@ -169,7 +169,7 @@ class AsynchronousLoginTest {
         asynchronousLogin.forceLogin(player);
 
         // then
-        verify(playerCache, only()).isAuthenticated(name);
+        verify(playerCache, only()).isAuthenticated(player);
         verify(commonService).send(player, MessageKey.ALREADY_LOGGED_IN_ERROR);
         verify(dataSource, only()).getAuth(name);
         verify(asynchronousLogin).hasReachedMaxLoggedInPlayersForIp(player, ip);
@@ -182,7 +182,7 @@ class AsynchronousLoginTest {
         String ip = "1.1.1.245";
         Player player = mockPlayer(name);
         TestHelper.mockIpAddressToPlayer(player, ip);
-        given(playerCache.isAuthenticated(name)).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         PlayerAuth auth = PlayerAuth.builder().name(name).build();
         given(dataSource.getAuth(name)).willReturn(auth);
         given(commonService.getProperty(DatabaseSettings.MYSQL_COL_GROUP)).willReturn("");
@@ -197,7 +197,7 @@ class AsynchronousLoginTest {
         asynchronousLogin.forceLogin(player);
 
         // then
-        verify(playerCache, only()).isAuthenticated(name);
+        verify(playerCache, only()).isAuthenticated(player);
         verify(dataSource, only()).getAuth(name);
         verify(asynchronousLogin).hasReachedMaxLoggedInPlayersForIp(player, ip);
     }
@@ -273,7 +273,7 @@ class AsynchronousLoginTest {
         TestHelper.mockIpAddressToPlayer(player, "203.0.113.5");
         PlayerAuth auth = PlayerAuth.builder().name("bobby").totpKey("secret").build();
         LimboPlayer limboPlayer = mock(LimboPlayer.class);
-        given(playerCache.isAuthenticated("bobby")).willReturn(false, false);
+        given(playerCache.isAuthenticated(player)).willReturn(false, false);
         given(dataSource.getAuth("bobby")).willReturn(auth);
         given(commonService.getProperty(DatabaseSettings.MYSQL_COL_GROUP)).willReturn("");
         given(commonService.getProperty(RestrictionSettings.MAX_LOGIN_PER_IP)).willReturn(0);
@@ -307,7 +307,7 @@ class AsynchronousLoginTest {
         TestHelper.mockIpAddressToPlayer(player, "203.0.113.5");
         PlayerAuth auth = PlayerAuth.builder().name("bobby").totpKey("secret").build();
         LimboPlayer limboPlayer = mock(LimboPlayer.class);
-        given(playerCache.isAuthenticated("bobby")).willReturn(false);
+        given(playerCache.isAuthenticated(player)).willReturn(false);
         given(dataSource.getAuth("bobby")).willReturn(auth);
         given(commonService.getProperty(DatabaseSettings.MYSQL_COL_GROUP)).willReturn("");
         given(commonService.getProperty(RestrictionSettings.MAX_LOGIN_PER_IP)).willReturn(0);

--- a/authme-core/src/test/java/fr/xephi/authme/process/unregister/AsynchronousUnregisterTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/process/unregister/AsynchronousUnregisterTest.java
@@ -80,7 +80,7 @@ class AsynchronousUnregisterTest {
         String name = "Bobby";
         given(player.getName()).willReturn(name);
         PlayerAuth auth = mock(PlayerAuth.class);
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         HashedPassword password = new HashedPassword("password", "in_auth_obj");
         given(auth.getPassword()).willReturn(password);
         String userPassword = "pass";
@@ -104,7 +104,7 @@ class AsynchronousUnregisterTest {
         given(player.getName()).willReturn(name);
         given(player.isOnline()).willReturn(true);
         PlayerAuth auth = mock(PlayerAuth.class);
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         HashedPassword password = new HashedPassword("password", "in_auth_obj");
         given(auth.getPassword()).willReturn(password);
         String userPassword = "pass";
@@ -123,7 +123,7 @@ class AsynchronousUnregisterTest {
         verify(service).send(player, MessageKey.UNREGISTERED_SUCCESS);
         verify(passwordSecurity).comparePassword(userPassword, password, name);
         verify(dataSource).removeAuth(name);
-        verify(playerCache).removePlayer(name);
+        verify(playerCache).removePlayer(player);
         verify(teleportationService).teleportOnJoin(player);
         verifyCalledUnregisterEventFor(player);
         verify(commandManager).runCommandsOnUnregister(player);
@@ -137,7 +137,7 @@ class AsynchronousUnregisterTest {
         given(player.getName()).willReturn(name);
         given(player.isOnline()).willReturn(true);
         PlayerAuth auth = mock(PlayerAuth.class);
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         HashedPassword password = new HashedPassword("password", "in_auth_obj");
         given(auth.getPassword()).willReturn(password);
         String userPassword = "pass";
@@ -154,7 +154,7 @@ class AsynchronousUnregisterTest {
         verify(service).send(player, MessageKey.UNREGISTERED_SUCCESS);
         verify(passwordSecurity).comparePassword(userPassword, password, name);
         verify(dataSource).removeAuth(name);
-        verify(playerCache).removePlayer(name);
+        verify(playerCache).removePlayer(player);
         verify(teleportationService).teleportOnJoin(player);
         verifyCalledUnregisterEventFor(player);
         verify(commandManager).runCommandsOnUnregister(player);
@@ -171,7 +171,7 @@ class AsynchronousUnregisterTest {
         String userPassword = "141$$5ad";
         HashedPassword password = new HashedPassword("ttt123");
         PlayerAuth auth = PlayerAuth.builder().name(name).password(password).build();
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         given(passwordSecurity.comparePassword(userPassword, password, name)).willReturn(true);
         given(dataSource.removeAuth(name)).willReturn(true);
         given(service.getProperty(RegistrationSettings.FORCE)).willReturn(false);
@@ -184,7 +184,7 @@ class AsynchronousUnregisterTest {
         verify(service).send(player, MessageKey.UNREGISTERED_SUCCESS);
         verify(passwordSecurity).comparePassword(userPassword, password, name);
         verify(dataSource).removeAuth(name);
-        verify(playerCache).removePlayer(name);
+        verify(playerCache).removePlayer(player);
         verifyNoInteractions(teleportationService, limboService);
         verifyCalledUnregisterEventFor(player);
         verify(commandManager).runCommandsOnUnregister(player);
@@ -197,7 +197,7 @@ class AsynchronousUnregisterTest {
         String name = "Frank21";
         given(player.getName()).willReturn(name);
         PlayerAuth auth = mock(PlayerAuth.class);
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         HashedPassword password = new HashedPassword("password", "in_auth_obj");
         given(auth.getPassword()).willReturn(password);
         String userPassword = "pass";
@@ -222,7 +222,7 @@ class AsynchronousUnregisterTest {
         given(player.getName()).willReturn(name);
         given(player.isOnline()).willReturn(false);
         PlayerAuth auth = mock(PlayerAuth.class);
-        given(playerCache.getAuth(name)).willReturn(auth);
+        given(playerCache.getAuth(player)).willReturn(auth);
         HashedPassword password = new HashedPassword("password", "in_auth_obj");
         given(auth.getPassword()).willReturn(password);
         String userPassword = "pass";
@@ -235,7 +235,7 @@ class AsynchronousUnregisterTest {
         // then
         verify(passwordSecurity).comparePassword(userPassword, password, name);
         verify(dataSource).removeAuth(name);
-        verify(playerCache).removePlayer(name);
+        verify(playerCache).removePlayer(player);
         verifyNoInteractions(teleportationService);
         verifyCalledUnregisterEventFor(player);
     }
@@ -260,7 +260,7 @@ class AsynchronousUnregisterTest {
         verify(service).send(player, MessageKey.UNREGISTERED_SUCCESS);
         verify(service).send(initiator, MessageKey.UNREGISTERED_SUCCESS);
         verify(dataSource).removeAuth(name);
-        verify(playerCache).removePlayer(name);
+        verify(playerCache).removePlayer(player);
         verify(teleportationService).teleportOnJoin(player);
         verifyCalledUnregisterEventFor(player);
         verify(commandManager).runCommandsOnUnregister(player);

--- a/authme-core/src/test/java/fr/xephi/authme/service/bungeecord/BungeeReceiverTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/service/bungeecord/BungeeReceiverTest.java
@@ -121,8 +121,8 @@ class BungeeReceiverTest {
         given(messenger.isIncomingChannelRegistered(plugin, "authme:main")).willReturn(false);
 
         Player player = mock(Player.class);
+        given(player.getName()).willReturn(playerName);
         given(player.isOnline()).willReturn(true);
-        given(bukkitService.getPlayerExact(playerName)).willReturn(player);
         given(proxyLoginRequestValidator.validate(player, null)).willReturn(true);
 
         BungeeReceiver receiver =
@@ -141,7 +141,7 @@ class BungeeReceiverTest {
     }
 
     @Test
-    void shouldOnlyQueueSessionWhenPerformLoginReceivedForOfflinePlayer() {
+    void shouldRejectPerformLoginCarriedByAnotherPlayer() {
         // given
         String sharedSecret = "test-secret";
         String playerName = "Bobby";
@@ -151,20 +151,19 @@ class BungeeReceiverTest {
         given(settings.getProperty(HooksSettings.BUNGEECORD)).willReturn(true);
         given(settings.getProperty(HooksSettings.PROXY_SHARED_SECRET)).willReturn(sharedSecret);
         given(messenger.isIncomingChannelRegistered(plugin, "authme:main")).willReturn(false);
-        given(bukkitService.getPlayerExact(playerName)).willReturn(null);
-
         BungeeReceiver receiver =
             new BungeeReceiver(plugin, bukkitService, proxySessionManager, management, bungeeSender, dataSource,
                 proxyLoginRequestValidator, settings);
 
         Player carrier = mock(Player.class);
+        given(carrier.getName()).willReturn("Alice");
         byte[] payload = buildPerformLoginPayload(playerName, timestamp, hmac);
 
         // when
         receiver.onPluginMessageReceived("authme:main", carrier, payload);
 
         // then
-        verify(proxySessionManager).processProxySessionMessage(playerName, null);
+        verify(proxySessionManager, never()).processProxySessionMessage(any(), any());
         verify(management, never()).forceLoginFromProxy(any(Player.class));
         verify(bungeeSender, never()).sendAuthMeBungeecordMessage(any(), any());
     }
@@ -185,8 +184,8 @@ class BungeeReceiverTest {
         setBukkitServiceToScheduleSyncEntityTaskFromOptionallyAsyncTask(bukkitService);
 
         Player player = mock(Player.class);
+        given(player.getName()).willReturn(playerName);
         given(player.isOnline()).willReturn(true);
-        given(bukkitService.getPlayerExact(playerName)).willReturn(player);
         given(proxyLoginRequestValidator.validate(player, verifiedUuid)).willReturn(true);
 
         BungeeReceiver receiver =
@@ -219,8 +218,8 @@ class BungeeReceiverTest {
         setBukkitServiceToRunTaskAsynchronously(bukkitService);
 
         Player player = mock(Player.class);
+        given(player.getName()).willReturn(playerName);
         given(player.isOnline()).willReturn(true);
-        given(bukkitService.getPlayerExact(playerName)).willReturn(player);
         given(proxyLoginRequestValidator.validate(player, verifiedUuid)).willReturn(false);
 
         BungeeReceiver receiver =

--- a/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityAuthenticationStore.java
+++ b/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityAuthenticationStore.java
@@ -2,35 +2,26 @@ package fr.xephi.authme.velocity;
 
 import com.velocitypowered.api.proxy.Player;
 
-import java.util.Locale;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 final class VelocityAuthenticationStore {
 
-    private final Set<String> authenticatedPlayers = ConcurrentHashMap.newKeySet();
+    private final Map<Player, String> authenticatedPlayers = new IdentityHashMap<>();
 
-    void markAuthenticated(String playerName) {
-        authenticatedPlayers.add(normalizeName(playerName));
+    synchronized void markAuthenticated(Player player) {
+        authenticatedPlayers.put(player, player.getUsername());
     }
 
-    void markLoggedOut(String playerName) {
-        authenticatedPlayers.remove(normalizeName(playerName));
+    synchronized void markLoggedOut(Player player) {
+        authenticatedPlayers.remove(player);
     }
 
-    boolean isAuthenticated(Player player) {
-        return isAuthenticated(player.getUsername());
-    }
-
-    boolean isAuthenticated(String playerName) {
-        return authenticatedPlayers.contains(normalizeName(playerName));
+    synchronized boolean isAuthenticated(Player player) {
+        return authenticatedPlayers.containsKey(player);
     }
 
     void clear(Player player) {
-        markLoggedOut(player.getUsername());
-    }
-
-    private static String normalizeName(String playerName) {
-        return playerName.toLowerCase(Locale.ROOT);
+        markLoggedOut(player);
     }
 }

--- a/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityProxyBridge.java
+++ b/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityProxyBridge.java
@@ -34,7 +34,9 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -69,7 +71,8 @@ final class VelocityProxyBridge {
     private final Logger logger;
     private VelocityProxyConfiguration configuration;
     private final VelocityAuthenticationStore authenticationStore;
-    private final Map<String, AtomicInteger> pendingAutoLogins = new ConcurrentHashMap<>();
+    private final Map<Player, AtomicInteger> pendingAutoLogins =
+        Collections.synchronizedMap(new IdentityHashMap<>());
     private final Set<String> notifiedAuthServers = ConcurrentHashMap.newKeySet();
     private volatile Set<String> premiumUsernames = ConcurrentHashMap.newKeySet();
     private List<String> premiumListBuffer = new ArrayList<>();
@@ -230,7 +233,8 @@ final class VelocityProxyBridge {
         if (!(identifier.equals(AUTHME_CHANNEL) || identifier.equals(AUTHME_LEGACY_CHANNEL))) {
             return;
         }
-        if (!(event.getSource() instanceof ServerConnection serverConnection)) {
+        if (!(event.getSource() instanceof ServerConnection serverConnection)
+            || !(event.getTarget() instanceof Player player)) {
             event.setResult(PluginMessageEvent.ForwardResult.handled());
             logger.debug("Blocked authme:main message from non-server source (client-side spoofing attempt?)");
             return;
@@ -242,32 +246,38 @@ final class VelocityProxyBridge {
         if (parsedMessage.typeId() == null || parsedMessage.playerName() == null) {
             return;
         }
+        if (isPlayerSessionMessage(parsedMessage.typeId())
+            && !parsedMessage.playerName().equalsIgnoreCase(player.getUsername())) {
+            logger.warn("Ignoring AuthMe message for '{}' carried by player '{}'",
+                parsedMessage.playerName(), player.getUsername());
+            return;
+        }
 
         String serverName = serverConnection.getServer().getServerInfo().getName();
 
         if (LOGIN_MESSAGE.equals(parsedMessage.typeId())) {
             if (configuration.isAuthServer(serverConnection.getServer())) {
                 logger.info("Player {} authenticated on auth server '{}'", parsedMessage.playerName(), serverName);
-                authenticationStore.markAuthenticated(parsedMessage.playerName());
-                sendAutoLoginIfAlreadySwitched(parsedMessage.playerName(), serverConnection.getServer());
-                redirectToLoginServer(parsedMessage.playerName());
-            } else if (pendingAutoLogins.containsKey(parsedMessage.playerName())) {
+                authenticationStore.markAuthenticated(player);
+                sendAutoLoginIfAlreadySwitched(player, serverConnection.getServer());
+                redirectToLoginServer(player);
+            } else if (pendingAutoLogins.containsKey(player)) {
                 // Implicit ACK: login from non-auth server confirms perform.login was processed
                 logger.info("Auto-login confirmed for {} via login from server '{}'",
                     parsedMessage.playerName(), serverName);
-                cancelPendingLogin(parsedMessage.playerName());
+                cancelPendingLogin(player);
             } else {
                 logger.debug("Ignoring login from non-auth server '{}' for {} (no pending auto-login)",
                     serverName, parsedMessage.playerName());
             }
         } else if (LOGOUT_MESSAGE.equals(parsedMessage.typeId())) {
             logger.info("Player {} logged out (notified by server '{}')", parsedMessage.playerName(), serverName);
-            authenticationStore.markLoggedOut(parsedMessage.playerName());
-            redirectLoggedOutPlayer(parsedMessage.playerName());
+            authenticationStore.markLoggedOut(player);
+            redirectLoggedOutPlayer(player);
         } else if (PERFORM_LOGIN_ACK_MESSAGE.equals(parsedMessage.typeId())) {
             logger.info("Auto-login ACK received for {} from server '{}'",
                 parsedMessage.playerName(), serverName);
-            cancelPendingLogin(parsedMessage.playerName());
+            cancelPendingLogin(player);
         } else if (PREMIUM_SET_MESSAGE.equals(parsedMessage.typeId())) {
             premiumUsernames.add(parsedMessage.playerName());
             pendingPremiumUsernames.remove(parsedMessage.playerName());
@@ -345,7 +355,7 @@ final class VelocityProxyBridge {
         String normalizedName = normalizeName(event.player().getUsername());
         UUID verifiedPremiumUuid = premiumVerificationManager.getVerifiedPremiumUuid(normalizedName);
         boolean isPremiumJoin = verifiedPremiumUuid != null;
-        if (!authenticationStore.isAuthenticated(normalizedName) && !isPremiumJoin) {
+        if (!authenticationStore.isAuthenticated(event.player()) && !isPremiumJoin) {
             return;
         }
 
@@ -354,7 +364,7 @@ final class VelocityProxyBridge {
         if (sent) {
             logger.info("Sent config-phase auto-login to auth server '{}' for player {} (verifiedPremiumUuid={})",
                 target.getServerInfo().getName(), normalizedName, verifiedPremiumUuid);
-            initiatePendingLogin(normalizedName);
+            initiatePendingLogin(event.player());
         } else {
             logger.debug("Config-phase auto-login send to '{}' for {} returned false; onServerConnected will retry",
                 target.getServerInfo().getName(), normalizedName);
@@ -383,7 +393,7 @@ final class VelocityProxyBridge {
             normalizedName, verifiedPremiumUuid, connectingToAuthServer);
 
         boolean isPremiumJoin = connectingToAuthServer && verifiedPremiumUuid != null;
-        if (!authenticationStore.isAuthenticated(normalizedName) && !isPremiumJoin) {
+        if (!authenticationStore.isAuthenticated(event.getPlayer()) && !isPremiumJoin) {
             logger.debug("Skipping auto-login for {} — not authenticated or proxy-verified premium", normalizedName);
             return;
         }
@@ -396,7 +406,7 @@ final class VelocityProxyBridge {
         if (currentServer.isEmpty()) {
             // Velocity hasn't registered the new connection yet; let the retry mechanism handle it
             logger.debug("Player {} has no active server connection in ServerConnectedEvent; scheduling auto-login retry", normalizedName);
-            initiatePendingLogin(normalizedName);
+            initiatePendingLogin(event.getPlayer());
             return;
         }
 
@@ -406,10 +416,10 @@ final class VelocityProxyBridge {
         if (sent) {
             logger.info("Sending auto-login request to server '{}' for player {} (verifiedPremiumUuid={})",
                 serverName, normalizedName, verifiedPremiumUuid);
-            initiatePendingLogin(normalizedName);
+            initiatePendingLogin(event.getPlayer());
         } else {
             logger.warn("Failed to send auto-login request to server '{}' for player {}; scheduling retry", serverName, normalizedName);
-            initiatePendingLogin(normalizedName);
+            initiatePendingLogin(event.getPlayer());
         }
     }
 
@@ -487,11 +497,11 @@ final class VelocityProxyBridge {
 
     void onDisconnect(DisconnectEvent event) {
         String normalizedName = normalizeName(event.getPlayer().getUsername());
-        if (pendingAutoLogins.containsKey(normalizedName)) {
+        if (pendingAutoLogins.containsKey(event.getPlayer())) {
             logger.debug("Cancelling pending auto-login for {} (player disconnected)", normalizedName);
         }
-        cancelPendingLogin(normalizedName);
-        if (authenticationStore.isAuthenticated(normalizedName)) {
+        cancelPendingLogin(event.getPlayer());
+        if (authenticationStore.isAuthenticated(event.getPlayer())) {
             logger.debug("Clearing auth state for {} (player disconnected)", normalizedName);
         }
         authenticationStore.clear(event.getPlayer());
@@ -504,15 +514,12 @@ final class VelocityProxyBridge {
         retryScheduler.shutdownNow();
     }
 
-    private void sendAutoLoginIfAlreadySwitched(String normalizedName, RegisteredServer authServer) {
+    private void sendAutoLoginIfAlreadySwitched(Player player, RegisteredServer authServer) {
         if (!configuration.autoLoginEnabled()) {
             return;
         }
-        Optional<Player> playerOpt = proxyServer.getPlayer(normalizedName);
-        if (playerOpt.isEmpty()) {
-            return;
-        }
-        Optional<ServerConnection> currentConn = playerOpt.get().getCurrentServer();
+        String normalizedName = normalizeName(player.getUsername());
+        Optional<ServerConnection> currentConn = player.getCurrentServer();
         if (currentConn.isEmpty()) {
             return;
         }
@@ -529,7 +536,7 @@ final class VelocityProxyBridge {
         boolean sent = currentConn.get().sendPluginMessage(
             AUTHME_CHANNEL, createPerformLoginMessage(normalizedName, verifiedPremiumUuid));
         if (sent) {
-            initiatePendingLogin(normalizedName);
+            initiatePendingLogin(player);
         } else {
             logger.warn("Failed to send auto-login to '{}' for {} (race condition path)", currentServerName, normalizedName);
         }
@@ -571,36 +578,36 @@ final class VelocityProxyBridge {
         }
     }
 
-    private void initiatePendingLogin(String normalizedName) {
-        pendingAutoLogins.put(normalizedName, new AtomicInteger(0));
-        scheduleRetry(normalizedName);
+    private void initiatePendingLogin(Player player) {
+        pendingAutoLogins.put(player, new AtomicInteger(0));
+        scheduleRetry(player);
     }
 
-    private void cancelPendingLogin(String normalizedName) {
-        pendingAutoLogins.remove(normalizedName);
+    private void cancelPendingLogin(Player player) {
+        pendingAutoLogins.remove(player);
     }
 
-    private void scheduleRetry(String normalizedName) {
+    private void scheduleRetry(Player player) {
         retryScheduler.schedule(() -> {
-            AtomicInteger attempts = pendingAutoLogins.get(normalizedName);
+            AtomicInteger attempts = pendingAutoLogins.get(player);
             if (attempts == null) {
                 return;
             }
-            Optional<Player> playerOpt = proxyServer.getPlayer(normalizedName);
-            if (playerOpt.isEmpty()) {
-                pendingAutoLogins.remove(normalizedName);
+            String normalizedName = normalizeName(player.getUsername());
+            if (!player.isActive()) {
+                pendingAutoLogins.remove(player);
                 logger.debug("Auto-login retry cancelled for {} (player no longer online)", normalizedName);
                 return;
             }
-            Optional<ServerConnection> serverOpt = playerOpt.get().getCurrentServer();
+            Optional<ServerConnection> serverOpt = player.getCurrentServer();
             if (serverOpt.isEmpty()) {
                 logger.debug("Auto-login retry for {} deferred: no active server connection yet", normalizedName);
-                scheduleRetry(normalizedName);
+                scheduleRetry(player);
                 return;
             }
             int current = attempts.getAndIncrement();
             if (current >= MAX_RETRIES) {
-                pendingAutoLogins.remove(normalizedName);
+                pendingAutoLogins.remove(player);
                 logger.warn("No auto-login ACK received for {} after {} retries; giving up", normalizedName, MAX_RETRIES);
                 return;
             }
@@ -610,7 +617,7 @@ final class VelocityProxyBridge {
             UUID verifiedPremiumUuid = premiumVerificationManager.getVerifiedPremiumUuid(normalizedName);
             serverOpt.get().sendPluginMessage(AUTHME_CHANNEL,
                 createPerformLoginMessage(normalizedName, verifiedPremiumUuid));
-            scheduleRetry(normalizedName);
+            scheduleRetry(player);
         }, 1, TimeUnit.SECONDS);
     }
 
@@ -639,6 +646,11 @@ final class VelocityProxyBridge {
         }
     }
 
+    private static boolean isPlayerSessionMessage(String typeId) {
+        return LOGIN_MESSAGE.equals(typeId) || LOGOUT_MESSAGE.equals(typeId)
+            || PERFORM_LOGIN_ACK_MESSAGE.equals(typeId);
+    }
+
     private byte[] createPerformLoginMessage(String normalizedName, UUID verifiedPremiumUuid) {
         long timestamp = System.currentTimeMillis();
         String hmac = ProxyMessageSecurity.computeHmac(
@@ -652,12 +664,12 @@ final class VelocityProxyBridge {
         return output.toByteArray();
     }
 
-    private void redirectToLoginServer(String normalizedPlayerName) {
+    private void redirectToLoginServer(Player player) {
+        String normalizedPlayerName = normalizeName(player.getUsername());
         if (configuration.loginServer().isEmpty()) {
             return;
         }
-        Optional<Player> playerOpt = proxyServer.getPlayer(normalizedPlayerName);
-        if (playerOpt.isEmpty()) {
+        if (!player.isActive()) {
             logger.debug("Cannot redirect {} to loginServer: player no longer on proxy", normalizedPlayerName);
             return;
         }
@@ -669,10 +681,11 @@ final class VelocityProxyBridge {
         }
         logger.info("Redirecting {} to login server '{}' after authentication",
             normalizedPlayerName, configuration.loginServer());
-        playerOpt.get().createConnectionRequest(targetServer.get()).fireAndForget();
+        player.createConnectionRequest(targetServer.get()).fireAndForget();
     }
 
-    private void redirectLoggedOutPlayer(String normalizedPlayerName) {
+    private void redirectLoggedOutPlayer(Player player) {
+        String normalizedPlayerName = normalizeName(player.getUsername());
         if (!configuration.sendOnLogoutEnabled()) {
             return;
         }
@@ -681,8 +694,7 @@ final class VelocityProxyBridge {
             return;
         }
 
-        Optional<Player> player = proxyServer.getPlayer(normalizedPlayerName);
-        if (player.isEmpty()) {
+        if (!player.isActive()) {
             logger.debug("Received logout for {} but they are no longer on the proxy", normalizedPlayerName);
             return;
         }
@@ -695,7 +707,7 @@ final class VelocityProxyBridge {
         }
 
         logger.info("Redirecting {} to server '{}' after logout", normalizedPlayerName, configuration.sendOnLogoutTarget());
-        ConnectionRequestBuilder connectionRequest = player.get().createConnectionRequest(targetServer.get());
+        ConnectionRequestBuilder connectionRequest = player.createConnectionRequest(targetServer.get());
         connectionRequest.fireAndForget();
     }
 

--- a/authme-velocity/src/test/java/fr/xephi/authme/velocity/VelocityProxyBridgeTest.java
+++ b/authme-velocity/src/test/java/fr/xephi/authme/velocity/VelocityProxyBridgeTest.java
@@ -21,6 +21,7 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import net.kyori.adventure.text.Component;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -96,6 +97,11 @@ class VelocityProxyBridgeTest {
     @Captor
     private ArgumentCaptor<byte[]> payloadCaptor;
 
+    @BeforeEach
+    void setPluginMessageTarget() {
+        org.mockito.Mockito.lenient().when(pluginMessageEvent.getTarget()).thenReturn(player);
+    }
+
     @Test
     void shouldRegisterAuthMeChannel() {
         given(proxyServer.getChannelRegistrar()).willReturn(channelRegistrar);
@@ -129,6 +135,50 @@ class VelocityProxyBridgeTest {
         // Two messages are sent: proxy.started handshake (first) and perform.login (second)
         verify(currentServer, times(2)).sendPluginMessage(eq(VelocityProxyBridge.AUTHME_CHANNEL), payloadCaptor.capture());
         assertPerformLoginPayload(payloadCaptor.getValue(), "alice", "test-secret");
+    }
+
+    @Test
+    void shouldAuthenticateThePlayerCarryingTheLoginMessage() {
+        Player olderPlayer = mock(Player.class);
+        given(olderPlayer.getUsername()).willReturn("Example");
+        given(player.getUsername()).willReturn("example");
+        given(pluginMessageEvent.getResult()).willReturn(PluginMessageEvent.ForwardResult.forward());
+        given(pluginMessageEvent.getIdentifier()).willReturn(VelocityProxyBridge.AUTHME_CHANNEL);
+        given(pluginMessageEvent.getSource()).willReturn(sourceConnection);
+        given(pluginMessageEvent.getTarget()).willReturn(player);
+        given(pluginMessageEvent.getData()).willReturn(createAuthMePayload("login", "Example"));
+        given(sourceConnection.getServer()).willReturn(authServer);
+        given(authServer.getServerInfo()).willReturn(authServerInfo);
+        given(authServerInfo.getName()).willReturn("lobby");
+
+        VelocityAuthenticationStore store = new VelocityAuthenticationStore();
+        VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), store, null);
+        bridge.onPluginMessage(pluginMessageEvent);
+
+        assertFalse(store.isAuthenticated(olderPlayer));
+        assertTrue(store.isAuthenticated(player));
+        verify(proxyServer, never()).getPlayer(any(String.class));
+    }
+
+    @Test
+    void shouldRejectLoginForANameDifferentFromTheMessageTarget() {
+        given(player.getUsername()).willReturn("Alice");
+        given(pluginMessageEvent.getResult()).willReturn(PluginMessageEvent.ForwardResult.forward());
+        given(pluginMessageEvent.getIdentifier()).willReturn(VelocityProxyBridge.AUTHME_CHANNEL);
+        given(pluginMessageEvent.getSource()).willReturn(sourceConnection);
+        given(pluginMessageEvent.getTarget()).willReturn(player);
+        given(pluginMessageEvent.getData()).willReturn(createAuthMePayload("login", "Bob"));
+        given(sourceConnection.getServer()).willReturn(authServer);
+        given(authServer.getServerInfo()).willReturn(authServerInfo);
+        given(authServerInfo.getName()).willReturn("lobby");
+
+        VelocityAuthenticationStore store = new VelocityAuthenticationStore();
+        VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), store, null);
+        bridge.onPluginMessage(pluginMessageEvent);
+
+        assertFalse(store.isAuthenticated(player));
+        verify(player, never()).createConnectionRequest(any(RegisteredServer.class));
+        verify(proxyServer, never()).getPlayer(any(String.class));
     }
 
     @Test
@@ -187,7 +237,8 @@ class VelocityProxyBridgeTest {
         given(sourceConnection.getServer()).willReturn(nonAuthServer);
         given(nonAuthServer.getServerInfo()).willReturn(nonAuthServerInfo);
         given(nonAuthServerInfo.getName()).willReturn("survival");
-        given(proxyServer.getPlayer("alice")).willReturn(Optional.of(player));
+        given(player.getUsername()).willReturn("Alice");
+        given(player.isActive()).willReturn(true);
         given(proxyServer.getServer("limbo")).willReturn(Optional.of(nonAuthServer));
         given(player.createConnectionRequest(nonAuthServer)).willReturn(connectionRequest);
 
@@ -227,7 +278,6 @@ class VelocityProxyBridgeTest {
         given(currentServer.getServer()).willReturn(authServer);
         given(currentServer.sendPluginMessage(eq(VelocityProxyBridge.AUTHME_CHANNEL), any(byte[].class)))
             .willReturn(true);
-        given(proxyServer.getPlayer("alice")).willReturn(Optional.of(player));
 
         VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), new VelocityAuthenticationStore(), null);
         bridge.onPluginMessage(pluginMessageEvent);
@@ -237,9 +287,7 @@ class VelocityProxyBridgeTest {
         given(pluginMessageEvent.getData()).willReturn(createAuthMePayload("perform.login.ack", "Alice"));
         bridge.onPluginMessage(pluginMessageEvent);
 
-        // After ACK, proxyServer.getPlayer should have been called exactly once (by sendAutoLoginIfAlreadySwitched,
-        // not by any retry) — the pending login was cancelled before any retry could fire.
-        verify(proxyServer, org.mockito.Mockito.times(1)).getPlayer("alice");
+        verify(proxyServer, never()).getPlayer(any(String.class));
     }
 
     @Test
@@ -256,7 +304,6 @@ class VelocityProxyBridgeTest {
         given(currentServer.getServer()).willReturn(authServer);
         given(currentServer.sendPluginMessage(eq(VelocityProxyBridge.AUTHME_CHANNEL), any(byte[].class)))
             .willReturn(true);
-        given(proxyServer.getPlayer("alice")).willReturn(Optional.of(player));
 
         VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), new VelocityAuthenticationStore(), null);
 
@@ -271,9 +318,7 @@ class VelocityProxyBridgeTest {
         given(sourceConnection.getServer()).willReturn(nonAuthServer);
         bridge.onPluginMessage(pluginMessageEvent);
 
-        // Pending is now cancelled; proxyServer.getPlayer was called exactly once (by sendAutoLoginIfAlreadySwitched),
-        // not again by any retry.
-        verify(proxyServer, org.mockito.Mockito.times(1)).getPlayer("alice");
+        verify(proxyServer, never()).getPlayer(any(String.class));
     }
 
     @Test
@@ -352,7 +397,7 @@ class VelocityProxyBridgeTest {
         given(nonAuthServer.getServerInfo()).willReturn(nonAuthServerInfo);
         given(nonAuthServerInfo.getName()).willReturn("survival");
         given(player.getUsername()).willReturn("Alice");
-        given(player.getCurrentServer()).willReturn(Optional.of(currentServer));
+        given(player.getCurrentServer()).willReturn(Optional.of(sourceConnection), Optional.of(currentServer));
         given(currentServer.getServer()).willReturn(nonAuthServer);
         given(currentServer.sendPluginMessage(eq(VelocityProxyBridge.AUTHME_CHANNEL), any(byte[].class)))
             .willReturn(true);
@@ -375,7 +420,7 @@ class VelocityProxyBridgeTest {
             .willReturn(true);
 
         VelocityAuthenticationStore store = new VelocityAuthenticationStore();
-        store.markAuthenticated("alice");
+        store.markAuthenticated(player);
 
         VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), store, null);
         bridge.onPlayerEnteredConfiguration(new PlayerEnteredConfigurationEvent(player, currentServer));
@@ -406,7 +451,7 @@ class VelocityProxyBridgeTest {
         given(nonAuthServerInfo.getName()).willReturn("survival");
 
         VelocityAuthenticationStore store = new VelocityAuthenticationStore();
-        store.markAuthenticated("alice");
+        store.markAuthenticated(player);
 
         VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), store, null);
         bridge.onPlayerEnteredConfiguration(new PlayerEnteredConfigurationEvent(player, currentServer));
@@ -458,7 +503,7 @@ class VelocityProxyBridgeTest {
         given(authServerInfo.getName()).willReturn("lobby");
 
         VelocityAuthenticationStore store = new VelocityAuthenticationStore();
-        store.markAuthenticated("alice");
+        store.markAuthenticated(player);
 
         VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), store, null);
         bridge.onCommandExecute(commandEvent);
@@ -540,7 +585,7 @@ class VelocityProxyBridgeTest {
         given(authServerInfo.getName()).willReturn("lobby");
 
         VelocityAuthenticationStore store = new VelocityAuthenticationStore();
-        store.markAuthenticated("alice");
+        store.markAuthenticated(player);
 
         VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), store, null);
         bridge.onPlayerChat(chatEvent);


### PR DESCRIPTION
Login completion was routed by player name after the backend had already sent the message through the player who entered the password. During overlapping same-name connections, the proxy lookup could resolve the older player and move that session instead.

Keep the player attached to the plugin message through the authentication flow. Bungee uses the message receiver and Velocity uses the message target. Both reject session messages whose payload name does not match that player.

Authentication state, pending login retries, ACK handling, redirects, and disconnect cleanup now belong to the exact connection. The backend cache also tracks the Bukkit Player that owns the authenticated session, so an old disconnect cannot clear its replacement.

Added regression coverage for concurrent same-name connections, mismatched message targets, stale disconnects, backend message carriers, and pending login routing.