### PR TITLE
fix(premium): send premium list via triggering player and persist non-chunked list

### DIFF
--- a/authme-bungee/src/main/java/fr/xephi/authme/bungee/BungeeProxyBridge.java
+++ b/authme-bungee/src/main/java/fr/xephi/authme/bungee/BungeeProxyBridge.java
@@ -290,6 +290,7 @@ public final class BungeeProxyBridge implements Listener {
             }
             premiumUsernames = newPremiumSet;
             logger.info("Premium list received from backend: " + premiumUsernames.size() + " premium player(s)");
+            savePremiumNamesAsync();
         } else if (PREMIUM_LIST_CHUNK_MESSAGE.equals(parsedMessage.typeId())) {
             String[] parts = parsedMessage.playerName().split(":", 3);
             if (parts.length < 3) {

--- a/authme-bungee/src/test/java/fr/xephi/authme/bungee/BungeeProxyBridgeTest.java
+++ b/authme-bungee/src/test/java/fr/xephi/authme/bungee/BungeeProxyBridgeTest.java
@@ -14,6 +14,7 @@ import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.event.ServerSwitchEvent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -26,6 +27,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -484,6 +487,44 @@ class BungeeProxyBridgeTest {
         ByteArrayDataOutput output = ByteStreams.newDataOutput();
         output.writeUTF("premium.list.chunk");
         output.writeUTF(seq + ":" + (last ? "1" : "0") + ":" + csv);
+        return output.toByteArray();
+    }
+
+    @Test
+    void shouldPersistNonChunkedPremiumListToCache(@TempDir Path tempDir) throws Exception {
+        given(pluginMessageEvent.isCancelled()).willReturn(false);
+        given(pluginMessageEvent.getTag()).willReturn(BungeeProxyBridge.AUTHME_CHANNEL);
+        given(pluginMessageEvent.getSender()).willReturn(sourceServer);
+        given(pluginMessageEvent.getData()).willReturn(createListPayload("Alice"));
+
+        BungeeProxyBridge bridge = new BungeeProxyBridge(proxyServer, logger, createConfiguration(), new BungeeAuthenticationStore(), tempDir);
+        bridge.onPluginMessage(pluginMessageEvent);
+
+        Path cacheFile = tempDir.resolve("premium_names.cache");
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.exists(cacheFile) && Files.readString(cacheFile).contains("alice")) {
+                break;
+            }
+            Thread.sleep(50);
+        }
+        assertTrue(Files.exists(cacheFile), "premium cache file should be written");
+        bridge.shutdown();
+
+        BungeeProxyBridge restarted = new BungeeProxyBridge(proxyServer, logger, createConfiguration(), new BungeeAuthenticationStore(), tempDir);
+        given(playerHandshakeEvent.getConnection()).willReturn(pendingConnection);
+        given(pendingConnection.getName()).willReturn("Alice");
+        given(pendingConnection.isOnlineMode()).willReturn(false);
+        restarted.onPlayerHandshake(playerHandshakeEvent);
+        restarted.shutdown();
+
+        verify(pendingConnection).setOnlineMode(true);
+    }
+
+    private static byte[] createListPayload(String csv) {
+        ByteArrayDataOutput output = ByteStreams.newDataOutput();
+        output.writeUTF("premium.list");
+        output.writeUTF(csv);
         return output.toByteArray();
     }
 

