### PR TITLE
fix(velocity): cancel pending premium verification after a failed forced online-mode login

### DIFF
--- a/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityProxyBridge.java
+++ b/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityProxyBridge.java
@@ -92,6 +92,7 @@ final class VelocityProxyBridge {
         this.premiumVerificationManager =
             new VelocityPremiumVerificationManager(logger,
                 this::requiresPremiumVerification, this::isPendingPremiumVerification,
+                this::clearPendingPremiumVerification,
                 () -> this.configuration.keepOfflineUuidCompatibility());
         this.cacheFile = dataDirectory != null ? dataDirectory.resolve("premium_names.cache") : null;
         if (cacheFile != null) {

--- a/authme-velocity/src/main/java/fr/xephi/authme/velocity/premium/VelocityPremiumVerificationManager.java
+++ b/authme-velocity/src/main/java/fr/xephi/authme/velocity/premium/VelocityPremiumVerificationManager.java
@@ -6,8 +6,11 @@ import com.velocitypowered.api.util.UuidUtils;
 import org.slf4j.Logger;
 
 import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 public final class VelocityPremiumVerificationManager {
@@ -15,17 +18,21 @@ public final class VelocityPremiumVerificationManager {
     private final Logger logger;
     private final Predicate<String> requiresVerification;
     private final Predicate<String> isPendingVerification;
+    private final Consumer<String> pendingVerificationFailureHandler;
     private final BooleanSupplier keepOfflineUuidCompatibility;
+    private final Set<String> pendingVerificationAttempted = ConcurrentHashMap.newKeySet();
     private final ProxyPremiumLoginVerifier loginVerifier;
     private boolean registered;
 
     public VelocityPremiumVerificationManager(Logger logger,
                                               Predicate<String> requiresVerification,
                                               Predicate<String> isPendingVerification,
+                                              Consumer<String> pendingVerificationFailureHandler,
                                               BooleanSupplier keepOfflineUuidCompatibility) {
         this.logger = logger;
         this.requiresVerification = requiresVerification;
         this.isPendingVerification = isPendingVerification;
+        this.pendingVerificationFailureHandler = pendingVerificationFailureHandler;
         this.keepOfflineUuidCompatibility = keepOfflineUuidCompatibility;
         this.loginVerifier = new ProxyPremiumLoginVerifier("authme-velocity-premium",
             message -> this.logger.warn(message));
@@ -41,6 +48,13 @@ public final class VelocityPremiumVerificationManager {
 
     public void onPreLogin(PreLoginEvent event) {
         String normalizedName = normalize(event.getUsername());
+        if (isPendingVerification.test(normalizedName) && !pendingVerificationAttempted.add(normalizedName)) {
+            // Velocity fires no event when Mojang rejects a forced online-mode login, so a pending
+            // player showing up again means the previous attempt failed: cancel the enrollment and
+            // let them log in with their password instead of forcing online mode forever.
+            pendingVerificationAttempted.remove(normalizedName);
+            pendingVerificationFailureHandler.accept(normalizedName);
+        }
         if (requiresVerification.test(normalizedName)) {
             event.setResult(PreLoginEvent.PreLoginComponentResult.forceOnlineMode());
         }
@@ -54,6 +68,7 @@ public final class VelocityPremiumVerificationManager {
 
         UUID verifiedPremiumUuid = event.getOriginalProfile().getId();
         loginVerifier.storeVerified(normalizedName, verifiedPremiumUuid);
+        pendingVerificationAttempted.remove(normalizedName);
         boolean rewrite = keepOfflineUuidCompatibility.getAsBoolean();
         logger.info("onGameProfileRequest: stored verified premium UUID {} for '{}' (keepOfflineUuidCompatibility={})",
             verifiedPremiumUuid, normalizedName, rewrite);
@@ -74,6 +89,7 @@ public final class VelocityPremiumVerificationManager {
 
     public void clearVerifiedPremium(String normalizedName) {
         loginVerifier.clearVerified(normalizedName);
+        pendingVerificationAttempted.remove(normalizedName);
     }
 
     public void shutdown() {

--- a/authme-velocity/src/test/java/fr/xephi/authme/velocity/VelocityProxyBridgeTest.java
+++ b/authme-velocity/src/test/java/fr/xephi/authme/velocity/VelocityProxyBridgeTest.java
@@ -604,6 +604,32 @@ class VelocityProxyBridgeTest {
         assertEquals(PreLoginEvent.PreLoginComponentResult.forceOnlineMode().toString(), event.getResult().toString());
     }
 
+    @Test
+    void shouldCancelPendingPremiumVerificationWhenForcedOnlineLoginNeverCompletes() {
+        given(pluginMessageEvent.getResult()).willReturn(PluginMessageEvent.ForwardResult.forward());
+        given(pluginMessageEvent.getIdentifier()).willReturn(VelocityProxyBridge.AUTHME_CHANNEL);
+        given(pluginMessageEvent.getSource()).willReturn(sourceConnection);
+        given(pluginMessageEvent.getData()).willReturn(createAuthMePayload("premium.pending.set", "Alice"));
+        given(sourceConnection.getServer()).willReturn(authServer);
+        given(authServer.getServerInfo()).willReturn(authServerInfo);
+        given(authServerInfo.getName()).willReturn("lobby");
+
+        VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), new VelocityAuthenticationStore(), null);
+        bridge.onPluginMessage(pluginMessageEvent);
+
+        PreLoginEvent firstAttempt = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
+        bridge.onPreLogin(firstAttempt);
+        // Mojang rejected the unlicensed client; Velocity fires no event for that, the player just reconnects
+        PreLoginEvent secondAttempt = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
+        bridge.onPreLogin(secondAttempt);
+        PreLoginEvent thirdAttempt = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
+        bridge.onPreLogin(thirdAttempt);
+
+        assertEquals(PreLoginEvent.PreLoginComponentResult.forceOnlineMode().toString(), firstAttempt.getResult().toString());
+        assertEquals(PreLoginEvent.PreLoginComponentResult.allowed().toString(), secondAttempt.getResult().toString());
+        assertEquals(PreLoginEvent.PreLoginComponentResult.allowed().toString(), thirdAttempt.getResult().toString());
+    }
+
     private static byte[] createChunkPayload(int seq, boolean last, String csv) {
         ByteArrayDataOutput output = ByteStreams.newDataOutput();
         output.writeUTF("premium.list.chunk");

--- a/authme-velocity/src/test/java/fr/xephi/authme/velocity/premium/VelocityPremiumVerificationManagerTest.java
+++ b/authme-velocity/src/test/java/fr/xephi/authme/velocity/premium/VelocityPremiumVerificationManagerTest.java
@@ -8,11 +8,16 @@ import com.velocitypowered.api.util.UuidUtils;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class VelocityPremiumVerificationManagerTest {
@@ -20,7 +25,7 @@ class VelocityPremiumVerificationManagerTest {
     @Test
     void shouldForceOnlineModeForPremiumUser() {
         VelocityPremiumVerificationManager manager = new VelocityPremiumVerificationManager(
-            mock(Logger.class), "alice"::equals, normalizedName -> false, () -> false);
+            mock(Logger.class), "alice"::equals, normalizedName -> false, name -> { }, () -> false);
 
         PreLoginEvent event = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
         manager.onPreLogin(event);
@@ -32,7 +37,7 @@ class VelocityPremiumVerificationManagerTest {
     @Test
     void shouldRewriteVerifiedProfileToOfflineUuid() {
         VelocityPremiumVerificationManager manager = new VelocityPremiumVerificationManager(
-            mock(Logger.class), "alice"::equals, normalizedName -> false, () -> true);
+            mock(Logger.class), "alice"::equals, normalizedName -> false, name -> { }, () -> true);
         UUID mojangUuid = UUID.fromString("8d6d0684-d8b4-4d40-8d2d-0dd4df5555c8");
         GameProfile originalProfile = new GameProfile(mojangUuid, "Alice", List.of());
         GameProfileRequestEvent event = new GameProfileRequestEvent(
@@ -47,7 +52,7 @@ class VelocityPremiumVerificationManagerTest {
     @Test
     void shouldIgnoreOfflineModeProfileRequest() {
         VelocityPremiumVerificationManager manager = new VelocityPremiumVerificationManager(
-            mock(Logger.class), "alice"::equals, normalizedName -> false, () -> true);
+            mock(Logger.class), "alice"::equals, normalizedName -> false, name -> { }, () -> true);
         UUID mojangUuid = UUID.fromString("8d6d0684-d8b4-4d40-8d2d-0dd4df5555c8");
         GameProfile originalProfile = new GameProfile(mojangUuid, "Alice", List.of());
         GameProfileRequestEvent event = new GameProfileRequestEvent(
@@ -62,7 +67,7 @@ class VelocityPremiumVerificationManagerTest {
     @Test
     void shouldKeepMojangUuidWhenOfflineCompatibilityDisabled() {
         VelocityPremiumVerificationManager manager = new VelocityPremiumVerificationManager(
-            mock(Logger.class), "alice"::equals, normalizedName -> false, () -> false);
+            mock(Logger.class), "alice"::equals, normalizedName -> false, name -> { }, () -> false);
         UUID mojangUuid = UUID.fromString("8d6d0684-d8b4-4d40-8d2d-0dd4df5555c8");
         GameProfile originalProfile = new GameProfile(mojangUuid, "Alice", List.of());
         GameProfileRequestEvent event = new GameProfileRequestEvent(
@@ -72,5 +77,76 @@ class VelocityPremiumVerificationManagerTest {
 
         assertEquals(mojangUuid, event.getGameProfile().getId());
         assertEquals(mojangUuid, manager.getVerifiedPremiumUuid("alice"));
+    }
+
+    @Test
+    void shouldForceOnlineModeOnFirstPendingAttemptThenCancelOnSecond() {
+        Set<String> pending = new HashSet<>(Set.of("alice"));
+        VelocityPremiumVerificationManager manager = new VelocityPremiumVerificationManager(
+            mock(Logger.class), pending::contains, pending::contains, pending::remove, () -> false);
+
+        PreLoginEvent firstAttempt = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
+        manager.onPreLogin(firstAttempt);
+        // Mojang rejected the session: no profile request, no login and no disconnect event follow
+        PreLoginEvent secondAttempt = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
+        manager.onPreLogin(secondAttempt);
+
+        assertEquals(PreLoginEvent.PreLoginComponentResult.forceOnlineMode().toString(),
+            firstAttempt.getResult().toString());
+        assertEquals(PreLoginEvent.PreLoginComponentResult.allowed().toString(),
+            secondAttempt.getResult().toString());
+        assertFalse(pending.contains("alice"));
+    }
+
+    @Test
+    void shouldKeepForcingOnlineModeForPendingPlayerAfterSuccessfulVerification() {
+        Set<String> pending = new HashSet<>(Set.of("alice"));
+        VelocityPremiumVerificationManager manager = new VelocityPremiumVerificationManager(
+            mock(Logger.class), pending::contains, pending::contains, pending::remove, () -> false);
+        GameProfile profile = new GameProfile(
+            UUID.fromString("8d6d0684-d8b4-4d40-8d2d-0dd4df5555c8"), "Alice", List.of());
+
+        manager.onPreLogin(new PreLoginEvent(mock(InboundConnection.class), "Alice", null));
+        manager.onGameProfileRequest(new GameProfileRequestEvent(mock(InboundConnection.class), profile, true));
+        // The backend has not finalized the enrollment yet, so the player is still pending on reconnect
+        PreLoginEvent reconnect = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
+        manager.onPreLogin(reconnect);
+
+        assertEquals(PreLoginEvent.PreLoginComponentResult.forceOnlineMode().toString(),
+            reconnect.getResult().toString());
+        assertTrue(pending.contains("alice"));
+    }
+
+    @Test
+    void shouldStillForceOnlineModeForEnrolledPremiumPlayerWhenPendingAttemptFails() {
+        Set<String> pending = new HashSet<>(Set.of("alice"));
+        Predicate<String> requiresVerification = name -> "alice".equals(name) || pending.contains(name);
+        VelocityPremiumVerificationManager manager = new VelocityPremiumVerificationManager(
+            mock(Logger.class), requiresVerification, pending::contains, pending::remove, () -> false);
+
+        manager.onPreLogin(new PreLoginEvent(mock(InboundConnection.class), "Alice", null));
+        PreLoginEvent secondAttempt = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
+        manager.onPreLogin(secondAttempt);
+
+        assertEquals(PreLoginEvent.PreLoginComponentResult.forceOnlineMode().toString(),
+            secondAttempt.getResult().toString());
+        assertFalse(pending.contains("alice"));
+    }
+
+    @Test
+    void shouldResetAttemptWhenPendingVerificationIsRearmed() {
+        Set<String> pending = new HashSet<>(Set.of("alice"));
+        VelocityPremiumVerificationManager manager = new VelocityPremiumVerificationManager(
+            mock(Logger.class), pending::contains, pending::contains, pending::remove, () -> false);
+
+        manager.onPreLogin(new PreLoginEvent(mock(InboundConnection.class), "Alice", null));
+        // A new /premium run sends premium.pending.set again, which clears the verification state
+        manager.clearVerifiedPremium("alice");
+        PreLoginEvent reconnect = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
+        manager.onPreLogin(reconnect);
+
+        assertEquals(PreLoginEvent.PreLoginComponentResult.forceOnlineMode().toString(),
+            reconnect.getResult().toString());
+        assertTrue(pending.contains("alice"));
     }
 }


### PR DESCRIPTION
Fixes #3124 — the same problem as #3051, which came back after the premium verification refactor.

What players hit: after running `/premium`, AuthMe kicks you so the next connection can be checked against a licensed account. If that reconnect comes from a client that isn't logged into a licensed account, the check fails — that part is expected. The problem is what happens next: Velocity keeps treating the player as "waiting for premium verification" indefinitely, so every further reconnect is forced through the licensed-account check again and the player can never get back to the password login. Only a proxy restart helped.

Why: when the licensed-account check fails, Velocity closes the connection quietly, without telling plugins anything. So the proxy never learns the attempt failed and never clears its pending state. The original fix for #3051 handled this by remembering that an attempt had already been made; that piece got lost in the refactor — the cleanup code was still there, just no longer called.

The fix restores that logic. The first time a pending player connects, the proxy runs the licensed-account check as before. If the same player connects again while still pending, that can only mean the previous attempt didn't complete, so the pending state is dropped and the player gets the normal password login, from which they can run `/premium` again. The "attempt made" mark is reset when the check succeeds, when a new `/premium` starts, and when the player disconnects. Players already enrolled as premium are not affected and keep being verified as before.

Not covered here: BungeeCord's built-in verification path (the one used with `keepOfflineUuidCompatibility: false`) lost the same logic in that refactor and most likely has the same problem — happy to do that in a follow-up.

Tests: four new unit tests for the verification manager plus one at the bridge level that replays the exact scenario from the issue; the velocity module suite is green.
