### PR TITLE
Claim pre-join connection and re-key it by a session identifier (instead of player's uuid)

### DIFF
--- a/authme-core/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
+++ b/authme-core/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
@@ -152,14 +152,13 @@ public class AsynchronousJoin implements AsynchronousProcess {
     public void processJoin(Player player) {
         String name = player.getName().toLowerCase(Locale.ROOT);
         String ip = PlayerUtils.getPlayerIp(player);
-        UUID playerId = player.getUniqueId();
-        String pendingLoginPassword = preJoinDialogService.consumePendingLoginPassword(playerId);
-        String pendingRecoveryEmail = preJoinDialogService.consumePendingRecoveryEmail(playerId);
-        PreJoinDialogService.PendingRegistration pendingRegistration =
-            preJoinDialogService.consumePendingRegistration(playerId);
-        boolean shouldSkipPostJoinDialog = preJoinDialogService.consumeSkipPostJoinDialog(playerId);
-        boolean pendingForceLogin = preJoinDialogService.consumePendingForceLogin(playerId);
-        String pendingKick = preJoinDialogService.consumePendingKickMessage(playerId);
+        PreJoinDialogService.PendingDialogState dialogState = preJoinDialogService.consumeSession(name);
+        String pendingLoginPassword = dialogState.loginPassword();
+        String pendingRecoveryEmail = dialogState.recoveryEmail();
+        PreJoinDialogService.PendingRegistration pendingRegistration = dialogState.registration();
+        boolean shouldSkipPostJoinDialog = dialogState.skipPostJoinDialog();
+        boolean pendingForceLogin = dialogState.forceLogin();
+        String pendingKick = dialogState.kickMessage();
         // pendingKick is applied below, after proxy/premium/session checks, which take priority:
         // a Velocity perform.login arriving just after the player cancelled the pre-join dialog
         // must win over the dialog cancel kick.

--- a/authme-core/src/main/java/fr/xephi/authme/service/PreJoinDialogService.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/PreJoinDialogService.java
@@ -1,139 +1,181 @@
 package fr.xephi.authme.service;
 
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Stores transient dialog state between Paper/Folia's configuration phase and the actual join.
+ * <p>
+ * State belongs to a session opened for one configuration-phase connection, never to a player name
+ * or profile id: those are shared by every connection authenticating as the same player on an
+ * offline-mode server, so a later connection could otherwise consume or wipe the state of the one
+ * that is still authenticating.
  */
 public class PreJoinDialogService {
 
-    private final Map<UUID, String> pendingLoginPasswords = new ConcurrentHashMap<>();
-    private final Map<UUID, String> pendingRecoveryEmails = new ConcurrentHashMap<>();
-    private final Map<UUID, PendingRegistration> pendingRegistrations = new ConcurrentHashMap<>();
-    private final Set<UUID> skipPostJoinDialogs = ConcurrentHashMap.newKeySet();
-    private final Map<UUID, String> pendingKickMessages = new ConcurrentHashMap<>();
-
-    // Pre-join force-login: tracks players blocked in the pre-join login dialog so that
-    // ForceLoginCommand can unblock them without requiring the player to be in PLAY state.
-    private final Map<String, UUID> pendingPreJoinByName = new ConcurrentHashMap<>();
-    private final Map<UUID, CompletableFuture<String>> pendingPreJoinFutures = new ConcurrentHashMap<>();
-    private final Set<UUID> pendingForceLogins = ConcurrentHashMap.newKeySet();
+    private final AtomicLong nextSessionId = new AtomicLong();
+    private final Map<String, Long> sessionByName = new ConcurrentHashMap<>();
+    private final Map<Long, DialogSession> sessions = new ConcurrentHashMap<>();
 
     public PreJoinDialogService() {
     }
 
-    public void storePendingLoginPassword(UUID playerId, String password) {
-        pendingLoginPasswords.put(playerId, password);
+    /**
+     * Opens a session for a connection entering the configuration phase, dropping the state of any
+     * earlier session for that name so it can never be inherited.
+     *
+     * @param normalizedName the player name in lowercase
+     * @return the id identifying this session in every other call
+     */
+    public long openSession(String normalizedName) {
+        long sessionId = nextSessionId.incrementAndGet();
+        sessions.put(sessionId, new DialogSession(normalizedName));
+
+        Long previousId = sessionByName.put(normalizedName, sessionId);
+        if (previousId != null) {
+            sessions.remove(previousId);
+        }
+        return sessionId;
     }
 
-    public String consumePendingLoginPassword(UUID playerId) {
-        return pendingLoginPasswords.remove(playerId);
-    }
-
-    public void storePendingRecoveryEmail(UUID playerId, String email) {
-        pendingRecoveryEmails.put(playerId, email);
-    }
-
-    public String consumePendingRecoveryEmail(UUID playerId) {
-        return pendingRecoveryEmails.remove(playerId);
-    }
-
-    public void storePendingPasswordRegistration(UUID playerId, String password, String email) {
-        pendingRegistrations.put(playerId, new PendingRegistration(password, email, false));
-    }
-
-    public void storePendingEmailRegistration(UUID playerId, String email) {
-        pendingRegistrations.put(playerId, new PendingRegistration(email, null, true));
-    }
-
-    public PendingRegistration consumePendingRegistration(UUID playerId) {
-        return pendingRegistrations.remove(playerId);
-    }
-
-    public void markSkipPostJoinDialog(UUID playerId) {
-        skipPostJoinDialogs.add(playerId);
-    }
-
-    public boolean consumeSkipPostJoinDialog(UUID playerId) {
-        return skipPostJoinDialogs.remove(playerId);
-    }
-
-    public void storePendingKickMessage(UUID playerId, String message) {
-        pendingKickMessages.put(playerId, message);
-    }
-
-    public String consumePendingKickMessage(UUID playerId) {
-        return pendingKickMessages.remove(playerId);
+    public void retireSession(long sessionId) {
+        DialogSession session = sessions.remove(sessionId);
+        if (session != null) {
+            sessionByName.remove(session.name, sessionId);
+        }
     }
 
     /**
-     * Registers the blocking {@link CompletableFuture} used by the pre-join login dialog so that
+     * Consumes everything the player's session holds, at once so that nothing can be left half-read.
+     *
+     * @param normalizedName the player name in lowercase
+     * @return the pending state, or {@link PendingDialogState#NONE} if the player has no session
+     */
+    public PendingDialogState consumeSession(String normalizedName) {
+        Long sessionId = sessionByName.remove(normalizedName);
+        if (sessionId == null) {
+            return PendingDialogState.NONE;
+        }
+
+        DialogSession session = sessions.remove(sessionId);
+        return session == null ? PendingDialogState.NONE : session.toPendingState();
+    }
+
+    public void storePendingLoginPassword(long sessionId, String password) {
+        DialogSession session = sessions.get(sessionId);
+        if (session != null) {
+            session.loginPassword = password;
+        }
+    }
+
+    public void storePendingRecoveryEmail(long sessionId, String email) {
+        DialogSession session = sessions.get(sessionId);
+        if (session != null) {
+            session.recoveryEmail = email;
+        }
+    }
+
+    public void storePendingPasswordRegistration(long sessionId, String password, String email) {
+        DialogSession session = sessions.get(sessionId);
+        if (session != null) {
+            session.registration = new PendingRegistration(password, email, false);
+        }
+    }
+
+    public void storePendingEmailRegistration(long sessionId, String email) {
+        DialogSession session = sessions.get(sessionId);
+        if (session != null) {
+            session.registration = new PendingRegistration(email, null, true);
+        }
+    }
+
+    public void markSkipPostJoinDialog(long sessionId) {
+        DialogSession session = sessions.get(sessionId);
+        if (session != null) {
+            session.skipPostJoinDialog = true;
+        }
+    }
+
+    public void storePendingKickMessage(long sessionId, String message) {
+        DialogSession session = sessions.get(sessionId);
+        if (session != null) {
+            session.kickMessage = message;
+        }
+    }
+
+    /**
+     * Registers the blocking {@link CompletableFuture} used by the pre-join dialog so that
      * {@link #approvePreJoinForceLogin} can resolve it from outside the event handler thread.
      *
-     * @param normalizedName the player name in lowercase
-     * @param uuid the player's UUID
+     * @param sessionId the session waiting on the dialog
      * @param future the future that blocks the configuration-phase thread
      */
-    public void registerPreJoinFuture(String normalizedName, UUID uuid, CompletableFuture<String> future) {
-        pendingPreJoinByName.put(normalizedName, uuid);
-        pendingPreJoinFutures.put(uuid, future);
+    public void registerPreJoinFuture(long sessionId, CompletableFuture<String> future) {
+        DialogSession session = sessions.get(sessionId);
+        if (session != null) {
+            session.future = future;
+        }
+    }
+
+    public void unregisterPreJoinFuture(long sessionId) {
+        DialogSession session = sessions.get(sessionId);
+        if (session != null) {
+            session.future = null;
+        }
     }
 
     /**
-     * Removes the pre-join future registration once the blocking wait is over.
-     *
-     * @param uuid the player's UUID
-     */
-    public void unregisterPreJoinFuture(UUID uuid) {
-        pendingPreJoinFutures.remove(uuid);
-        pendingPreJoinByName.values().remove(uuid);
-    }
-
-    /**
-     * Approves a force-login for a player currently blocked in the pre-join login dialog.
-     * Completes the blocking future with {@code null} (no kick message), allowing the player to
-     * proceed to PLAY state where {@link #consumePendingForceLogin} will trigger a force-login.
+     * Approves a force-login for a player currently blocked in the pre-join dialog, letting him
+     * proceed to the play state where the force-login is performed. Resolved by name because a proxy
+     * or the console only knows the name; unambiguous because a name has at most one session.
      *
      * @param normalizedName the player name in lowercase
-     * @return {@code true} if the player was in the pre-join dialog and the approval was registered,
-     *         {@code false} if no such player was found (e.g. already joined or not in dialog)
+     * @return {@code true} if the player was in the pre-join dialog and the approval was registered
      */
     public boolean approvePreJoinForceLogin(String normalizedName) {
-        UUID uuid = pendingPreJoinByName.get(normalizedName);
-        if (uuid == null) {
-            return false;
-        }
-        CompletableFuture<String> future = pendingPreJoinFutures.get(uuid);
+        Long sessionId = sessionByName.get(normalizedName);
+        DialogSession session = sessionId == null ? null : sessions.get(sessionId);
+        CompletableFuture<String> future = session == null ? null : session.future;
         if (future == null) {
             return false;
         }
-        pendingForceLogins.add(uuid);
+
+        session.forceLogin = true;
         future.complete(null);
         return true;
     }
 
-    /**
-     * Consumes the force-login flag for the given player.
-     *
-     * @param playerId the player's UUID
-     * @return {@code true} if a force-login was approved for this player (flag is cleared)
-     */
-    public boolean consumePendingForceLogin(UUID playerId) {
-        return pendingForceLogins.remove(playerId);
+    private static final class DialogSession {
+
+        private final String name;
+
+        // Written on the configuration-phase thread, read on the join thread
+        private volatile String loginPassword;
+        private volatile String recoveryEmail;
+        private volatile PendingRegistration registration;
+        private volatile boolean skipPostJoinDialog;
+        private volatile boolean forceLogin;
+        private volatile String kickMessage;
+        private volatile CompletableFuture<String> future;
+
+        DialogSession(String name) {
+            this.name = name;
+        }
+
+        PendingDialogState toPendingState() {
+            return new PendingDialogState(loginPassword, recoveryEmail, registration,
+                skipPostJoinDialog, forceLogin, kickMessage);
+        }
     }
 
-    public void clear(UUID playerId) {
-        pendingLoginPasswords.remove(playerId);
-        pendingRecoveryEmails.remove(playerId);
-        pendingRegistrations.remove(playerId);
-        skipPostJoinDialogs.remove(playerId);
-        pendingForceLogins.remove(playerId);
-        pendingKickMessages.remove(playerId);
-        unregisterPreJoinFuture(playerId);
+    public record PendingDialogState(String loginPassword, String recoveryEmail,
+                                     PendingRegistration registration, boolean skipPostJoinDialog,
+                                     boolean forceLogin, String kickMessage) {
+
+        public static final PendingDialogState NONE =
+            new PendingDialogState(null, null, null, false, false, null);
     }
 
     public record PendingRegistration(String primaryValue, String secondaryValue, boolean isEmailRegistration) {

--- a/authme-core/src/test/java/fr/xephi/authme/process/join/AsynchronousJoinTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/process/join/AsynchronousJoinTest.java
@@ -48,6 +48,7 @@ import static fr.xephi.authme.service.BukkitServiceTestHelper.setBukkitServiceTo
 import static fr.xephi.authme.service.BukkitServiceTestHelper.setBukkitServiceToRunTaskOptionallyAsync;
 import static fr.xephi.authme.service.BukkitServiceTestHelper.setBukkitServiceToScheduleSyncEntityTaskFromOptionallyAsyncTask;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
@@ -118,6 +119,8 @@ public class AsynchronousJoinTest {
         setBukkitServiceToRunTaskOptionallyAsync(bukkitService);
         setBukkitServiceToRunTaskLater(bukkitService);
         given(service.getProperty(PremiumSettings.ENABLE_PREMIUM)).willReturn(false);
+        given(preJoinDialogService.consumeSession(anyString()))
+            .willReturn(PreJoinDialogService.PendingDialogState.NONE);
     }
 
     @Test
@@ -231,9 +234,8 @@ public class AsynchronousJoinTest {
         // but by the time processJoin() runs the proxy session is available; the kick must be discarded.
         Player player = mockPlayer("Bobby");
         setUpRegisteredJoin(player);
-        UUID playerId = UUID.randomUUID();
-        given(player.getUniqueId()).willReturn(playerId);
-        given(preJoinDialogService.consumePendingKickMessage(playerId)).willReturn("You have canceled the login.");
+        givenPendingDialogState(new PreJoinDialogService.PendingDialogState(
+            null, null, null, false, false, "You have canceled the login."));
         given(proxySessionManager.consumeLoginRequest("bobby"))
             .willReturn(new ProxySessionManager.ProxyLoginRequest("bobby", null));
         given(proxyLoginRequestValidator.validate(player, null)).willReturn(true);
@@ -252,10 +254,8 @@ public class AsynchronousJoinTest {
         // given
         Player player = mockPlayer("Bobby");
         setUpRegisteredJoin(player);
-        java.util.UUID playerId = java.util.UUID.randomUUID();
-        given(player.getUniqueId()).willReturn(playerId);
-        given(preJoinDialogService.consumePendingLoginPassword(playerId)).willReturn("hunter2");
-        given(preJoinDialogService.consumeSkipPostJoinDialog(playerId)).willReturn(false);
+        givenPendingDialogState(new PreJoinDialogService.PendingDialogState(
+            "hunter2", null, null, false, false, null));
         given(playerCache.isAuthenticated("Bobby")).willReturn(false);
 
         // when
@@ -350,9 +350,8 @@ public class AsynchronousJoinTest {
         // given
         Player player = mockPlayer("Bobby");
         setUpRegisteredJoin(player);
-        java.util.UUID playerId = java.util.UUID.randomUUID();
-        given(player.getUniqueId()).willReturn(playerId);
-        given(preJoinDialogService.consumePendingForceLogin(playerId)).willReturn(true);
+        givenPendingDialogState(new PreJoinDialogService.PendingDialogState(
+            null, null, null, false, true, null));
 
         // when
         asynchronousJoin.processJoin(player);
@@ -369,9 +368,8 @@ public class AsynchronousJoinTest {
         // given
         Player player = mockPlayer("Bobby");
         setUpRegisteredJoin(player);
-        java.util.UUID playerId = java.util.UUID.randomUUID();
-        given(player.getUniqueId()).willReturn(playerId);
-        given(preJoinDialogService.consumeSkipPostJoinDialog(playerId)).willReturn(true);
+        givenPendingDialogState(new PreJoinDialogService.PendingDialogState(
+            null, null, null, true, false, null));
         given(playerCache.isAuthenticated("Bobby")).willReturn(false);
         given(service.getProperty(RegistrationSettings.USE_DIALOG_UI)).willReturn(true);
         given(dialogAdapter.isDialogSupported()).willReturn(true);
@@ -382,6 +380,10 @@ public class AsynchronousJoinTest {
         // then
         verify(limboService).createLimboPlayer(player, true);
         verify(dialogAdapter, never()).showLoginDialog(eq(player), any(DialogWindowSpec.class));
+    }
+
+    private void givenPendingDialogState(PreJoinDialogService.PendingDialogState state) {
+        given(preJoinDialogService.consumeSession("bobby")).willReturn(state);
     }
 
     private void setUpRegisteredJoin(Player player) {

--- a/authme-core/src/test/java/fr/xephi/authme/service/PreJoinDialogServiceTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/service/PreJoinDialogServiceTest.java
@@ -1,8 +1,8 @@
 package fr.xephi.authme.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,54 +14,117 @@ import static org.hamcrest.Matchers.nullValue;
  */
 class PreJoinDialogServiceTest {
 
+    private PreJoinDialogService service;
+
+    @BeforeEach
+    void createService() {
+        service = new PreJoinDialogService();
+    }
+
     @Test
     void shouldStoreAndConsumePendingLoginPassword() {
-        PreJoinDialogService service = new PreJoinDialogService();
-        UUID uuid = UUID.randomUUID();
+        long sessionId = service.openSession("bobby");
 
-        service.storePendingLoginPassword(uuid, "s3cr3t");
+        service.storePendingLoginPassword(sessionId, "s3cr3t");
 
-        assertThat(service.consumePendingLoginPassword(uuid), is("s3cr3t"));
-        assertThat(service.consumePendingLoginPassword(uuid), nullValue());
+        assertThat(service.consumeSession("bobby").loginPassword(), is("s3cr3t"));
+        assertThat(service.consumeSession("bobby").loginPassword(), nullValue());
+    }
+
+    @Test
+    void shouldConsumeWholeSessionAtOnce() {
+        long sessionId = service.openSession("bobby");
+        service.storePendingLoginPassword(sessionId, "s3cr3t");
+        service.storePendingRecoveryEmail(sessionId, "bob@example.com");
+        service.storePendingPasswordRegistration(sessionId, "pw", "reg@example.com");
+        service.markSkipPostJoinDialog(sessionId);
+        service.storePendingKickMessage(sessionId, "bye");
+
+        PreJoinDialogService.PendingDialogState state = service.consumeSession("bobby");
+
+        assertThat(state.loginPassword(), is("s3cr3t"));
+        assertThat(state.recoveryEmail(), is("bob@example.com"));
+        assertThat(state.registration(), is(new PreJoinDialogService.PendingRegistration("pw", "reg@example.com", false)));
+        assertThat(state.skipPostJoinDialog(), is(true));
+        assertThat(state.kickMessage(), is("bye"));
+    }
+
+    @Test
+    void shouldReturnEmptyStateForPlayerWithoutSession() {
+        PreJoinDialogService.PendingDialogState state = service.consumeSession("nobody");
+
+        assertThat(state, is(PreJoinDialogService.PendingDialogState.NONE));
+        assertThat(state.loginPassword(), nullValue());
+        assertThat(state.forceLogin(), is(false));
+    }
+
+    @Test
+    void shouldStoreEmailRegistration() {
+        long sessionId = service.openSession("bobby");
+
+        service.storePendingEmailRegistration(sessionId, "bob@example.com");
+
+        assertThat(service.consumeSession("bobby").registration(),
+            is(new PreJoinDialogService.PendingRegistration("bob@example.com", null, true)));
+    }
+
+    @Test
+    void shouldNotLetLaterSessionConsumeStateOfEarlierOne() {
+        long firstSession = service.openSession("bobby");
+        service.storePendingLoginPassword(firstSession, "s3cr3t");
+
+        service.openSession("bobby");
+
+        assertThat(service.consumeSession("bobby").loginPassword(), nullValue());
+        // The earlier session is gone, so writing to it must not resurrect it either
+        service.storePendingLoginPassword(firstSession, "s3cr3t");
+        assertThat(service.consumeSession("bobby").loginPassword(), nullValue());
+    }
+
+    @Test
+    void shouldIgnoreStoresForRetiredSession() {
+        long sessionId = service.openSession("bobby");
+        service.retireSession(sessionId);
+
+        service.storePendingLoginPassword(sessionId, "s3cr3t");
+        service.markSkipPostJoinDialog(sessionId);
+
+        assertThat(service.consumeSession("bobby"), is(PreJoinDialogService.PendingDialogState.NONE));
     }
 
     @Test
     void shouldApprovePreJoinForceLoginAndCompleteFuture() {
-        PreJoinDialogService service = new PreJoinDialogService();
-        UUID uuid = UUID.randomUUID();
+        long sessionId = service.openSession("bobby");
         CompletableFuture<String> future = new CompletableFuture<>();
-        service.registerPreJoinFuture("bobby", uuid, future);
+        service.registerPreJoinFuture(sessionId, future);
 
         boolean result = service.approvePreJoinForceLogin("bobby");
 
         assertThat(result, is(true));
         assertThat(future.isDone(), is(true));
         assertThat(future.getNow("sentinel"), is(nullValue()));
-        assertThat(service.consumePendingForceLogin(uuid), is(true));
-        assertThat(service.consumePendingForceLogin(uuid), is(false));
+        assertThat(service.consumeSession("bobby").forceLogin(), is(true));
+        assertThat(service.consumeSession("bobby").forceLogin(), is(false));
     }
 
     @Test
     void shouldReturnFalseForApproveWhenNoPreJoinDialogPending() {
-        PreJoinDialogService service = new PreJoinDialogService();
-
         assertThat(service.approvePreJoinForceLogin("nobody"), is(false));
     }
 
     @Test
-    void shouldReturnFalseForConsumeForceLoginWhenNotApproved() {
-        PreJoinDialogService service = new PreJoinDialogService();
+    void shouldReturnFalseForApproveWhenSessionHasNoDialog() {
+        service.openSession("bobby");
 
-        assertThat(service.consumePendingForceLogin(UUID.randomUUID()), is(false));
+        assertThat(service.approvePreJoinForceLogin("bobby"), is(false));
     }
 
     @Test
     void shouldNotApproveAfterUnregister() {
-        PreJoinDialogService service = new PreJoinDialogService();
-        UUID uuid = UUID.randomUUID();
+        long sessionId = service.openSession("alice");
         CompletableFuture<String> future = new CompletableFuture<>();
-        service.registerPreJoinFuture("alice", uuid, future);
-        service.unregisterPreJoinFuture(uuid);
+        service.registerPreJoinFuture(sessionId, future);
+        service.unregisterPreJoinFuture(sessionId);
 
         boolean result = service.approvePreJoinForceLogin("alice");
 
@@ -70,17 +133,15 @@ class PreJoinDialogServiceTest {
     }
 
     @Test
-    void shouldClearAllStateForPlayer() {
-        PreJoinDialogService service = new PreJoinDialogService();
-        UUID uuid = UUID.randomUUID();
+    void shouldNotApproveAfterSessionRetired() {
+        long sessionId = service.openSession("charlie");
         CompletableFuture<String> future = new CompletableFuture<>();
-        service.storePendingLoginPassword(uuid, "pw");
-        service.registerPreJoinFuture("charlie", uuid, future);
+        service.storePendingLoginPassword(sessionId, "pw");
+        service.registerPreJoinFuture(sessionId, future);
 
-        service.clear(uuid);
+        service.retireSession(sessionId);
 
-        assertThat(service.consumePendingLoginPassword(uuid), is(nullValue()));
         assertThat(service.approvePreJoinForceLogin("charlie"), is(false));
-        assertThat(service.consumePendingForceLogin(uuid), is(false));
+        assertThat(service.consumeSession("charlie"), is(PreJoinDialogService.PendingDialogState.NONE));
     }
 }

--- a/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java
+++ b/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java
@@ -16,7 +16,6 @@ import fr.xephi.authme.process.register.RegistrationType;
 import fr.xephi.authme.security.PasswordSecurity;
 import fr.xephi.authme.service.CommonService;
 import fr.xephi.authme.service.DialogWindowService;
-import fr.xephi.authme.service.PendingConnectionRegistry;
 import fr.xephi.authme.service.PendingPremiumCache;
 import fr.xephi.authme.service.PreJoinDialogService;
 import fr.xephi.authme.service.PremiumLoginVerifier;
@@ -31,7 +30,6 @@ import io.papermc.paper.dialog.Dialog;
 import io.papermc.paper.dialog.DialogResponseView;
 import io.papermc.paper.event.connection.configuration.AsyncPlayerConnectionConfigureEvent;
 import io.papermc.paper.event.player.PlayerCustomClickEvent;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -54,10 +52,9 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class PaperDialogFlowListener implements Listener {
 
-    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
-
-    private final ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses = new ConcurrentHashMap<>();
-    private final ConcurrentMap<UUID, CompletableFuture<String>> pendingRegisterResponses = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, CompletableFuture<String>> pendingLoginResponses = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, CompletableFuture<String>> pendingRegisterResponses = new ConcurrentHashMap<>();
+    private final ConcurrentMap<PlayerConfigurationConnection, Long> connectionSessions = new ConcurrentHashMap<>();
 
     @Inject
     private CommonService commonService;
@@ -79,9 +76,6 @@ public class PaperDialogFlowListener implements Listener {
 
     @Inject
     private PreJoinDialogService preJoinDialogService;
-
-    @Inject
-    private PendingConnectionRegistry pendingConnectionRegistry;
 
     @Inject
     private PendingPremiumCache pendingPremiumCache;
@@ -112,16 +106,7 @@ public class PaperDialogFlowListener implements Listener {
             return;
         }
 
-        // Clearing the state here would hand this connection the pending login of the one in the dialog
-        if (hasDialogInFlight(playerId)) {
-            connection.disconnect(LEGACY_SERIALIZER.deserialize(
-                messages.retrieveSingle(playerName, MessageKey.USERNAME_ALREADY_ONLINE_ERROR)));
-            return;
-        }
-
-        pendingLoginResponses.remove(playerId);
-        pendingRegisterResponses.remove(playerId);
-        preJoinDialogService.clear(playerId);
+        retireSession(connection);
 
         String normalizedName = playerName.toLowerCase(Locale.ROOT);
         Set<String> unrestrictedNames = commonService.getProperty(RestrictionSettings.UNRESTRICTED_NAMES);
@@ -132,18 +117,21 @@ public class PaperDialogFlowListener implements Listener {
             return;
         }
 
+        long sessionId = preJoinDialogService.openSession(normalizedName);
+        connectionSessions.put(connection, sessionId);
+
         PlayerAuth auth = dataSource.getAuth(normalizedName);
         if (auth != null) {
             if (shouldSkipPreJoinDialogForPremium(auth, playerName, playerId)) {
-                preJoinDialogService.markSkipPostJoinDialog(playerId);
+                preJoinDialogService.markSkipPostJoinDialog(sessionId);
                 return;
             }
-            handleBlockingLoginDialog(connection, playerId, playerName);
+            handleBlockingLoginDialog(connection, sessionId, playerName);
         } else if (commonService.getProperty(RegistrationSettings.FORCE)) {
             RegistrationType registrationType = commonService.getProperty(RegistrationSettings.REGISTRATION_TYPE);
             RegisterSecondaryArgument secondArg =
                 commonService.getProperty(RegistrationSettings.REGISTER_SECOND_ARGUMENT);
-            handleBlockingRegisterDialog(connection, playerId, playerName, PaperDialogHelper.createPreJoinRegisterDialog(
+            handleBlockingRegisterDialog(connection, sessionId, playerName, PaperDialogHelper.createPreJoinRegisterDialog(
                 dialogWindowService.createPreJoinRegisterDialog(playerName, registrationType, secondArg)));
         }
     }
@@ -154,9 +142,9 @@ public class PaperDialogFlowListener implements Listener {
             return;
         }
 
-        UUID playerId = connection.getProfile().getId();
         String playerName = connection.getProfile().getName();
-        if (playerId == null || playerName == null) {
+        Long sessionId = connectionSessions.get(connection);
+        if (playerName == null || sessionId == null) {
             return;
         }
 
@@ -164,17 +152,17 @@ public class PaperDialogFlowListener implements Listener {
             String kickMessage = commonService.getProperty(RegistrationSettings.PRE_JOIN_LOGIN_CANCEL_KICKS)
                 ? messages.retrieveSingle(playerName, MessageKey.DIALOG_LOGIN_CANCELED)
                 : null;
-            completeLoginResponse(playerId, kickMessage);
+            completeLoginResponse(sessionId, kickMessage);
             return;
         }
 
         if (PaperDialogActionKeys.PRE_JOIN_LOGIN_RECOVERY.equals(event.getIdentifier())) {
-            processPreJoinLoginRecovery(playerId, playerName, connection);
+            processPreJoinLoginRecovery(playerName, connection);
             return;
         }
 
         if (PaperDialogActionKeys.PRE_JOIN_RECOVERY_SUBMIT.equals(event.getIdentifier())) {
-            processPreJoinRecoverySubmit(playerId, playerName, event.getDialogResponseView());
+            processPreJoinRecoverySubmit(sessionId, event.getDialogResponseView());
             return;
         }
 
@@ -182,17 +170,17 @@ public class PaperDialogFlowListener implements Listener {
             String kickMessage = commonService.getProperty(RegistrationSettings.PRE_JOIN_LOGIN_CANCEL_KICKS)
                 ? messages.retrieveSingle(playerName, MessageKey.DIALOG_LOGIN_CANCELED)
                 : null;
-            completeLoginResponse(playerId, kickMessage);
+            completeLoginResponse(sessionId, kickMessage);
             return;
         }
 
         if (PaperDialogActionKeys.PRE_JOIN_LOGIN_SUBMIT.equals(event.getIdentifier())) {
-            processPreJoinLogin(playerId, playerName, event.getDialogResponseView());
+            processPreJoinLogin(sessionId, playerName, event.getDialogResponseView());
             return;
         }
 
         if (PaperDialogActionKeys.PRE_JOIN_REGISTER_SUBMIT.equals(event.getIdentifier())) {
-            storePendingRegistration(connection, playerId, playerName, event.getDialogResponseView());
+            storePendingRegistration(connection, sessionId, playerName, event.getDialogResponseView());
             return;
         }
 
@@ -200,32 +188,38 @@ public class PaperDialogFlowListener implements Listener {
             String kickMessage = commonService.getProperty(RegistrationSettings.PRE_JOIN_REGISTER_CANCEL_KICKS)
                 ? messages.retrieveSingle(playerName, MessageKey.DIALOG_REGISTER_CANCELED)
                 : null;
-            completeRegisterResponse(playerId, kickMessage);
+            completeRegisterResponse(sessionId, kickMessage);
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerConnectionClose(PlayerConnectionCloseEvent event) {
-        // Offline UUIDs are derived from the name, so a refused duplicate closing must not wipe the state
-        String playerName = event.getPlayerName();
-        if (playerName != null && pendingConnectionRegistry.hasLiveClaim(playerName)) {
-            return;
+        // The event only carries a name and profile id, both shared by every connection using that
+        // name, so retire by connection instead: the ones that are gone, whichever player they were
+        for (PlayerConfigurationConnection connection : connectionSessions.keySet()) {
+            if (!connection.isConnected()) {
+                retireSession(connection);
+            }
         }
-
-        UUID playerId = event.getPlayerUniqueId();
-        pendingLoginResponses.remove(playerId);
-        pendingRegisterResponses.remove(playerId);
-        preJoinDialogService.clear(playerId);
     }
 
-    private void handleBlockingLoginDialog(PlayerConfigurationConnection connection, UUID playerId, String playerName) {
+    private void retireSession(PlayerConfigurationConnection connection) {
+        Long sessionId = connectionSessions.remove(connection);
+        if (sessionId != null) {
+            pendingLoginResponses.remove(sessionId);
+            pendingRegisterResponses.remove(sessionId);
+            preJoinDialogService.retireSession(sessionId);
+        }
+    }
+
+    private void handleBlockingLoginDialog(PlayerConfigurationConnection connection, long sessionId, String playerName) {
         CompletableFuture<String> loginResponse = new CompletableFuture<>();
         long timeoutSeconds = Math.max(commonService.getProperty(RestrictionSettings.LOGIN_TIMEOUT), 1);
         loginResponse.completeOnTimeout(
             messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR), timeoutSeconds, TimeUnit.SECONDS);
         String normalizedName = playerName.toLowerCase(Locale.ROOT);
-        pendingLoginResponses.put(playerId, loginResponse);
-        preJoinDialogService.registerPreJoinFuture(normalizedName, playerId, loginResponse);
+        pendingLoginResponses.put(sessionId, loginResponse);
+        preJoinDialogService.registerPreJoinFuture(sessionId, loginResponse);
 
         // Close the race with a proxy auto-login (perform.login) that arrived during the configuration
         // phase between the shouldSkipDialogs() check and now: if a proxy session has been queued,
@@ -243,72 +237,72 @@ public class PaperDialogFlowListener implements Listener {
                 PaperDialogHelper.createPreJoinLoginDialog(dialogWindowService.createPreJoinLoginDialog(playerName)));
         }
         String kickMessage = loginResponse.join();
-        pendingLoginResponses.remove(playerId);
-        preJoinDialogService.unregisterPreJoinFuture(playerId);
+        pendingLoginResponses.remove(sessionId);
+        preJoinDialogService.unregisterPreJoinFuture(sessionId);
 
         if (kickMessage != null) {
-            preJoinDialogService.storePendingKickMessage(playerId, kickMessage);
+            preJoinDialogService.storePendingKickMessage(sessionId, kickMessage);
         }
         connection.getAudience().closeDialog();
     }
 
-    private void processPreJoinLogin(UUID playerId, String playerName, DialogResponseView dialogResponseView) {
+    private void processPreJoinLogin(long sessionId, String playerName, DialogResponseView dialogResponseView) {
         String password = dialogResponseView == null ? null : dialogResponseView.getText("password");
         if (password == null || password.isBlank()) {
-            completeLoginResponse(playerId, messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR));
+            completeLoginResponse(sessionId, messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR));
             return;
         }
 
         PlayerAuth auth = dataSource.getAuth(playerName.toLowerCase(Locale.ROOT));
         if (auth == null) {
-            completeLoginResponse(playerId, messages.retrieveSingle(playerName, MessageKey.UNKNOWN_USER));
+            completeLoginResponse(sessionId, messages.retrieveSingle(playerName, MessageKey.UNKNOWN_USER));
             return;
         }
 
         if (passwordSecurity.comparePassword(password, auth.getPassword(), playerName)) {
-            preJoinDialogService.storePendingLoginPassword(playerId, password);
-            completeLoginResponse(playerId, null);
+            preJoinDialogService.storePendingLoginPassword(sessionId, password);
+            completeLoginResponse(sessionId, null);
         } else {
-            completeLoginResponse(playerId, messages.retrieveSingle(playerName, MessageKey.WRONG_PASSWORD));
+            completeLoginResponse(sessionId, messages.retrieveSingle(playerName, MessageKey.WRONG_PASSWORD));
         }
     }
 
-    private void processPreJoinLoginRecovery(UUID playerId, String playerName,
-                                             PlayerConfigurationConnection connection) {
+    private void processPreJoinLoginRecovery(String playerName, PlayerConfigurationConnection connection) {
         DialogWindowSpec recoverySpec = dialogWindowService.createPreJoinRecoveryDialog(playerName);
         connection.getAudience().showDialog(PaperDialogHelper.createPreJoinRecoveryDialog(recoverySpec));
     }
 
-    private void processPreJoinRecoverySubmit(UUID playerId, String playerName, DialogResponseView dialogResponseView) {
+    private void processPreJoinRecoverySubmit(long sessionId, DialogResponseView dialogResponseView) {
         String email = dialogResponseView == null ? null : dialogResponseView.getText("email");
         if (email != null && !email.isBlank()) {
-            preJoinDialogService.storePendingRecoveryEmail(playerId, email);
+            preJoinDialogService.storePendingRecoveryEmail(sessionId, email);
         }
         // Let the player join; AsynchronousJoin will execute the recovery and kick on failure
-        completeLoginResponse(playerId, null);
+        completeLoginResponse(sessionId, null);
     }
 
-    private void handleBlockingRegisterDialog(PlayerConfigurationConnection connection, UUID playerId, String playerName, Dialog dialog) {
+    private void handleBlockingRegisterDialog(PlayerConfigurationConnection connection, long sessionId,
+                                              String playerName, Dialog dialog) {
         CompletableFuture<String> registerResponse = new CompletableFuture<>();
         long timeoutSeconds = Math.max(commonService.getProperty(RestrictionSettings.REGISTER_TIMEOUT), 1);
         registerResponse.completeOnTimeout(
             messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR), timeoutSeconds, TimeUnit.SECONDS);
-        pendingRegisterResponses.put(playerId, registerResponse);
+        pendingRegisterResponses.put(sessionId, registerResponse);
 
         connection.getAudience().showDialog(dialog);
         String kickMessage = registerResponse.join();
-        pendingRegisterResponses.remove(playerId);
+        pendingRegisterResponses.remove(sessionId);
 
         if (kickMessage != null) {
-            preJoinDialogService.storePendingKickMessage(playerId, kickMessage);
+            preJoinDialogService.storePendingKickMessage(sessionId, kickMessage);
         }
         connection.getAudience().closeDialog();
     }
 
-    private void storePendingRegistration(PlayerConfigurationConnection connection, UUID playerId, String playerName,
-                                          DialogResponseView dialogResponseView) {
+    private void storePendingRegistration(PlayerConfigurationConnection connection, long sessionId,
+                                          String playerName, DialogResponseView dialogResponseView) {
         if (dialogResponseView == null) {
-            completeRegisterResponse(playerId, null);
+            completeRegisterResponse(sessionId, null);
             return;
         }
 
@@ -322,7 +316,7 @@ public class PaperDialogFlowListener implements Listener {
                     String kickMessage = messages.retrieveSingle(playerName, MessageKey.MAX_REGISTER_EXCEEDED,
                         Integer.toString(maxRegPerIp), Integer.toString(otherAccounts.size()),
                         String.join(", ", otherAccounts));
-                    completeRegisterResponse(playerId, kickMessage);
+                    completeRegisterResponse(sessionId, kickMessage);
                     return;
                 }
             }
@@ -343,8 +337,8 @@ public class PaperDialogFlowListener implements Listener {
                     messages.retrieveSingle(playerName, MessageKey.PASSWORD_MATCH_ERROR));
                 return;
             }
-            preJoinDialogService.storePendingEmailRegistration(playerId, email);
-            completeRegisterResponse(playerId, null);
+            preJoinDialogService.storePendingEmailRegistration(sessionId, email);
+            completeRegisterResponse(sessionId, null);
             return;
         }
 
@@ -369,8 +363,8 @@ public class PaperDialogFlowListener implements Listener {
             return;
         }
         if (secondArg == RegisterSecondaryArgument.CONFIRMATION) {
-            preJoinDialogService.storePendingPasswordRegistration(playerId, password, null);
-            completeRegisterResponse(playerId, null);
+            preJoinDialogService.storePendingPasswordRegistration(sessionId, password, null);
+            completeRegisterResponse(sessionId, null);
             return;
         }
 
@@ -387,13 +381,13 @@ public class PaperDialogFlowListener implements Listener {
                     messages.retrieveSingle(playerName, MessageKey.INVALID_EMAIL));
                 return;
             }
-            preJoinDialogService.storePendingPasswordRegistration(playerId, password, email);
-            completeRegisterResponse(playerId, null);
+            preJoinDialogService.storePendingPasswordRegistration(sessionId, password, email);
+            completeRegisterResponse(sessionId, null);
             return;
         }
 
-        preJoinDialogService.storePendingPasswordRegistration(playerId, password, null);
-        completeRegisterResponse(playerId, null);
+        preJoinDialogService.storePendingPasswordRegistration(sessionId, password, null);
+        completeRegisterResponse(sessionId, null);
     }
 
     private void showRegisterDialogWithError(PlayerConfigurationConnection connection, String playerName,
@@ -404,27 +398,18 @@ public class PaperDialogFlowListener implements Listener {
         connection.getAudience().showDialog(PaperDialogHelper.createPreJoinRegisterDialog(spec.withBody(errorMessage)));
     }
 
-    private void completeLoginResponse(UUID playerId, String kickMessage) {
-        CompletableFuture<String> loginResponse = pendingLoginResponses.get(playerId);
+    private void completeLoginResponse(long sessionId, String kickMessage) {
+        CompletableFuture<String> loginResponse = pendingLoginResponses.get(sessionId);
         if (loginResponse != null) {
             loginResponse.complete(kickMessage);
         }
     }
 
-    private void completeRegisterResponse(UUID playerId, String kickMessage) {
-        CompletableFuture<String> registerResponse = pendingRegisterResponses.get(playerId);
+    private void completeRegisterResponse(long sessionId, String kickMessage) {
+        CompletableFuture<String> registerResponse = pendingRegisterResponses.get(sessionId);
         if (registerResponse != null) {
             registerResponse.complete(kickMessage);
         }
-    }
-
-    private boolean hasDialogInFlight(UUID playerId) {
-        return isInFlight(pendingLoginResponses.get(playerId))
-            || isInFlight(pendingRegisterResponses.get(playerId));
-    }
-
-    private static boolean isInFlight(CompletableFuture<String> response) {
-        return response != null && !response.isDone();
     }
 
     private boolean shouldSkipPreJoinDialogForPremium(PlayerAuth auth, String playerName, UUID playerId) {

--- a/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java
+++ b/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java
@@ -16,6 +16,7 @@ import fr.xephi.authme.process.register.RegistrationType;
 import fr.xephi.authme.security.PasswordSecurity;
 import fr.xephi.authme.service.CommonService;
 import fr.xephi.authme.service.DialogWindowService;
+import fr.xephi.authme.service.PendingConnectionRegistry;
 import fr.xephi.authme.service.PendingPremiumCache;
 import fr.xephi.authme.service.PreJoinDialogService;
 import fr.xephi.authme.service.PremiumLoginVerifier;
@@ -30,6 +31,7 @@ import io.papermc.paper.dialog.Dialog;
 import io.papermc.paper.dialog.DialogResponseView;
 import io.papermc.paper.event.connection.configuration.AsyncPlayerConnectionConfigureEvent;
 import io.papermc.paper.event.player.PlayerCustomClickEvent;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -51,6 +53,8 @@ import java.util.concurrent.ConcurrentMap;
  * Handles Paper/Folia dialog flows that happen during the configuration phase.
  */
 public class PaperDialogFlowListener implements Listener {
+
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
 
     private final ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses = new ConcurrentHashMap<>();
     private final ConcurrentMap<UUID, CompletableFuture<String>> pendingRegisterResponses = new ConcurrentHashMap<>();
@@ -75,6 +79,9 @@ public class PaperDialogFlowListener implements Listener {
 
     @Inject
     private PreJoinDialogService preJoinDialogService;
+
+    @Inject
+    private PendingConnectionRegistry pendingConnectionRegistry;
 
     @Inject
     private PendingPremiumCache pendingPremiumCache;
@@ -102,6 +109,13 @@ public class PaperDialogFlowListener implements Listener {
         UUID playerId = profile.getId();
         String playerName = profile.getName();
         if (playerId == null || playerName == null) {
+            return;
+        }
+
+        // Clearing the state here would hand this connection the pending login of the one in the dialog
+        if (hasDialogInFlight(playerId)) {
+            connection.disconnect(LEGACY_SERIALIZER.deserialize(
+                messages.retrieveSingle(playerName, MessageKey.USERNAME_ALREADY_ONLINE_ERROR)));
             return;
         }
 
@@ -192,6 +206,12 @@ public class PaperDialogFlowListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerConnectionClose(PlayerConnectionCloseEvent event) {
+        // Offline UUIDs are derived from the name, so a refused duplicate closing must not wipe the state
+        String playerName = event.getPlayerName();
+        if (playerName != null && pendingConnectionRegistry.hasLiveClaim(playerName)) {
+            return;
+        }
+
         UUID playerId = event.getPlayerUniqueId();
         pendingLoginResponses.remove(playerId);
         pendingRegisterResponses.remove(playerId);
@@ -396,6 +416,15 @@ public class PaperDialogFlowListener implements Listener {
         if (registerResponse != null) {
             registerResponse.complete(kickMessage);
         }
+    }
+
+    private boolean hasDialogInFlight(UUID playerId) {
+        return isInFlight(pendingLoginResponses.get(playerId))
+            || isInFlight(pendingRegisterResponses.get(playerId));
+    }
+
+    private static boolean isInFlight(CompletableFuture<String> response) {
+        return response != null && !response.isDone();
     }
 
     private boolean shouldSkipPreJoinDialogForPremium(PlayerAuth auth, String playerName, UUID playerId) {

--- a/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperLoginValidationListener.java
+++ b/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperLoginValidationListener.java
@@ -28,8 +28,8 @@ public class PaperLoginValidationListener implements Listener {
 
     private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
 
-    /** Extra time a name stays claimed on top of the configured login / register timeout. */
-    private static final long CLAIM_GRACE_MILLIS = TimeUnit.SECONDS.toMillis(10);
+    /** Safety net for a connection that never reports itself as gone; not the release mechanism. */
+    private static final long CLAIM_GRACE_MILLIS = TimeUnit.SECONDS.toMillis(60);
 
     @Inject
     private OnJoinVerifier onJoinVerifier;
@@ -110,8 +110,18 @@ public class PaperLoginValidationListener implements Listener {
                                           PlayerConfigurationConnection connection) {
         PlayerProfile profile = connection.getProfile();
         String playerName = profile == null ? null : profile.getName();
-        // No claim means an online player being reconfigured, which must not be checked against itself
-        if (playerName == null || !pendingConnectionRegistry.holdsClaim(playerName, connection)) {
+        if (playerName == null) {
+            return;
+        }
+
+        // This connection held the name to get here, so losing it means another one took it over
+        if (pendingConnectionRegistry.isClaimedByOtherConnection(playerName, connection)) {
+            denyConnection(event, playerName, MessageKey.USERNAME_ALREADY_ONLINE_ERROR);
+            return;
+        }
+
+        // No claim at all means an online player being reconfigured, never checked against itself
+        if (!pendingConnectionRegistry.holdsClaim(playerName, connection)) {
             return;
         }
 

--- a/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperLoginValidationListener.java
+++ b/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperLoginValidationListener.java
@@ -1,7 +1,14 @@
 package fr.xephi.authme.listener;
 
+import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
 import com.destroystokyo.paper.profile.PlayerProfile;
+import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
+import fr.xephi.authme.service.PendingConnectionRegistry;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.RestrictionSettings;
+import io.papermc.paper.connection.PlayerConfigurationConnection;
+import io.papermc.paper.connection.PlayerConnection;
 import io.papermc.paper.connection.PlayerLoginConnection;
 import io.papermc.paper.event.connection.PlayerConnectionValidateLoginEvent;
 import io.papermc.paper.event.player.PlayerServerFullCheckEvent;
@@ -9,8 +16,10 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 
 import javax.inject.Inject;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Shared login validation listener for Paper-derived platforms.
@@ -19,28 +28,29 @@ public class PaperLoginValidationListener implements Listener {
 
     private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
 
+    /** Extra time a name stays claimed on top of the configured login / register timeout. */
+    private static final long CLAIM_GRACE_MILLIS = TimeUnit.SECONDS.toMillis(10);
+
     @Inject
     private OnJoinVerifier onJoinVerifier;
 
     @Inject
     private Messages messages;
 
+    @Inject
+    private PendingConnectionRegistry pendingConnectionRegistry;
+
+    @Inject
+    private Settings settings;
+
+    // Paper fires this twice: in the login phase, and again once the connection is configured
     @EventHandler(priority = EventPriority.LOW)
     public void onPlayerConnectionValidateLogin(PlayerConnectionValidateLoginEvent event) {
-        if (!(event.getConnection() instanceof PlayerLoginConnection loginConnection)) {
-            return;
-        }
-
-        String playerName = getPlayerName(loginConnection);
-        if (playerName == null) {
-            return;
-        }
-
-        try {
-            onJoinVerifier.checkSingleSession(playerName);
-        } catch (FailedVerificationException e) {
-            String kickMessage = messages.retrieveSingle(playerName, e.getReason(), e.getArgs());
-            event.kickMessage(LEGACY_SERIALIZER.deserialize(kickMessage));
+        PlayerConnection connection = event.getConnection();
+        if (connection instanceof PlayerLoginConnection loginConnection) {
+            verifyLoginPhase(event, loginConnection);
+        } else if (connection instanceof PlayerConfigurationConnection configurationConnection) {
+            verifyConfigurationPhase(event, configurationConnection);
         }
     }
 
@@ -61,6 +71,70 @@ public class PaperLoginValidationListener implements Listener {
         } else {
             event.deny(LEGACY_SERIALIZER.deserialize(kickMessage));
         }
+    }
+
+    // From the play state on, checkSingleSession sees the player itself
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        pendingConnectionRegistry.release(event.getPlayer().getName());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerConnectionClose(PlayerConnectionCloseEvent event) {
+        String playerName = event.getPlayerName();
+        if (playerName != null) {
+            pendingConnectionRegistry.releaseIfStale(playerName);
+        }
+    }
+
+    private void verifyLoginPhase(PlayerConnectionValidateLoginEvent event, PlayerLoginConnection connection) {
+        String playerName = getPlayerName(connection);
+        if (playerName == null) {
+            return;
+        }
+
+        try {
+            onJoinVerifier.checkSingleSession(playerName);
+        } catch (FailedVerificationException e) {
+            denyConnection(event, playerName, e.getReason(), e.getArgs());
+            return;
+        }
+
+        // A concurrent connection on the same name would take over its pre-join dialog state
+        if (!pendingConnectionRegistry.tryClaim(playerName, connection, getClaimTtlMillis())) {
+            denyConnection(event, playerName, MessageKey.USERNAME_ALREADY_ONLINE_ERROR);
+        }
+    }
+
+    private void verifyConfigurationPhase(PlayerConnectionValidateLoginEvent event,
+                                          PlayerConfigurationConnection connection) {
+        PlayerProfile profile = connection.getProfile();
+        String playerName = profile == null ? null : profile.getName();
+        // No claim means an online player being reconfigured, which must not be checked against itself
+        if (playerName == null || !pendingConnectionRegistry.holdsClaim(playerName, connection)) {
+            return;
+        }
+
+        try {
+            onJoinVerifier.checkSingleSession(playerName);
+        } catch (FailedVerificationException e) {
+            denyConnection(event, playerName, e.getReason(), e.getArgs());
+            return;
+        }
+
+        // Renew so the claim covers the remaining wait until the player is placed in the world
+        pendingConnectionRegistry.tryClaim(playerName, connection, getClaimTtlMillis());
+    }
+
+    private void denyConnection(PlayerConnectionValidateLoginEvent event, String playerName,
+                                MessageKey reason, String... args) {
+        event.kickMessage(LEGACY_SERIALIZER.deserialize(messages.retrieveSingle(playerName, reason, args)));
+    }
+
+    private long getClaimTtlMillis() {
+        int timeoutSeconds = Math.max(settings.getProperty(RestrictionSettings.LOGIN_TIMEOUT),
+            settings.getProperty(RestrictionSettings.REGISTER_TIMEOUT));
+        return TimeUnit.SECONDS.toMillis(Math.max(timeoutSeconds, 0)) + CLAIM_GRACE_MILLIS;
     }
 
     private static String getPlayerName(PlayerLoginConnection connection) {

--- a/authme-paper-common/src/main/java/fr/xephi/authme/service/PendingConnectionRegistry.java
+++ b/authme-paper-common/src/main/java/fr/xephi/authme/service/PendingConnectionRegistry.java
@@ -33,11 +33,6 @@ public class PendingConnectionRegistry {
         return claim != null && !claim.isStale() && claim.isHeldBy(connectionKey(connection));
     }
 
-    public boolean hasLiveClaim(String name) {
-        Claim claim = claims.get(normalize(name));
-        return claim != null && !claim.isStale();
-    }
-
     public void release(String name) {
         claims.remove(normalize(name));
     }

--- a/authme-paper-common/src/main/java/fr/xephi/authme/service/PendingConnectionRegistry.java
+++ b/authme-paper-common/src/main/java/fr/xephi/authme/service/PendingConnectionRegistry.java
@@ -1,0 +1,80 @@
+package fr.xephi.authme.service;
+
+import io.papermc.paper.connection.PlayerConnection;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Reserves a player name while its connection is still being established, before the play state.
+ */
+public class PendingConnectionRegistry {
+
+    private final Map<String, Claim> claims = new ConcurrentHashMap<>();
+
+    public PendingConnectionRegistry() {
+    }
+
+    public boolean tryClaim(String name, PlayerConnection connection, long ttlMillis) {
+        String connectionKey = connectionKey(connection);
+        long expiresAt = System.currentTimeMillis() + ttlMillis;
+        Claim claim = claims.compute(normalize(name), (ignored, existing) -> {
+            if (existing == null || existing.isStale() || existing.isHeldBy(connectionKey)) {
+                return new Claim(connectionKey, connection, expiresAt);
+            }
+            return existing;
+        });
+        return claim.isHeldBy(connectionKey);
+    }
+
+    public boolean holdsClaim(String name, PlayerConnection connection) {
+        Claim claim = claims.get(normalize(name));
+        return claim != null && !claim.isStale() && claim.isHeldBy(connectionKey(connection));
+    }
+
+    public boolean hasLiveClaim(String name) {
+        Claim claim = claims.get(normalize(name));
+        return claim != null && !claim.isStale();
+    }
+
+    public void release(String name) {
+        claims.remove(normalize(name));
+    }
+
+    // A refused duplicate connection closes too, so releasing by name alone would hand it the name
+    public void releaseIfStale(String name) {
+        claims.computeIfPresent(normalize(name), (ignored, claim) -> claim.isStale() ? null : claim);
+    }
+
+    private static String normalize(String name) {
+        return name.toLowerCase(Locale.ROOT);
+    }
+
+    // The ephemeral port makes this unique per connection and unchanged across the phase switch
+    private static String connectionKey(PlayerConnection connection) {
+        return String.valueOf(connection.getAddress());
+    }
+
+    private static final class Claim {
+
+        private final String connectionKey;
+        private final PlayerConnection connection;
+        private final long expiresAt;
+
+        Claim(String connectionKey, PlayerConnection connection, long expiresAt) {
+            this.connectionKey = connectionKey;
+            this.connection = connection;
+            this.expiresAt = expiresAt;
+        }
+
+        boolean isHeldBy(String otherConnectionKey) {
+            return connectionKey.equals(otherConnectionKey);
+        }
+
+        // The TTL guarantees a claim can never lock a name out for good
+        boolean isStale() {
+            return !connection.isConnected() || System.currentTimeMillis() > expiresAt;
+        }
+    }
+}

--- a/authme-paper-common/src/main/java/fr/xephi/authme/service/PendingConnectionRegistry.java
+++ b/authme-paper-common/src/main/java/fr/xephi/authme/service/PendingConnectionRegistry.java
@@ -33,6 +33,11 @@ public class PendingConnectionRegistry {
         return claim != null && !claim.isStale() && claim.isHeldBy(connectionKey(connection));
     }
 
+    public boolean isClaimedByOtherConnection(String name, PlayerConnection connection) {
+        Claim claim = claims.get(normalize(name));
+        return claim != null && !claim.isStale() && !claim.isHeldBy(connectionKey(connection));
+    }
+
     public void release(String name) {
         claims.remove(normalize(name));
     }

--- a/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperDialogFlowListenerTest.java
+++ b/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperDialogFlowListenerTest.java
@@ -16,7 +16,6 @@ import fr.xephi.authme.security.crypts.HashedPassword;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.service.CommonService;
 import fr.xephi.authme.service.DialogWindowService;
-import fr.xephi.authme.service.PendingConnectionRegistry;
 import fr.xephi.authme.service.PreJoinDialogService;
 import fr.xephi.authme.service.PremiumLoginVerifier;
 import fr.xephi.authme.service.SessionService;
@@ -30,14 +29,9 @@ import io.papermc.paper.event.connection.configuration.AsyncPlayerConnectionConf
 import io.papermc.paper.event.player.PlayerCustomClickEvent;
 import fr.xephi.authme.platform.PaperDialogHelper;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -52,6 +46,8 @@ import java.util.concurrent.ConcurrentMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -60,6 +56,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 public class PaperDialogFlowListenerTest {
+
+    private static final long SESSION_ID = 42L;
 
     @Test
     public void shouldListenLateOnPlayerConfigure() throws Exception {
@@ -72,7 +70,6 @@ public class PaperDialogFlowListenerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void shouldShowErrorDialogAndKeepFutureOpenForEmptyPasswordSubmission() throws Exception {
         PaperDialogFlowListener listener = new PaperDialogFlowListener();
         CommonService commonService = mock(CommonService.class);
@@ -95,22 +92,10 @@ public class PaperDialogFlowListenerTest {
             new DialogWindowSpec("Register", List.of(new DialogInputSpec("password", "Password", 100)),
                 "Register", "Cancel", false, false, null));
 
-        UUID playerId = UUID.randomUUID();
         CompletableFuture<String> future = new CompletableFuture<>();
-        Field pendingField = PaperDialogFlowListener.class.getDeclaredField("pendingRegisterResponses");
-        pendingField.setAccessible(true);
-        ConcurrentMap<UUID, CompletableFuture<String>> pendingRegisterResponses =
-            (ConcurrentMap<UUID, CompletableFuture<String>>) pendingField.get(listener);
-        pendingRegisterResponses.put(playerId, future);
-
-        PlayerProfile profile = mock(PlayerProfile.class);
-        given(profile.getId()).willReturn(playerId);
-        given(profile.getName()).willReturn("Bobby");
-
-        Audience audience = mock(Audience.class);
-        PlayerConfigurationConnection connection = mock(PlayerConfigurationConnection.class);
-        given(connection.getProfile()).willReturn(profile);
-        given(connection.getAudience()).willReturn(audience);
+        PlayerConfigurationConnection connection = mockConnection("Bobby");
+        given(connection.getAudience()).willReturn(mock(Audience.class));
+        seedSession(listener, connection, "pendingRegisterResponses", future);
 
         DialogResponseView responseView = mock(DialogResponseView.class);
         given(responseView.getText("password")).willReturn("");
@@ -129,32 +114,20 @@ public class PaperDialogFlowListenerTest {
 
             assertThat("future must stay open so the player can retry", future.isDone(), is(false));
             verify(connection).getAudience();
-            verify(preJoinDialogService, never()).storePendingPasswordRegistration(any(), any(), any());
+            verify(preJoinDialogService, never()).storePendingPasswordRegistration(anyLong(), any(), any());
         }
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void shouldFallbackToPostJoinDialogWhenPreJoinLoginIsCancelled() throws Exception {
         PaperDialogFlowListener listener = new PaperDialogFlowListener();
         CommonService commonService = mock(CommonService.class);
         setField(listener, "commonService", commonService);
         given(commonService.getProperty(RegistrationSettings.PRE_JOIN_LOGIN_CANCEL_KICKS)).willReturn(false);
 
-        UUID playerId = UUID.randomUUID();
         CompletableFuture<String> future = new CompletableFuture<>();
-        Field pendingField = PaperDialogFlowListener.class.getDeclaredField("pendingLoginResponses");
-        pendingField.setAccessible(true);
-        ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses =
-            (ConcurrentMap<UUID, CompletableFuture<String>>) pendingField.get(listener);
-        pendingLoginResponses.put(playerId, future);
-
-        PlayerProfile profile = mock(PlayerProfile.class);
-        given(profile.getId()).willReturn(playerId);
-        given(profile.getName()).willReturn("Bobby");
-
-        PlayerConfigurationConnection connection = mock(PlayerConfigurationConnection.class);
-        given(connection.getProfile()).willReturn(profile);
+        PlayerConfigurationConnection connection = mockConnection("Bobby");
+        seedSession(listener, connection, "pendingLoginResponses", future);
 
         PlayerCustomClickEvent event = mock(PlayerCustomClickEvent.class);
         given(event.getCommonConnection()).willReturn(connection);
@@ -167,7 +140,6 @@ public class PaperDialogFlowListenerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void shouldKickWhenPreJoinLoginIsCancelledAndSettingEnabled() throws Exception {
         PaperDialogFlowListener listener = new PaperDialogFlowListener();
         CommonService commonService = mock(CommonService.class);
@@ -177,20 +149,9 @@ public class PaperDialogFlowListenerTest {
         given(commonService.getProperty(RegistrationSettings.PRE_JOIN_LOGIN_CANCEL_KICKS)).willReturn(true);
         given(messages.retrieveSingle("Bobby", MessageKey.DIALOG_LOGIN_CANCELED)).willReturn("Canceled!");
 
-        UUID playerId = UUID.randomUUID();
         CompletableFuture<String> future = new CompletableFuture<>();
-        Field pendingField = PaperDialogFlowListener.class.getDeclaredField("pendingLoginResponses");
-        pendingField.setAccessible(true);
-        ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses =
-            (ConcurrentMap<UUID, CompletableFuture<String>>) pendingField.get(listener);
-        pendingLoginResponses.put(playerId, future);
-
-        PlayerProfile profile = mock(PlayerProfile.class);
-        given(profile.getId()).willReturn(playerId);
-        given(profile.getName()).willReturn("Bobby");
-
-        PlayerConfigurationConnection connection = mock(PlayerConfigurationConnection.class);
-        given(connection.getProfile()).willReturn(profile);
+        PlayerConfigurationConnection connection = mockConnection("Bobby");
+        seedSession(listener, connection, "pendingLoginResponses", future);
 
         PlayerCustomClickEvent event = mock(PlayerCustomClickEvent.class);
         given(event.getCommonConnection()).willReturn(connection);
@@ -203,27 +164,15 @@ public class PaperDialogFlowListenerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void shouldFallbackToPostJoinDialogWhenPreJoinRegisterIsCancelled() throws Exception {
         PaperDialogFlowListener listener = new PaperDialogFlowListener();
         CommonService commonService = mock(CommonService.class);
         setField(listener, "commonService", commonService);
         given(commonService.getProperty(RegistrationSettings.PRE_JOIN_REGISTER_CANCEL_KICKS)).willReturn(false);
 
-        UUID playerId = UUID.randomUUID();
         CompletableFuture<String> future = new CompletableFuture<>();
-        Field pendingField = PaperDialogFlowListener.class.getDeclaredField("pendingRegisterResponses");
-        pendingField.setAccessible(true);
-        ConcurrentMap<UUID, CompletableFuture<String>> pendingRegisterResponses =
-            (ConcurrentMap<UUID, CompletableFuture<String>>) pendingField.get(listener);
-        pendingRegisterResponses.put(playerId, future);
-
-        PlayerProfile profile = mock(PlayerProfile.class);
-        given(profile.getId()).willReturn(playerId);
-        given(profile.getName()).willReturn("Bobby");
-
-        PlayerConfigurationConnection connection = mock(PlayerConfigurationConnection.class);
-        given(connection.getProfile()).willReturn(profile);
+        PlayerConfigurationConnection connection = mockConnection("Bobby");
+        seedSession(listener, connection, "pendingRegisterResponses", future);
 
         PlayerCustomClickEvent event = mock(PlayerCustomClickEvent.class);
         given(event.getCommonConnection()).willReturn(connection);
@@ -236,7 +185,6 @@ public class PaperDialogFlowListenerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void shouldKickWhenPreJoinRegisterIsCancelledAndSettingEnabled() throws Exception {
         PaperDialogFlowListener listener = new PaperDialogFlowListener();
         CommonService commonService = mock(CommonService.class);
@@ -246,20 +194,9 @@ public class PaperDialogFlowListenerTest {
         given(commonService.getProperty(RegistrationSettings.PRE_JOIN_REGISTER_CANCEL_KICKS)).willReturn(true);
         given(messages.retrieveSingle("Bobby", MessageKey.DIALOG_REGISTER_CANCELED)).willReturn("Canceled!");
 
-        UUID playerId = UUID.randomUUID();
         CompletableFuture<String> future = new CompletableFuture<>();
-        Field pendingField = PaperDialogFlowListener.class.getDeclaredField("pendingRegisterResponses");
-        pendingField.setAccessible(true);
-        ConcurrentMap<UUID, CompletableFuture<String>> pendingRegisterResponses =
-            (ConcurrentMap<UUID, CompletableFuture<String>>) pendingField.get(listener);
-        pendingRegisterResponses.put(playerId, future);
-
-        PlayerProfile profile = mock(PlayerProfile.class);
-        given(profile.getId()).willReturn(playerId);
-        given(profile.getName()).willReturn("Bobby");
-
-        PlayerConfigurationConnection connection = mock(PlayerConfigurationConnection.class);
-        given(connection.getProfile()).willReturn(profile);
+        PlayerConfigurationConnection connection = mockConnection("Bobby");
+        seedSession(listener, connection, "pendingRegisterResponses", future);
 
         PlayerCustomClickEvent event = mock(PlayerCustomClickEvent.class);
         given(event.getCommonConnection()).willReturn(connection);
@@ -305,7 +242,7 @@ public class PaperDialogFlowListenerTest {
 
         listener.onPlayerConfigure(event);
 
-        verify(preJoinDialogService).clear(playerId);
+        verify(preJoinDialogService, never()).openSession(anyString());
         verifyNoInteractions(audience);
     }
 
@@ -346,7 +283,7 @@ public class PaperDialogFlowListenerTest {
 
         listener.onPlayerConfigure(event);
 
-        verify(preJoinDialogService).clear(playerId);
+        verify(preJoinDialogService, never()).openSession(anyString());
         verifyNoInteractions(audience);
     }
 
@@ -386,7 +323,7 @@ public class PaperDialogFlowListenerTest {
 
         listener.onPlayerConfigure(event);
 
-        verify(preJoinDialogService).clear(playerId);
+        verify(preJoinDialogService, never()).openSession(anyString());
         verifyNoInteractions(audience);
         verifyNoInteractions(sessionService);
     }
@@ -426,6 +363,7 @@ public class PaperDialogFlowListenerTest {
         given(sessionService.hasValidSession("bobby", null)).willReturn(false);
         given(dataSource.getAuth("bobby")).willReturn(auth);
         given(premiumLoginVerifier.getVerifiedUuid("Bobby")).willReturn(premiumUuid);
+        given(preJoinDialogService.openSession("bobby")).willReturn(SESSION_ID);
 
         PlayerProfile profile = mock(PlayerProfile.class);
         given(profile.getId()).willReturn(playerId);
@@ -441,7 +379,7 @@ public class PaperDialogFlowListenerTest {
 
         listener.onPlayerConfigure(event);
 
-        verify(preJoinDialogService).markSkipPostJoinDialog(playerId);
+        verify(preJoinDialogService).markSkipPostJoinDialog(SESSION_ID);
         verifyNoInteractions(audience);
     }
 
@@ -477,7 +415,7 @@ public class PaperDialogFlowListenerTest {
 
         // UUID v4 that doesn't match stored premium UUID → must return false (impostor or wrong account)
         assertThat(invokeShouldSkipPreJoinDialogForPremium(listener, auth, "Bobby", playerId), is(false));
-        verify(preJoinDialogService, never()).markSkipPostJoinDialog(playerId);
+        verify(preJoinDialogService, never()).markSkipPostJoinDialog(anyLong());
     }
 
     @Test
@@ -555,107 +493,60 @@ public class PaperDialogFlowListenerTest {
         return (boolean) method.invoke(listener, auth, playerName, playerId);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"pendingLoginResponses", "pendingRegisterResponses"})
-    @SuppressWarnings("unchecked")
-    public void shouldRefuseSecondConnectionWhileDialogOfFirstOneIsInFlight(String pendingFieldName)
-        throws Exception {
+    @Test
+    public void shouldRetireSessionOfClosedConnectionOnly() throws Exception {
         PaperDialogFlowListener listener = new PaperDialogFlowListener();
-        CommonService commonService = mock(CommonService.class);
-        Messages messages = mock(Messages.class);
         PreJoinDialogService preJoinDialogService = mock(PreJoinDialogService.class);
-        PlayerCache playerCache = mock(PlayerCache.class);
-        setField(listener, "commonService", commonService);
-        setField(listener, "messages", messages);
         setField(listener, "preJoinDialogService", preJoinDialogService);
-        setField(listener, "playerCache", playerCache);
 
-        given(commonService.getProperty(RegistrationSettings.USE_PREJOIN_DIALOG_UI)).willReturn(true);
-        given(messages.retrieveSingle("Bobby", MessageKey.USERNAME_ALREADY_ONLINE_ERROR))
-            .willReturn("Already online");
-        // Only reached if the guard stops firing, so that a regression fails on the assertion below
-        given(commonService.getProperty(RestrictionSettings.UNRESTRICTED_NAMES)).willReturn(Set.of());
-        given(playerCache.isAuthenticated("bobby")).willReturn(true);
+        PlayerConfigurationConnection gone = mockConnection("Bobby");
+        given(gone.isConnected()).willReturn(false);
+        PlayerConfigurationConnection live = mockConnection("Bobby");
+        given(live.isConnected()).willReturn(true);
+        CompletableFuture<String> liveFuture = new CompletableFuture<>();
+        connectionSessions(listener).put(gone, SESSION_ID);
+        connectionSessions(listener).put(live, SESSION_ID + 1);
+        pendingResponses(listener, "pendingLoginResponses").put(SESSION_ID, new CompletableFuture<>());
+        pendingResponses(listener, "pendingLoginResponses").put(SESSION_ID + 1, liveFuture);
 
-        // Offline UUIDs are derived from the name, so both connections resolve to the same profile id
-        UUID playerId = UUID.randomUUID();
-        CompletableFuture<String> inFlight = new CompletableFuture<>();
-        Field pendingField = PaperDialogFlowListener.class.getDeclaredField(pendingFieldName);
-        pendingField.setAccessible(true);
-        ConcurrentMap<UUID, CompletableFuture<String>> pendingResponses =
-            (ConcurrentMap<UUID, CompletableFuture<String>>) pendingField.get(listener);
-        pendingResponses.put(playerId, inFlight);
+        listener.onPlayerConnectionClose(new PlayerConnectionCloseEvent(
+            UUID.randomUUID(), "Bobby", InetAddress.getLoopbackAddress(), false));
 
+        verify(preJoinDialogService).retireSession(SESSION_ID);
+        verify(preJoinDialogService, never()).retireSession(SESSION_ID + 1);
+        assertThat(connectionSessions(listener).containsKey(gone), is(false));
+        assertThat(connectionSessions(listener).get(live), is(SESSION_ID + 1));
+        assertThat(pendingResponses(listener, "pendingLoginResponses").get(SESSION_ID + 1), is(liveFuture));
+    }
+
+    private static PlayerConfigurationConnection mockConnection(String playerName) {
         PlayerProfile profile = mock(PlayerProfile.class);
-        given(profile.getId()).willReturn(playerId);
-        given(profile.getName()).willReturn("Bobby");
-
+        given(profile.getName()).willReturn(playerName);
         PlayerConfigurationConnection connection = mock(PlayerConfigurationConnection.class);
         given(connection.getProfile()).willReturn(profile);
-
-        AsyncPlayerConnectionConfigureEvent event = mock(AsyncPlayerConnectionConfigureEvent.class);
-        given(event.getConnection()).willReturn(connection);
-
-        listener.onPlayerConfigure(event);
-
-        ArgumentCaptor<Component> kickMessage = ArgumentCaptor.forClass(Component.class);
-        verify(connection).disconnect(kickMessage.capture());
-        assertThat(LegacyComponentSerializer.legacySection().serialize(kickMessage.getValue()),
-            is("Already online"));
-        assertThat(pendingResponses.get(playerId), is(inFlight));
-        assertThat(inFlight.isDone(), is(false));
-        verifyNoInteractions(preJoinDialogService);
+        return connection;
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void shouldKeepDialogStateWhenAnotherConnectionOnTheSameNameCloses() throws Exception {
-        PaperDialogFlowListener listener = new PaperDialogFlowListener();
-        PreJoinDialogService preJoinDialogService = mock(PreJoinDialogService.class);
-        PendingConnectionRegistry pendingConnectionRegistry = mock(PendingConnectionRegistry.class);
-        setField(listener, "preJoinDialogService", preJoinDialogService);
-        setField(listener, "pendingConnectionRegistry", pendingConnectionRegistry);
-        given(pendingConnectionRegistry.hasLiveClaim("Bobby")).willReturn(true);
-
-        UUID playerId = UUID.randomUUID();
-        CompletableFuture<String> inFlight = new CompletableFuture<>();
-        ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses = pendingLoginResponses(listener);
-        pendingLoginResponses.put(playerId, inFlight);
-
-        listener.onPlayerConnectionClose(new PlayerConnectionCloseEvent(
-            playerId, "Bobby", InetAddress.getLoopbackAddress(), false));
-
-        assertThat(pendingLoginResponses.get(playerId), is(inFlight));
-        verifyNoInteractions(preJoinDialogService);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void shouldClearDialogStateWhenNoConnectionHoldsTheNameAnymore() throws Exception {
-        PaperDialogFlowListener listener = new PaperDialogFlowListener();
-        PreJoinDialogService preJoinDialogService = mock(PreJoinDialogService.class);
-        PendingConnectionRegistry pendingConnectionRegistry = mock(PendingConnectionRegistry.class);
-        setField(listener, "preJoinDialogService", preJoinDialogService);
-        setField(listener, "pendingConnectionRegistry", pendingConnectionRegistry);
-        given(pendingConnectionRegistry.hasLiveClaim("Bobby")).willReturn(false);
-
-        UUID playerId = UUID.randomUUID();
-        ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses = pendingLoginResponses(listener);
-        pendingLoginResponses.put(playerId, new CompletableFuture<>());
-
-        listener.onPlayerConnectionClose(new PlayerConnectionCloseEvent(
-            playerId, "Bobby", InetAddress.getLoopbackAddress(), false));
-
-        assertThat(pendingLoginResponses.containsKey(playerId), is(false));
-        verify(preJoinDialogService).clear(playerId);
+    private static void seedSession(PaperDialogFlowListener listener, PlayerConfigurationConnection connection,
+                                    String responseField, CompletableFuture<String> future) throws Exception {
+        connectionSessions(listener).put(connection, SESSION_ID);
+        pendingResponses(listener, responseField).put(SESSION_ID, future);
     }
 
     @SuppressWarnings("unchecked")
-    private static ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses(PaperDialogFlowListener listener)
-        throws ReflectiveOperationException {
-        Field field = PaperDialogFlowListener.class.getDeclaredField("pendingLoginResponses");
+    private static ConcurrentMap<PlayerConfigurationConnection, Long> connectionSessions(
+        PaperDialogFlowListener listener) throws ReflectiveOperationException {
+        Field field = PaperDialogFlowListener.class.getDeclaredField("connectionSessions");
         field.setAccessible(true);
-        return (ConcurrentMap<UUID, CompletableFuture<String>>) field.get(listener);
+        return (ConcurrentMap<PlayerConfigurationConnection, Long>) field.get(listener);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentMap<Long, CompletableFuture<String>> pendingResponses(
+        PaperDialogFlowListener listener, String responseField) throws ReflectiveOperationException {
+        Field field = PaperDialogFlowListener.class.getDeclaredField(responseField);
+        field.setAccessible(true);
+        return (ConcurrentMap<Long, CompletableFuture<String>>) field.get(listener);
     }
 
     private static void setField(Object target, String fieldName, Object value) throws ReflectiveOperationException {

--- a/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperDialogFlowListenerTest.java
+++ b/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperDialogFlowListenerTest.java
@@ -1,5 +1,6 @@
 package fr.xephi.authme.listener;
 
+import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import fr.xephi.authme.data.ProxySessionManager;
 import fr.xephi.authme.data.auth.PlayerCache;
@@ -15,6 +16,7 @@ import fr.xephi.authme.security.crypts.HashedPassword;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.service.CommonService;
 import fr.xephi.authme.service.DialogWindowService;
+import fr.xephi.authme.service.PendingConnectionRegistry;
 import fr.xephi.authme.service.PreJoinDialogService;
 import fr.xephi.authme.service.PremiumLoginVerifier;
 import fr.xephi.authme.service.SessionService;
@@ -28,9 +30,14 @@ import io.papermc.paper.event.connection.configuration.AsyncPlayerConnectionConf
 import io.papermc.paper.event.player.PlayerCustomClickEvent;
 import fr.xephi.authme.platform.PaperDialogHelper;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -546,6 +553,109 @@ public class PaperDialogFlowListenerTest {
             .getDeclaredMethod("shouldSkipPreJoinDialogForPremium", PlayerAuth.class, String.class, UUID.class);
         method.setAccessible(true);
         return (boolean) method.invoke(listener, auth, playerName, playerId);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"pendingLoginResponses", "pendingRegisterResponses"})
+    @SuppressWarnings("unchecked")
+    public void shouldRefuseSecondConnectionWhileDialogOfFirstOneIsInFlight(String pendingFieldName)
+        throws Exception {
+        PaperDialogFlowListener listener = new PaperDialogFlowListener();
+        CommonService commonService = mock(CommonService.class);
+        Messages messages = mock(Messages.class);
+        PreJoinDialogService preJoinDialogService = mock(PreJoinDialogService.class);
+        PlayerCache playerCache = mock(PlayerCache.class);
+        setField(listener, "commonService", commonService);
+        setField(listener, "messages", messages);
+        setField(listener, "preJoinDialogService", preJoinDialogService);
+        setField(listener, "playerCache", playerCache);
+
+        given(commonService.getProperty(RegistrationSettings.USE_PREJOIN_DIALOG_UI)).willReturn(true);
+        given(messages.retrieveSingle("Bobby", MessageKey.USERNAME_ALREADY_ONLINE_ERROR))
+            .willReturn("Already online");
+        // Only reached if the guard stops firing, so that a regression fails on the assertion below
+        given(commonService.getProperty(RestrictionSettings.UNRESTRICTED_NAMES)).willReturn(Set.of());
+        given(playerCache.isAuthenticated("bobby")).willReturn(true);
+
+        // Offline UUIDs are derived from the name, so both connections resolve to the same profile id
+        UUID playerId = UUID.randomUUID();
+        CompletableFuture<String> inFlight = new CompletableFuture<>();
+        Field pendingField = PaperDialogFlowListener.class.getDeclaredField(pendingFieldName);
+        pendingField.setAccessible(true);
+        ConcurrentMap<UUID, CompletableFuture<String>> pendingResponses =
+            (ConcurrentMap<UUID, CompletableFuture<String>>) pendingField.get(listener);
+        pendingResponses.put(playerId, inFlight);
+
+        PlayerProfile profile = mock(PlayerProfile.class);
+        given(profile.getId()).willReturn(playerId);
+        given(profile.getName()).willReturn("Bobby");
+
+        PlayerConfigurationConnection connection = mock(PlayerConfigurationConnection.class);
+        given(connection.getProfile()).willReturn(profile);
+
+        AsyncPlayerConnectionConfigureEvent event = mock(AsyncPlayerConnectionConfigureEvent.class);
+        given(event.getConnection()).willReturn(connection);
+
+        listener.onPlayerConfigure(event);
+
+        ArgumentCaptor<Component> kickMessage = ArgumentCaptor.forClass(Component.class);
+        verify(connection).disconnect(kickMessage.capture());
+        assertThat(LegacyComponentSerializer.legacySection().serialize(kickMessage.getValue()),
+            is("Already online"));
+        assertThat(pendingResponses.get(playerId), is(inFlight));
+        assertThat(inFlight.isDone(), is(false));
+        verifyNoInteractions(preJoinDialogService);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldKeepDialogStateWhenAnotherConnectionOnTheSameNameCloses() throws Exception {
+        PaperDialogFlowListener listener = new PaperDialogFlowListener();
+        PreJoinDialogService preJoinDialogService = mock(PreJoinDialogService.class);
+        PendingConnectionRegistry pendingConnectionRegistry = mock(PendingConnectionRegistry.class);
+        setField(listener, "preJoinDialogService", preJoinDialogService);
+        setField(listener, "pendingConnectionRegistry", pendingConnectionRegistry);
+        given(pendingConnectionRegistry.hasLiveClaim("Bobby")).willReturn(true);
+
+        UUID playerId = UUID.randomUUID();
+        CompletableFuture<String> inFlight = new CompletableFuture<>();
+        ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses = pendingLoginResponses(listener);
+        pendingLoginResponses.put(playerId, inFlight);
+
+        listener.onPlayerConnectionClose(new PlayerConnectionCloseEvent(
+            playerId, "Bobby", InetAddress.getLoopbackAddress(), false));
+
+        assertThat(pendingLoginResponses.get(playerId), is(inFlight));
+        verifyNoInteractions(preJoinDialogService);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldClearDialogStateWhenNoConnectionHoldsTheNameAnymore() throws Exception {
+        PaperDialogFlowListener listener = new PaperDialogFlowListener();
+        PreJoinDialogService preJoinDialogService = mock(PreJoinDialogService.class);
+        PendingConnectionRegistry pendingConnectionRegistry = mock(PendingConnectionRegistry.class);
+        setField(listener, "preJoinDialogService", preJoinDialogService);
+        setField(listener, "pendingConnectionRegistry", pendingConnectionRegistry);
+        given(pendingConnectionRegistry.hasLiveClaim("Bobby")).willReturn(false);
+
+        UUID playerId = UUID.randomUUID();
+        ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses = pendingLoginResponses(listener);
+        pendingLoginResponses.put(playerId, new CompletableFuture<>());
+
+        listener.onPlayerConnectionClose(new PlayerConnectionCloseEvent(
+            playerId, "Bobby", InetAddress.getLoopbackAddress(), false));
+
+        assertThat(pendingLoginResponses.containsKey(playerId), is(false));
+        verify(preJoinDialogService).clear(playerId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentMap<UUID, CompletableFuture<String>> pendingLoginResponses(PaperDialogFlowListener listener)
+        throws ReflectiveOperationException {
+        Field field = PaperDialogFlowListener.class.getDeclaredField("pendingLoginResponses");
+        field.setAccessible(true);
+        return (ConcurrentMap<UUID, CompletableFuture<String>>) field.get(listener);
     }
 
     private static void setField(Object target, String fieldName, Object value) throws ReflectiveOperationException {

--- a/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperLoginValidationListenerTest.java
+++ b/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperLoginValidationListenerTest.java
@@ -116,6 +116,20 @@ public class PaperLoginValidationListenerTest {
     }
 
     @Test
+    public void shouldKickWhenClaimWasTakenOverDuringConfiguration() {
+        PlayerConfigurationConnection connection = newConfigurationConnection("Bobby");
+        given(pendingConnectionRegistry.isClaimedByOtherConnection("Bobby", connection)).willReturn(true);
+        givenAlreadyOnlineMessage();
+        PlayerConnectionValidateLoginEvent event = new PlayerConnectionValidateLoginEvent(connection, null);
+
+        listener.onPlayerConnectionValidateLogin(event);
+
+        assertThat(event.isAllowed(), is(false));
+        assertThat(serialize(event.getKickMessage()), is("&cAlready online"));
+        verifyNoInteractions(onJoinVerifier);
+    }
+
+    @Test
     public void shouldVerifySingleSessionWhenFinishingConfiguration() throws FailedVerificationException {
         givenConfiguredTimeouts();
         PlayerConfigurationConnection connection = newConfigurationConnection("Bobby");

--- a/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperLoginValidationListenerTest.java
+++ b/authme-paper-common/src/test/java/fr/xephi/authme/listener/PaperLoginValidationListenerTest.java
@@ -1,14 +1,20 @@
 package fr.xephi.authme.listener;
 
+import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import fr.xephi.authme.message.MessageKey;
 import fr.xephi.authme.message.Messages;
+import fr.xephi.authme.service.PendingConnectionRegistry;
+import fr.xephi.authme.settings.Settings;
+import fr.xephi.authme.settings.properties.RestrictionSettings;
 import io.papermc.paper.connection.PlayerConfigurationConnection;
 import io.papermc.paper.connection.PlayerLoginConnection;
 import io.papermc.paper.event.connection.PlayerConnectionValidateLoginEvent;
 import io.papermc.paper.event.player.PlayerServerFullCheckEvent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,10 +23,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.net.InetAddress;
+import java.util.UUID;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -37,9 +50,63 @@ public class PaperLoginValidationListenerTest {
     @Mock
     private Messages messages;
 
+    @Mock
+    private PendingConnectionRegistry pendingConnectionRegistry;
+
+    @Mock
+    private Settings settings;
+
+    private void givenConfiguredTimeouts() {
+        given(settings.getProperty(RestrictionSettings.LOGIN_TIMEOUT)).willReturn(30);
+        given(settings.getProperty(RestrictionSettings.REGISTER_TIMEOUT)).willReturn(30);
+    }
+
     @Test
-    public void shouldIgnoreConfigurationStageValidationEvent() {
-        PlayerConfigurationConnection connection = mock(PlayerConfigurationConnection.class);
+    public void shouldClaimNameDuringLoginPhase() {
+        givenConfiguredTimeouts();
+        PlayerLoginConnection connection = newLoginConnection("Bobby");
+        given(pendingConnectionRegistry.tryClaim(eq("Bobby"), eq(connection), anyLong())).willReturn(true);
+        PlayerConnectionValidateLoginEvent event = new PlayerConnectionValidateLoginEvent(connection, null);
+
+        listener.onPlayerConnectionValidateLogin(event);
+
+        assertThat(event.isAllowed(), is(true));
+        verify(pendingConnectionRegistry).tryClaim(eq("Bobby"), eq(connection), anyLong());
+    }
+
+    @Test
+    public void shouldKickDuplicateSessionOnValidationEvent() throws FailedVerificationException {
+        PlayerLoginConnection connection = newLoginConnection("Bobby");
+        givenAlreadyOnlineMessage();
+        willThrow(new FailedVerificationException(MessageKey.USERNAME_ALREADY_ONLINE_ERROR))
+            .given(onJoinVerifier).checkSingleSession("Bobby");
+        PlayerConnectionValidateLoginEvent event = new PlayerConnectionValidateLoginEvent(connection, null);
+
+        listener.onPlayerConnectionValidateLogin(event);
+
+        assertThat(event.isAllowed(), is(false));
+        assertThat(serialize(event.getKickMessage()), is("&cAlready online"));
+        verify(pendingConnectionRegistry, never()).tryClaim(eq("Bobby"), eq(connection), anyLong());
+    }
+
+    @Test
+    public void shouldRefuseSecondConnectionUsingSameNameDuringLoginPhase() {
+        givenConfiguredTimeouts();
+        PlayerLoginConnection connection = newLoginConnection("Bobby");
+        given(pendingConnectionRegistry.tryClaim(eq("Bobby"), eq(connection), anyLong())).willReturn(false);
+        givenAlreadyOnlineMessage();
+        PlayerConnectionValidateLoginEvent event = new PlayerConnectionValidateLoginEvent(connection, null);
+
+        listener.onPlayerConnectionValidateLogin(event);
+
+        assertThat(event.isAllowed(), is(false));
+        assertThat(serialize(event.getKickMessage()), is("&cAlready online"));
+    }
+
+    @Test
+    public void shouldIgnoreReconfigurationOfPlayerWithoutClaim() {
+        PlayerConfigurationConnection connection = newConfigurationConnection("Bobby");
+        given(pendingConnectionRegistry.holdsClaim("Bobby", connection)).willReturn(false);
         PlayerConnectionValidateLoginEvent event = new PlayerConnectionValidateLoginEvent(connection, null);
 
         listener.onPlayerConnectionValidateLogin(event);
@@ -49,21 +116,52 @@ public class PaperLoginValidationListenerTest {
     }
 
     @Test
-    public void shouldKickDuplicateSessionOnValidationEvent() throws FailedVerificationException {
-        PlayerLoginConnection connection = mock(PlayerLoginConnection.class);
-        PlayerProfile profile = mock(PlayerProfile.class);
-        given(connection.getAuthenticatedProfile()).willReturn(profile);
-        given(profile.getName()).willReturn("Bobby");
-        given(messages.retrieveSingle("Bobby", MessageKey.USERNAME_ALREADY_ONLINE_ERROR))
-            .willReturn("&cAlready online");
-        FailedVerificationException exception = new FailedVerificationException(MessageKey.USERNAME_ALREADY_ONLINE_ERROR);
-        org.mockito.BDDMockito.willThrow(exception).given(onJoinVerifier).checkSingleSession("Bobby");
+    public void shouldVerifySingleSessionWhenFinishingConfiguration() throws FailedVerificationException {
+        givenConfiguredTimeouts();
+        PlayerConfigurationConnection connection = newConfigurationConnection("Bobby");
+        given(pendingConnectionRegistry.holdsClaim("Bobby", connection)).willReturn(true);
+        PlayerConnectionValidateLoginEvent event = new PlayerConnectionValidateLoginEvent(connection, null);
+
+        listener.onPlayerConnectionValidateLogin(event);
+
+        assertThat(event.isAllowed(), is(true));
+        verify(onJoinVerifier).checkSingleSession("Bobby");
+        verify(pendingConnectionRegistry).tryClaim(eq("Bobby"), eq(connection), anyLong());
+    }
+
+    @Test
+    public void shouldKickWhenNameWasTakenDuringConfiguration() throws FailedVerificationException {
+        PlayerConfigurationConnection connection = newConfigurationConnection("Bobby");
+        given(pendingConnectionRegistry.holdsClaim("Bobby", connection)).willReturn(true);
+        givenAlreadyOnlineMessage();
+        willThrow(new FailedVerificationException(MessageKey.USERNAME_ALREADY_ONLINE_ERROR))
+            .given(onJoinVerifier).checkSingleSession("Bobby");
         PlayerConnectionValidateLoginEvent event = new PlayerConnectionValidateLoginEvent(connection, null);
 
         listener.onPlayerConnectionValidateLogin(event);
 
         assertThat(event.isAllowed(), is(false));
-        assertThat(LegacyComponentSerializer.legacySection().serialize(event.getKickMessage()), is("&cAlready online"));
+        assertThat(serialize(event.getKickMessage()), is("&cAlready online"));
+    }
+
+    @Test
+    public void shouldReleaseClaimOnJoin() {
+        Player player = mock(Player.class);
+        given(player.getName()).willReturn("Bobby");
+
+        listener.onPlayerJoin(new PlayerJoinEvent(player, Component.text("joined")));
+
+        verify(pendingConnectionRegistry).release("Bobby");
+    }
+
+    @Test
+    public void shouldReleaseStaleClaimOnConnectionClose() {
+        PlayerConnectionCloseEvent event = new PlayerConnectionCloseEvent(
+            UUID.randomUUID(), "Bobby", InetAddress.getLoopbackAddress(), false);
+
+        listener.onPlayerConnectionClose(event);
+
+        verify(pendingConnectionRegistry).releaseIfStale("Bobby");
     }
 
     @Test
@@ -88,7 +186,32 @@ public class PaperLoginValidationListenerTest {
         listener.onPlayerServerFullCheck(event);
 
         assertThat(event.isAllowed(), is(false));
-        assertThat(LegacyComponentSerializer.legacySection().serialize(event.kickMessage()), is("&cServer full"));
+        assertThat(serialize(event.kickMessage()), is("&cServer full"));
         verify(onJoinVerifier).getServerFullKickMessageIfDenied("RegularPlayer");
+    }
+
+    private void givenAlreadyOnlineMessage() {
+        given(messages.retrieveSingle("Bobby", MessageKey.USERNAME_ALREADY_ONLINE_ERROR))
+            .willReturn("&cAlready online");
+    }
+
+    private static PlayerLoginConnection newLoginConnection(String name) {
+        PlayerLoginConnection connection = mock(PlayerLoginConnection.class);
+        PlayerProfile profile = mock(PlayerProfile.class);
+        given(connection.getAuthenticatedProfile()).willReturn(profile);
+        given(profile.getName()).willReturn(name);
+        return connection;
+    }
+
+    private static PlayerConfigurationConnection newConfigurationConnection(String name) {
+        PlayerConfigurationConnection connection = mock(PlayerConfigurationConnection.class);
+        PlayerProfile profile = mock(PlayerProfile.class);
+        given(connection.getProfile()).willReturn(profile);
+        given(profile.getName()).willReturn(name);
+        return connection;
+    }
+
+    private static String serialize(Component component) {
+        return LegacyComponentSerializer.legacySection().serialize(component);
     }
 }

--- a/authme-paper-common/src/test/java/fr/xephi/authme/service/PendingConnectionRegistryTest.java
+++ b/authme-paper-common/src/test/java/fr/xephi/authme/service/PendingConnectionRegistryTest.java
@@ -54,6 +54,31 @@ public class PendingConnectionRegistryTest {
     }
 
     @Test
+    public void shouldReportNameClaimedByAnotherLiveConnection() {
+        PlayerConnection holder = newConnection(50_000);
+        PlayerConnection other = newConnection(50_001);
+        registry.tryClaim("Bobby", holder, TTL);
+
+        assertThat(registry.isClaimedByOtherConnection("Bobby", other), is(true));
+        assertThat(registry.isClaimedByOtherConnection("Bobby", holder), is(false));
+    }
+
+    @Test
+    public void shouldNotReportStaleOrMissingClaimAsHeldByAnotherConnection() {
+        PlayerConnection other = newConnection(50_001);
+
+        assertThat(registry.isClaimedByOtherConnection("Bobby", other), is(false));
+
+        PlayerConnection gone = newConnection(50_000);
+        registry.tryClaim("Bobby", gone, TTL);
+        given(gone.isConnected()).willReturn(false);
+        assertThat(registry.isClaimedByOtherConnection("Bobby", other), is(false));
+
+        registry.tryClaim("Alice", newConnection(50_002), -1L);
+        assertThat(registry.isClaimedByOtherConnection("Alice", other), is(false));
+    }
+
+    @Test
     public void shouldAllowSameConnectionToRenewItsClaim() {
         PlayerConnection connection = newConnection(50_000);
         registry.tryClaim("Bobby", connection, TTL);

--- a/authme-paper-common/src/test/java/fr/xephi/authme/service/PendingConnectionRegistryTest.java
+++ b/authme-paper-common/src/test/java/fr/xephi/authme/service/PendingConnectionRegistryTest.java
@@ -1,0 +1,136 @@
+package fr.xephi.authme.service;
+
+import io.papermc.paper.connection.PlayerConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test for {@link PendingConnectionRegistry}.
+ */
+public class PendingConnectionRegistryTest {
+
+    private static final long TTL = 30_000L;
+
+    private PendingConnectionRegistry registry;
+
+    @BeforeEach
+    public void setUpRegistry() {
+        registry = new PendingConnectionRegistry();
+    }
+
+    @Test
+    public void shouldGrantClaimForFreeName() {
+        PlayerConnection connection = newConnection(50_000);
+
+        assertThat(registry.tryClaim("Bobby", connection, TTL), is(true));
+        assertThat(registry.holdsClaim("Bobby", connection), is(true));
+    }
+
+    @Test
+    public void shouldMatchClaimCaseInsensitively() {
+        PlayerConnection connection = newConnection(50_000);
+        registry.tryClaim("Bobby", connection, TTL);
+
+        assertThat(registry.holdsClaim("bOBBy", connection), is(true));
+        assertThat(registry.tryClaim("BOBBY", newConnection(50_001), TTL), is(false));
+    }
+
+    @Test
+    public void shouldRefuseSecondLiveConnectionWithSameName() {
+        PlayerConnection first = newConnection(50_000);
+        PlayerConnection second = newConnection(50_001);
+        registry.tryClaim("Bobby", first, TTL);
+
+        assertThat(registry.tryClaim("Bobby", second, TTL), is(false));
+        assertThat(registry.holdsClaim("Bobby", second), is(false));
+        assertThat(registry.holdsClaim("Bobby", first), is(true));
+    }
+
+    @Test
+    public void shouldAllowSameConnectionToRenewItsClaim() {
+        PlayerConnection connection = newConnection(50_000);
+        registry.tryClaim("Bobby", connection, TTL);
+
+        assertThat(registry.tryClaim("Bobby", connection, TTL), is(true));
+    }
+
+    @Test
+    public void shouldTakeOverClaimOfDisconnectedConnection() {
+        PlayerConnection gone = newConnection(50_000);
+        registry.tryClaim("Bobby", gone, TTL);
+        given(gone.isConnected()).willReturn(false);
+
+        assertThat(registry.tryClaim("Bobby", newConnection(50_001), TTL), is(true));
+    }
+
+    @Test
+    public void shouldTakeOverExpiredClaim() {
+        registry.tryClaim("Bobby", newConnection(50_000), -1L);
+
+        assertThat(registry.tryClaim("Bobby", newConnection(50_001), TTL), is(true));
+    }
+
+    @Test
+    public void shouldNotConsiderExpiredClaimAsHeld() {
+        PlayerConnection connection = newConnection(50_000);
+        registry.tryClaim("Bobby", connection, -1L);
+
+        assertThat(registry.holdsClaim("Bobby", connection), is(false));
+    }
+
+    @Test
+    public void shouldReleaseClaim() {
+        PlayerConnection connection = newConnection(50_000);
+        registry.tryClaim("Bobby", connection, TTL);
+
+        registry.release("Bobby");
+
+        assertThat(registry.holdsClaim("Bobby", connection), is(false));
+        assertThat(registry.tryClaim("Bobby", newConnection(50_001), TTL), is(true));
+    }
+
+    @Test
+    public void shouldKeepClaimOfLiveConnectionWhenAnotherOneCloses() {
+        PlayerConnection holder = newConnection(50_000);
+        registry.tryClaim("Bobby", holder, TTL);
+
+        // The refused duplicate connection closes and triggers the same close event
+        registry.releaseIfStale("Bobby");
+
+        assertThat(registry.holdsClaim("Bobby", holder), is(true));
+        assertThat(registry.tryClaim("Bobby", newConnection(50_001), TTL), is(false));
+    }
+
+    @Test
+    public void shouldReleaseClaimOfClosedConnection() {
+        PlayerConnection holder = newConnection(50_000);
+        registry.tryClaim("Bobby", holder, TTL);
+        given(holder.isConnected()).willReturn(false);
+
+        registry.releaseIfStale("Bobby");
+
+        assertThat(registry.tryClaim("Bobby", newConnection(50_001), TTL), is(true));
+    }
+
+    @Test
+    public void shouldHandleUnknownNameOnRelease() {
+        registry.release("Bobby");
+        registry.releaseIfStale("Bobby");
+
+        assertThat(registry.holdsClaim("Bobby", newConnection(50_000)), is(false));
+    }
+
+    private static PlayerConnection newConnection(int port) {
+        PlayerConnection connection = mock(PlayerConnection.class);
+        given(connection.getAddress()).willReturn(new InetSocketAddress("127.0.0.1", port));
+        given(connection.isConnected()).willReturn(true);
+        return connection;
+    }
+}


### PR DESCRIPTION
May fix #3132 fix #3131 
Need a strong test before merging

@TuxCoding 