--- a/authme-core/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
+++ b/authme-core/src/main/java/fr/xephi/authme/service/bungeecord/BungeeReceiver.java
@@ -114,6 +114,7 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
         if (type.get() == MessageType.PROXY_STARTED) {
             logger.info("Proxy plugin '" + argument + "' has started and registered the authme:main channel");
             final String proxyName = argument;
+            final Player triggeringPlayer = player;
             bukkitService.runTaskAsynchronously(() -> {
                 // Always send the list, even when it is empty: an empty list is authoritative and
                 // lets the proxy replace a stale premium cache. With premium disabled, stored
@@ -121,11 +122,14 @@ public class BungeeReceiver implements PluginMessageListener, SettingsDependent 
                 List<String> premiumNames = premiumEnabled ? dataSource.getPremiumUsernames() : List.of();
                 bukkitService.scheduleSyncTaskFromOptionallyAsyncTask(() -> {
                     // Re-fetch a carrier at send-time: the original player may have gone offline
-                    // during the async DB query.
+                    // during the async DB query. Fall back to the triggering player so the list
+                    // still goes out when no fully-joined player exists yet (first join during
+                    // the login phase) or the single online player disconnected mid-query.
                     Player freshCarrier = bukkitService.getOnlinePlayers().stream()
                         .findFirst().orElse(null);
-                    if (freshCarrier != null) {
-                        bungeeSender.sendPremiumList(freshCarrier, premiumNames);
+                    Player carrier = freshCarrier != null ? freshCarrier : triggeringPlayer;
+                    if (carrier != null) {
+                        bungeeSender.sendPremiumList(carrier, premiumNames);
                         logger.info("Sent premium list (" + premiumNames.size() + " player(s)) to proxy '" + proxyName + "'");
                     } else {
                         logger.warning("Cannot send premium list to proxy '" + proxyName

--- a/authme-core/src/test/java/fr/xephi/authme/service/bungeecord/BungeeReceiverTest.java
+++ b/authme-core/src/test/java/fr/xephi/authme/service/bungeecord/BungeeReceiverTest.java
@@ -337,6 +337,28 @@ class BungeeReceiverTest {
         verify(bungeeSender).sendPremiumList(carrier, List.of());
     }
 
+    @Test
+    void shouldSendPremiumListViaTriggeringPlayerWhenNoOnlinePlayers() {
+        // given
+        given(settings.getProperty(HooksSettings.BUNGEECORD)).willReturn(true);
+        given(dataSource.getPremiumUsernames()).willReturn(List.of("Alice"));
+        setBukkitServiceToRunTaskAsynchronously(bukkitService);
+        setBukkitServiceToScheduleSyncTaskFromOptionallyAsyncTask(bukkitService);
+        given(bukkitService.getOnlinePlayers()).willReturn(List.of());
+
+        Player triggeringPlayer = mock(Player.class);
+
+        BungeeReceiver receiver =
+            new BungeeReceiver(plugin, bukkitService, proxySessionManager, management, bungeeSender, dataSource,
+                proxyLoginRequestValidator, settings);
+
+        // when
+        receiver.onPluginMessageReceived("authme:main", triggeringPlayer, buildProxyStartedPayload("velocity"));
+
+        // then
+        verify(bungeeSender).sendPremiumList(triggeringPlayer, List.of("Alice"));
+    }
+
     private static byte[] buildProxyStartedPayload(String proxyName) {
         ByteArrayDataOutput out = ByteStreams.newDataOutput();
         out.writeUTF(MessageType.PROXY_STARTED.getId());

--- a/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityProxyBridge.java
+++ b/authme-velocity/src/main/java/fr/xephi/authme/velocity/VelocityProxyBridge.java
@@ -296,6 +296,7 @@ final class VelocityProxyBridge {
             }
             premiumUsernames = newPremiumSet;
             logger.info("Premium list received from backend: {} premium player(s)", premiumUsernames.size());
+            savePremiumNamesAsync();
         } else if (PREMIUM_LIST_CHUNK_MESSAGE.equals(parsedMessage.typeId())) {
             String[] parts = parsedMessage.playerName().split(":", 3);
             if (parts.length < 3) {

--- a/authme-velocity/src/test/java/fr/xephi/authme/velocity/VelocityProxyBridgeTest.java
+++ b/authme-velocity/src/test/java/fr/xephi/authme/velocity/VelocityProxyBridgeTest.java
@@ -22,6 +22,7 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import net.kyori.adventure.text.Component;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -33,6 +34,8 @@ import org.slf4j.Logger;
 
 import java.util.Optional;
 import java.util.Set;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -665,6 +668,45 @@ class VelocityProxyBridgeTest {
         ByteArrayDataOutput output = ByteStreams.newDataOutput();
         output.writeUTF("premium.list.chunk");
         output.writeUTF(seq + ":" + (last ? "1" : "0") + ":" + csv);
+        return output.toByteArray();
+    }
+
+    @Test
+    void shouldPersistNonChunkedPremiumListToCache(@TempDir Path tempDir) throws Exception {
+        given(pluginMessageEvent.getResult()).willReturn(PluginMessageEvent.ForwardResult.forward());
+        given(pluginMessageEvent.getIdentifier()).willReturn(VelocityProxyBridge.AUTHME_CHANNEL);
+        given(pluginMessageEvent.getSource()).willReturn(sourceConnection);
+        given(pluginMessageEvent.getData()).willReturn(createListPayload("Alice"));
+        given(sourceConnection.getServer()).willReturn(authServer);
+        given(authServer.getServerInfo()).willReturn(authServerInfo);
+        given(authServerInfo.getName()).willReturn("lobby");
+
+        VelocityProxyBridge bridge = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), new VelocityAuthenticationStore(), tempDir);
+        bridge.onPluginMessage(pluginMessageEvent);
+
+        Path cacheFile = tempDir.resolve("premium_names.cache");
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.exists(cacheFile) && Files.readString(cacheFile).contains("alice")) {
+                break;
+            }
+            Thread.sleep(50);
+        }
+        assertTrue(Files.exists(cacheFile), "premium cache file should be written");
+        bridge.shutdown();
+
+        VelocityProxyBridge restarted = new VelocityProxyBridge(proxyServer, logger, createConfiguration(), new VelocityAuthenticationStore(), tempDir);
+        PreLoginEvent event = new PreLoginEvent(mock(InboundConnection.class), "Alice", null);
+        restarted.onPreLogin(event);
+        restarted.shutdown();
+
+        assertEquals(PreLoginEvent.PreLoginComponentResult.forceOnlineMode().toString(), event.getResult().toString());
+    }
+
+    private static byte[] createListPayload(String csv) {
+        ByteArrayDataOutput output = ByteStreams.newDataOutput();
+        output.writeUTF("premium.list");
+        output.writeUTF(csv);
         return output.toByteArray();
     }
 


### PR DESCRIPTION
See #3116.

Problem: premium users cannot log in when the backend whitelist is enabled on Velocity networks.

Impact: the proxy never learns premium names, keeps sending offline UUIDs, and the backend whitelist kicks even though the premium UUID is whitelisted.

Root cause is two parts. BungeeReceiver.java sends the premium list on proxy.started using only getOnlinePlayers as carrier and drops it when empty. VelocityProxyBridge.java and BungeeProxyBridge.java persist chunked lists and set/unset to premium_names.cache but not the non-chunked premium.list path.

Fix: fall back to the triggering player when no online player exists at send time in BungeeReceiver.java:122. Persist the non-chunked list like the other paths in VelocityProxyBridge.java:296 and BungeeProxyBridge.java:293.

Test: BungeeReceiverTest 11 run 0 fail, new test pins 0 online players sends via triggering player and 1 online player uses fresh carrier. VelocityProxyBridgeTest 34 run 0 fail, BungeeProxyBridgeTest 21 run 0 fail, new tests send a non-chunked list, wait for premium_names.cache, restart the bridge from the same dir, and prelogin/handshake forces online mode.

Limits: fresh setup with the whitelist on from the start where ServerConnected never fires and proxy.started is never sent still needs docs or whitelist handling. I did not change that path here.