### PR TITLE
Multiple fixes for the dialog

### DIFF
--- a/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java
+++ b/authme-paper-common/src/main/java/fr/xephi/authme/listener/PaperDialogFlowListener.java
@@ -214,9 +214,11 @@ public class PaperDialogFlowListener implements Listener {
 
     private void handleBlockingLoginDialog(PlayerConfigurationConnection connection, long sessionId, String playerName) {
         CompletableFuture<String> loginResponse = new CompletableFuture<>();
-        long timeoutSeconds = Math.max(commonService.getProperty(RestrictionSettings.LOGIN_TIMEOUT), 1);
-        loginResponse.completeOnTimeout(
-            messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR), timeoutSeconds, TimeUnit.SECONDS);
+        long timeoutSeconds = commonService.getProperty(RestrictionSettings.LOGIN_TIMEOUT);
+        if (timeoutSeconds > 0) {
+            loginResponse.completeOnTimeout(
+                messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR), timeoutSeconds, TimeUnit.SECONDS);
+        }
         String normalizedName = playerName.toLowerCase(Locale.ROOT);
         pendingLoginResponses.put(sessionId, loginResponse);
         preJoinDialogService.registerPreJoinFuture(sessionId, loginResponse);
@@ -284,9 +286,11 @@ public class PaperDialogFlowListener implements Listener {
     private void handleBlockingRegisterDialog(PlayerConfigurationConnection connection, long sessionId,
                                               String playerName, Dialog dialog) {
         CompletableFuture<String> registerResponse = new CompletableFuture<>();
-        long timeoutSeconds = Math.max(commonService.getProperty(RestrictionSettings.REGISTER_TIMEOUT), 1);
-        registerResponse.completeOnTimeout(
-            messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR), timeoutSeconds, TimeUnit.SECONDS);
+        long timeoutSeconds = commonService.getProperty(RestrictionSettings.REGISTER_TIMEOUT);
+        if (timeoutSeconds > 0) {
+            registerResponse.completeOnTimeout(
+                messages.retrieveSingle(playerName, MessageKey.LOGIN_TIMEOUT_ERROR), timeoutSeconds, TimeUnit.SECONDS);
+        }
         pendingRegisterResponses.put(sessionId, registerResponse);
 
         connection.getAudience().showDialog(dialog);

--- a/authme-velocity/src/main/java/fr/xephi/authme/velocity/AuthMeVelocityPlugin.java
+++ b/authme-velocity/src/main/java/fr/xephi/authme/velocity/AuthMeVelocityPlugin.java
@@ -11,6 +11,7 @@ import com.velocitypowered.api.event.player.GameProfileRequestEvent;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
 import com.velocitypowered.api.event.player.ServerPreConnectEvent;
+import com.velocitypowered.api.event.player.configuration.PlayerEnterConfigurationEvent;
 import com.velocitypowered.api.event.player.configuration.PlayerEnteredConfigurationEvent;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
@@ -70,6 +71,11 @@ public final class AuthMeVelocityPlugin extends AbstractAuthMeVelocityPlugin {
     @Subscribe
     public void onGameProfileRequest(GameProfileRequestEvent event) {
         proxyBridge.onGameProfileRequest(event);
+    }
+
+    @Subscribe
+    public void onPlayerEnterConfiguration(PlayerEnterConfigurationEvent event) {
+        proxyBridge.onPlayerEnterConfiguration(event);
     }
 
     @Subscribe

--- a/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityProxyBridge.java
+++ b/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityProxyBridge.java
@@ -11,6 +11,7 @@ import com.velocitypowered.api.event.player.PlayerChatEvent;
 import com.velocitypowered.api.event.player.GameProfileRequestEvent;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
 import com.velocitypowered.api.event.player.ServerPreConnectEvent;
+import com.velocitypowered.api.event.player.configuration.PlayerEnterConfigurationEvent;
 import com.velocitypowered.api.event.player.configuration.PlayerEnteredConfigurationEvent;
 import com.velocitypowered.api.proxy.ConnectionRequestBuilder;
 import com.velocitypowered.api.proxy.Player;
@@ -320,6 +321,47 @@ final class VelocityProxyBridge {
                 logger.info("Premium list received from backend: {} premium player(s)", premiumUsernames.size());
                 savePremiumNamesAsync();
             }
+        }
+    }
+
+    /**
+     * Sends the auto-login {@code perform.login} as soon as an already-authenticated player is about to enter
+     * the configuration phase during a server switch, before the backend decides whether to show its blocking
+     * pre-join login dialog. The regular {@link #onServerConnected(ServerConnectedEvent)} path fires only after
+     * the configuration phase completes — too late to suppress that dialog.
+     * <p>
+     * During a switch the player is in the "null window" (neither the old nor the new server is set as the
+     * current one), so {@link PlayerEnteredConfigurationEvent} cannot reach the target backend. This event
+     * fires earlier with the in-flight target connection.
+     * <p>
+     * This is sent to all servers (not just auth servers) so that a non-auth server running AuthMe
+     * also receives the auto-login signal early enough to suppress its login dialog.
+     */
+    void onPlayerEnterConfiguration(PlayerEnterConfigurationEvent event) {
+        if (!configuration.autoLoginEnabled()) {
+            return;
+        }
+        ServerConnection server = event.server();
+        if (server == null) {
+            return;
+        }
+
+        String normalizedName = normalizeName(event.player().getUsername());
+        UUID verifiedPremiumUuid = premiumVerificationManager.getVerifiedPremiumUuid(normalizedName);
+        boolean isPremiumJoin = verifiedPremiumUuid != null;
+        if (!authenticationStore.isAuthenticated(normalizedName) && !isPremiumJoin) {
+            return;
+        }
+
+        boolean sent = server.sendPluginMessage(
+            AUTHME_CHANNEL, createPerformLoginMessage(normalizedName, verifiedPremiumUuid));
+        if (sent) {
+            logger.info("Sent config-phase auto-login to server '{}' for player {} (verifiedPremiumUuid={})",
+                server.getServer().getServerInfo().getName(), normalizedName, verifiedPremiumUuid);
+            initiatePendingLogin(normalizedName);
+        } else {
+            logger.debug("Config-phase auto-login send to '{}' for {} returned false; onServerConnected will retry",
+                server.getServer().getServerInfo().getName(), normalizedName);
         }
     }
 

