### PR TITLE
Fix single session check to match names case-insensitively

### DIFF
--- a/authme-core/src/main/java/fr/xephi/authme/listener/OnJoinVerifier.java
+++ b/authme-core/src/main/java/fr/xephi/authme/listener/OnJoinVerifier.java
@@ -234,9 +234,10 @@ public class OnJoinVerifier implements Reloadable {
             return;
         }
 
-        Player onlinePlayer = bukkitService.getPlayerExact(name);
-        if (onlinePlayer != null) {
-            throw new FailedVerificationException(MessageKey.USERNAME_ALREADY_ONLINE_ERROR);
+        for (Player player : bukkitService.getOnlinePlayers()) {
+            if (player.getName().equalsIgnoreCase(name)) {
+                throw new FailedVerificationException(MessageKey.USERNAME_ALREADY_ONLINE_ERROR);
+            }
         }
     }
 

--- a/authme-core/src/test/java/fr/xephi/authme/listener/OnJoinVerifierTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/listener/OnJoinVerifierTest.java
@@ -340,13 +340,13 @@ class OnJoinVerifierTest {
         // given
         String name = "bobby";
         given(settings.getProperty(RestrictionSettings.FORCE_SINGLE_SESSION)).willReturn(true);
-        given(bukkitService.getPlayerExact("bobby")).willReturn(null);
+        given(bukkitService.getOnlinePlayers()).willReturn(Collections.emptyList());
 
         // when
         onJoinVerifier.checkSingleSession(name);
 
         // then
-        verify(bukkitService).getPlayerExact(name);
+        verify(bukkitService).getOnlinePlayers();
     }
 
     @Test
@@ -355,8 +355,8 @@ class OnJoinVerifierTest {
         String name = "Charlie";
 
         Player onlinePlayer = mock(Player.class);
-
-        given(bukkitService.getPlayerExact("Charlie")).willReturn(onlinePlayer);
+        given(onlinePlayer.getName()).willReturn("CHARLIE");
+        given(bukkitService.getOnlinePlayers()).willReturn(Collections.singletonList(onlinePlayer));
         given(settings.getProperty(RestrictionSettings.FORCE_SINGLE_SESSION)).willReturn(true);
 
         // when / then


### PR DESCRIPTION
checkSingleSession used getPlayerExact which is case sensitive, but auth is looked up by lowercase name and offline UUIDs differ by case.

That lets Steve and steve stay online at the same time on the same account. When one logs in the other gets unlocked too.

Match the javadoc and scan online players with equalsIgnoreCase.