--- a/authme-velocity/src/test/java/fr/xephi/authme/velocity/VelocityProxyBridgeTest.java
+++ b/authme-velocity/src/test/java/fr/xephi/authme/velocity/VelocityProxyBridgeTest.java
@@ -10,6 +10,7 @@ import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
 import com.velocitypowered.api.event.player.ServerPreConnectEvent;
+import com.velocitypowered.api.event.player.configuration.PlayerEnterConfigurationEvent;
 import com.velocitypowered.api.event.player.configuration.PlayerEnteredConfigurationEvent;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
@@ -410,6 +411,36 @@ class VelocityProxyBridgeTest {
 
         VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), store, null);
         bridge.onPlayerEnteredConfiguration(new PlayerEnteredConfigurationEvent(player, currentServer));
+
+        verify(currentServer, never()).sendPluginMessage(any(), any(byte[].class));
+    }
+
+    @Test
+    void shouldSendConfigPhaseAutoLoginWhenEnteringNonAuthServerOnServerSwitch() {
+        given(player.getUsername()).willReturn("Alice");
+        given(currentServer.getServer()).willReturn(nonAuthServer);
+        given(nonAuthServer.getServerInfo()).willReturn(nonAuthServerInfo);
+        given(nonAuthServerInfo.getName()).willReturn("survival");
+        given(currentServer.sendPluginMessage(eq(VelocityProxyBridge.AUTHME_CHANNEL), any(byte[].class)))
+            .willReturn(true);
+
+        VelocityAuthenticationStore store = new VelocityAuthenticationStore();
+        store.markAuthenticated("alice");
+
+        VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), store, null);
+        bridge.onPlayerEnterConfiguration(new PlayerEnterConfigurationEvent(player, currentServer));
+
+        verify(currentServer).sendPluginMessage(eq(VelocityProxyBridge.AUTHME_CHANNEL), payloadCaptor.capture());
+        assertPerformLoginPayload(payloadCaptor.getValue(), "alice", "test-secret");
+    }
+
+    @Test
+    void shouldNotSendConfigPhaseAutoLoginWhenEnteredConfigurationWithoutServerConnection() {
+        VelocityAuthenticationStore store = new VelocityAuthenticationStore();
+        store.markAuthenticated("alice");
+
+        VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), store, null);
+        bridge.onPlayerEnteredConfiguration(new PlayerEnteredConfigurationEvent(player, null));
 
         verify(currentServer, never()).sendPluginMessage(any(), any(byte[].class));
     }


### PR DESCRIPTION
fix(dialog): respect loginTimeout/registerTimeout=0 as disabled ( https://github.com/AuthMe/AuthMeReloaded/issues/3122)
fix(velocity): suppress pre-join dialog on server switch (https://github.com/AuthMe/AuthMeReloaded/issues/3076)